### PR TITLE
Simplify ReAct tool execution

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -628,14 +628,14 @@ class BaseReactAgent:
                     str(error_message),
                 )
 
-            combined_tool_name = "_and_".join(
+            tool_batch_name = ", ".join(
                 [getattr(t, "tool_name", "unknown") for t in tool_errors]
             )
-            combined_tool_args = [getattr(t, "tool_args", {}) for t in tool_errors]
+            tool_batch_args = [getattr(t, "tool_args", {}) for t in tool_errors]
 
             logger.error(
-                f"Tool call validation failed for: {combined_tool_name} "
-                f"args={combined_tool_args} -> {obs_text}"
+                f"Tool call validation failed for: {tool_batch_name} "
+                f"args={tool_batch_args} -> {obs_text}"
             )
 
             for single_tool in tool_errors:
@@ -649,31 +649,33 @@ class BaseReactAgent:
                     }
                 )
         else:
-            tool_call_id = str(uuid.uuid4())
-            combined_tool_name = "_and_".join([t.tool_name for t in tool_call_result])
-            combined_tool_args = [t.tool_args for t in tool_call_result]
+            tool_batch_name = ", ".join([t.tool_name for t in tool_call_result])
+            tool_batch_args = [t.tool_args for t in tool_call_result]
+            for single_tool in tool_call_result:
+                single_tool.tool_call_id = str(uuid.uuid4())
 
             tool_calls_metadata = ToolCallMetadata(
                 agent_name=self.agent_name,
                 has_tool_calls=True,
-                tool_call_id=tool_call_id,
+                tool_call_id=tool_call_result[0].tool_call_id,
                 tool_calls=[
                     ToolCall(
-                        id=tool_call_id,
+                        id=single_tool.tool_call_id,
                         function=ToolFunction(
-                            name=combined_tool_name[:60],
-                            arguments=json.dumps(combined_tool_args),
+                            name=single_tool.tool_name,
+                            arguments=json.dumps(single_tool.tool_args),
                         ),
                     )
+                    for single_tool in tool_call_result
                 ],
             )
 
             event = Event(
                 type=EventType.TOOL_CALL_STARTED,
                 payload=ToolCallStartedPayload(
-                    tool_name=combined_tool_name,
-                    tool_args=json.dumps(combined_tool_args),
-                    tool_call_id=tool_call_id,
+                    tool_name=tool_batch_name,
+                    tool_args=json.dumps(tool_batch_args),
+                    tool_call_id=tool_call_result[0].tool_call_id,
                 ),
                 agent_name=self.agent_name,
             )
@@ -691,17 +693,33 @@ class BaseReactAgent:
             tools_results = []
             try:
                 async with asyncio.timeout(self.tool_call_timeout):
-                    first_executor = tool_call_result[0].tool_executor
-                    tool_output = await first_executor.execute(
-                        agent_name=self.agent_name,
-                        tool_args=combined_tool_args,
-                        tool_name=combined_tool_name,
-                        tool_call_id=tool_call_id,
-                        add_message_to_history=add_message_to_history,
-                        session_id=session_id,
+                    tool_outputs = await asyncio.gather(
+                        *[
+                            single_tool.tool_executor.execute(
+                                agent_name=self.agent_name,
+                                tool_args=single_tool.tool_args,
+                                tool_name=single_tool.tool_name,
+                                tool_call_id=single_tool.tool_call_id,
+                                add_message_to_history=add_message_to_history,
+                                session_id=session_id,
+                            )
+                            for single_tool in tool_call_result
+                        ]
                     )
 
-                observation = await self.parse_tool_observation(tool_output)
+                observation = await self.parse_tool_observation(
+                    {
+                        "status": (
+                            "error"
+                            if any(
+                                result.get("status") == "error"
+                                for result in tool_outputs
+                            )
+                            else "success"
+                        ),
+                        "tools_results": tool_outputs,
+                    }
+                )
 
                 tools_results = observation.get("tools_results", [])
                 obs_lines = []
@@ -785,10 +803,10 @@ class BaseReactAgent:
                 event = Event(
                     type=EventType.TOOL_CALL_RESULT,
                     payload=ToolCallResultPayload(
-                        tool_name=combined_tool_name,
-                        tool_args=json.dumps(combined_tool_args),
+                        tool_name=tool_batch_name,
+                        tool_args=json.dumps(tool_batch_args),
                         result=obs_text,
-                        tool_call_id=tool_call_id,
+                        tool_call_id=tool_call_result[0].tool_call_id,
                     ),
                     agent_name=self.agent_name,
                 )
@@ -818,20 +836,23 @@ class BaseReactAgent:
                         }
                     )
 
-                await add_message_to_history(
-                    role="tool",
-                    content=obs_text,
-                    metadata={
-                        "tool_call_id": tool_call_id,
-                        "agent_name": self.agent_name,
-                    },
-                    session_id=session_id,
-                )
+                for single_tool in tool_call_result:
+                    await add_message_to_history(
+                        role="tool",
+                        content=obs_text,
+                        metadata={
+                            "tool_call_id": single_tool.tool_call_id,
+                            "tool": single_tool.tool_name,
+                            "args": single_tool.tool_args,
+                            "agent_name": self.agent_name,
+                        },
+                        session_id=session_id,
+                    )
 
                 event = Event(
                     type=EventType.TOOL_CALL_ERROR,
                     payload=ToolCallErrorPayload(
-                        tool_name=combined_tool_name,
+                        tool_name=tool_batch_name,
                         error_message=obs_text,
                     ),
                     agent_name=self.agent_name,
@@ -860,19 +881,22 @@ class BaseReactAgent:
                         }
                     )
 
-                await add_message_to_history(
-                    role="tool",
-                    content=obs_text,
-                    metadata={
-                        "tool_call_id": tool_call_id,
-                        "agent_name": self.agent_name,
-                    },
-                    session_id=session_id,
-                )
+                for single_tool in tool_call_result:
+                    await add_message_to_history(
+                        role="tool",
+                        content=obs_text,
+                        metadata={
+                            "tool_call_id": single_tool.tool_call_id,
+                            "tool": single_tool.tool_name,
+                            "args": single_tool.tool_args,
+                            "agent_name": self.agent_name,
+                        },
+                        session_id=session_id,
+                    )
                 event = Event(
                     type=EventType.TOOL_CALL_ERROR,
                     payload=ToolCallErrorPayload(
-                        tool_name=combined_tool_name,
+                        tool_name=tool_batch_name,
                         error_message=obs_text,
                     ),
                     agent_name=self.agent_name,
@@ -883,8 +907,8 @@ class BaseReactAgent:
         if debug:
             show_tool_response(
                 agent_name=self.agent_name,
-                tool_name=combined_tool_name,
-                tool_args=combined_tool_args,
+                tool_name=tool_batch_name,
+                tool_args=tool_batch_args,
                 observation=obs_text,
             )
 

--- a/src/omnicoreagent/core/tools/tools_handler.py
+++ b/src/omnicoreagent/core/tools/tools_handler.py
@@ -3,7 +3,6 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
-import asyncio
 
 from omnicoreagent.core.guardrails import PromptInjectionGuard
 
@@ -212,121 +211,80 @@ class ToolExecutor:
         self,
         agent_name: str,
         tool_name: str,
-        tool_args: list[dict[str, Any]],
+        tool_args: dict[str, Any],
         tool_call_id: str,
         add_message_to_history: Callable[[str, str, dict | None], Any],
         session_id: str = None,
         **kwargs,
-    ) -> str:
+    ) -> dict[str, Any]:
         """
-        Executes one or more tools concurrently and always returns a single aggregated result object.
-        Includes both successful and failed tool results under `tools_results`.
-        Properly handles tool-level and global exceptions.
-        """
-        aggregated_results = []
+        Execute one validated tool call and normalize the result.
 
+        Multi-tool concurrency is owned by the agent loop. Keeping this executor
+        single-call avoids synthetic combined tool names and lets each call use
+        its own handler, server, and tool_call_id.
+        """
         try:
-            split_tool_names = tool_name.split("_and_")
-            tasks = []
-
-            for name, args in zip(split_tool_names, tool_args):
-                tasks.append(self.tool_handler.call(name, args))
-
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            for name, args, result in zip(split_tool_names, tool_args, results):
-                if isinstance(result, Exception):
-                    aggregated_results.append(
-                        {
-                            "tool_name": name,
-                            "args": args,
-                            "status": "error",
-                            "data": None,
-                            "message": str(result),
-                        }
-                    )
-                    continue
-
-                if isinstance(result, dict):
-                    status = result.get("status", "success")
-                    data = result.get("data")
-                    message = result.get("message")
-
-                    if status == "error" and not message:
-                        message = "Tool returned error status without message."
-
-                    if status == "success" and data is None:
-                        message = (
-                            message
-                            or "(Tool executed successfully but returned no data; This likely means the action completed or is async.)"
-                        )
-
-                elif hasattr(result, "content"):
-                    content = result.content
-                    data = content[0].text if isinstance(content, list) else content
-                    status = "success"
-                    message = None
-
-                else:
-                    data = result
-                    status = "success" if result else "error"
-                    message = (
-                        None if result else f"Tool '{name}' returned empty output."
-                    )
-
-                aggregated_results.append(
-                    {
-                        "tool_name": name,
-                        "args": args,
-                        "status": status,
-                        "data": data,
-                        "message": message,
-                    }
-                )
-
-                await add_message_to_history(
-                    role="tool",
-                    content=data if data is not None else message,
-                    metadata={
-                        "tool_call_id": tool_call_id,
-                        "tool": name,
-                        "args": args,
-                        "agent_name": agent_name,
-                    },
-                    session_id=session_id,
-                )
-
-            overall_status = (
-                "error"
-                if any(r["status"] == "error" for r in aggregated_results)
-                else "success"
-            )
-
-            return json.dumps(
-                {"status": overall_status, "tools_results": aggregated_results}
-            )
+            result = await self.tool_handler.call(tool_name, tool_args)
+            normalized = self._normalize_result(tool_name, tool_args, result)
 
         except Exception as e:
-            aggregated_results.append(
-                {
-                    "tool_name": tool_name,
-                    "args": tool_args,
-                    "status": "error",
-                    "data": None,
-                    "message": str(e),
-                }
-            )
+            normalized = {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "error",
+                "data": None,
+                "message": str(e),
+            }
 
-            await add_message_to_history(
-                role="tool",
-                content=str(e),
-                metadata={
-                    "tool_call_id": tool_call_id,
-                    "tool": tool_name,
-                    "args": tool_args,
-                    "agent_name": agent_name,
-                },
-                session_id=session_id,
-            )
+        await add_message_to_history(
+            role="tool",
+            content=normalized["data"]
+            if normalized["data"] is not None
+            else normalized["message"],
+            metadata={
+                "tool_call_id": tool_call_id,
+                "tool": tool_name,
+                "args": tool_args,
+                "agent_name": agent_name,
+            },
+            session_id=session_id,
+        )
 
-            return json.dumps({"status": "error", "tools_results": aggregated_results})
+        return normalized
+
+    def _normalize_result(
+        self, tool_name: str, tool_args: dict[str, Any], result: Any
+    ) -> dict[str, Any]:
+        if isinstance(result, dict):
+            status = result.get("status", "success")
+            data = result.get("data")
+            message = result.get("message")
+
+            if status == "error" and not message:
+                message = "Tool returned error status without message."
+
+            if status == "success" and data is None:
+                message = (
+                    message
+                    or "(Tool executed successfully but returned no data; This likely means the action completed or is async.)"
+                )
+
+        elif hasattr(result, "content"):
+            content = result.content
+            data = content[0].text if isinstance(content, list) else content
+            status = "success"
+            message = None
+
+        else:
+            data = result
+            status = "success" if result else "error"
+            message = None if result else f"Tool '{tool_name}' returned empty output."
+
+        return {
+            "tool_name": tool_name,
+            "args": tool_args,
+            "status": status,
+            "data": data,
+            "message": message,
+        }

--- a/src/omnicoreagent/core/types.py
+++ b/src/omnicoreagent/core/types.py
@@ -215,6 +215,7 @@ class ToolCallResult(BaseModel):
     tool_executor: Any
     tool_name: str
     tool_args: dict
+    tool_call_id: str | None = None
 
 
 class ToolError(BaseModel):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,8 @@ from unittest.mock import AsyncMock
 import pytest
 import json
 from omnicoreagent.core.agents.base import BaseReactAgent
+from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.types import ParsedResponse
 
 
 @pytest.fixture
@@ -60,3 +62,129 @@ async def test_update_llm_working_memory_empty(agent):
     )
     session_state = agent._get_session_state("chat456", debug=False)
     assert len(session_state.messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_act_executes_tool_name_with_and_as_literal(agent):
+    registry = ToolRegistry()
+    history = []
+
+    @registry.register_tool(
+        name="search_and_read",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        description="Search and read in one call.",
+    )
+    async def search_and_read(query: str):
+        return {"status": "success", "data": f"result for {query}"}
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    parsed_response = ParsedResponse(
+        action=True,
+        tool_calls=True,
+        data=json.dumps(
+            [{"tool": "search_and_read", "parameters": {"query": "runtime"}}]
+        ),
+    )
+
+    await agent.act(
+        parsed_response=parsed_response,
+        response="<tool_call><tool_name>search_and_read</tool_name></tool_call>",
+        add_message_to_history=add_message_to_history,
+        system_prompt="system",
+        sessions={},
+        local_tools=registry,
+        session_id="chat789",
+    )
+
+    tool_messages = [item for item in history if item["role"] == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["metadata"]["tool"] == "search_and_read"
+    assert "result for runtime" in tool_messages[0]["content"]
+
+    observations = [item for item in history if item["role"] == "user"]
+    assert observations
+    assert 'tool_name="search_and_read#1"' in observations[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_act_records_one_tool_call_id_per_parallel_tool(agent):
+    registry = ToolRegistry()
+    history = []
+
+    @registry.register_tool(
+        name="alpha",
+        inputSchema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        description="Alpha tool.",
+    )
+    async def alpha(value: str):
+        return {"status": "success", "data": f"alpha:{value}"}
+
+    @registry.register_tool(
+        name="beta",
+        inputSchema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        description="Beta tool.",
+    )
+    async def beta(value: str):
+        return {"status": "success", "data": f"beta:{value}"}
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    parsed_response = ParsedResponse(
+        action=True,
+        tool_calls=True,
+        data=json.dumps(
+            [
+                {"tool": "alpha", "parameters": {"value": "one"}},
+                {"tool": "beta", "parameters": {"value": "two"}},
+            ]
+        ),
+    )
+
+    await agent.act(
+        parsed_response=parsed_response,
+        response="<tool_calls>...</tool_calls>",
+        add_message_to_history=add_message_to_history,
+        system_prompt="system",
+        sessions={},
+        local_tools=registry,
+        session_id="chat790",
+    )
+
+    assistant_message = next(item for item in history if item["role"] == "assistant")
+    tool_calls = assistant_message["metadata"]["tool_calls"]
+    tool_messages = [item for item in history if item["role"] == "tool"]
+
+    assert [call["function"]["name"] for call in tool_calls] == ["alpha", "beta"]
+    assert [item["metadata"]["tool"] for item in tool_messages] == ["alpha", "beta"]
+    assert {call["id"] for call in tool_calls} == {
+        item["metadata"]["tool_call_id"] for item in tool_messages
+    }


### PR DESCRIPTION
## Summary
- execute each parsed tool call with its own executor/handler instead of combining names with `_and_`
- keep multi-tool calls concurrent while preserving per-tool names, args, and tool_call_ids
- normalize single-tool results inside ToolExecutor and let the ReAct loop own batching
- add regression coverage for tool names containing `_and_` and distinct ids for parallel calls

## Why
The old path reused the first executor for an entire batch and split synthetic tool names by `_and_`. That made valid tool names fragile, mixed MCP/local batches unsafe, and different MCP servers in one batch unreliable.

## Validation
- uv run ruff check src tests
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_base.py tests/test_react_agent.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check