### PR TITLE
Prepare runtime tools once per run

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -324,10 +324,6 @@ class BaseReactAgent:
         sub_agents: list = None,
     ) -> ToolError | list[ToolCallResult]:
         try:
-            local_tools = await self.process_local_tools(
-                local_tools=local_tools, local_tool_verification=True
-            )
-
             if not parsed_response.data:
                 return ToolError(
                     observation="Invalid tool call request: No data provided",
@@ -1022,58 +1018,43 @@ class BaseReactAgent:
         finally:
             session_state.state = previous_state
 
-    async def process_local_tools(
-        self, local_tools: Any = None, local_tool_verification: bool = False
-    ):
+    async def prepare_runtime_tools(self, local_tools: Any = None):
+        registry = local_tools
+        needs_internal_registry = (
+            self.enable_advanced_tool_use
+            or self.memory_tool_backend
+            or self.tool_offloader.config.enabled
+            or (self.enable_agent_skills and self.skill_manager)
+        )
+
+        if registry is None and needs_internal_registry:
+            registry = self.register_internal_tool
+
+        if registry is None:
+            return None
+
         if self.enable_advanced_tool_use:
-            if not local_tool_verification:
-                local_tools = self.register_internal_tool
-                await build_tool_registry_advance_tools_use(
-                    registry=local_tools,
-                )
-            else:
-                if local_tools and local_tool_verification:
-                    await build_tool_registry_advance_tools_use(
-                        registry=local_tools,
-                    )
+            await build_tool_registry_advance_tools_use(registry=registry)
 
         if self.memory_tool_backend:
-            if local_tools:
-                build_tool_registry_memory_tool(
-                    memory_tool_backend=self.memory_tool_backend,
-                    registry=local_tools,
-                )
-            else:
-                local_tools = self.register_internal_tool
-                build_tool_registry_memory_tool(
-                    memory_tool_backend=self.memory_tool_backend,
-                    registry=local_tools,
-                )
+            build_tool_registry_memory_tool(
+                memory_tool_backend=self.memory_tool_backend,
+                registry=registry,
+            )
+
         if self.tool_offloader.config.enabled:
-            if local_tools:
-                build_tool_registry_artifact_tool(
-                    offloader=self.tool_offloader,
-                    registry=local_tools,
-                )
-            else:
-                local_tools = self.register_internal_tool
-                build_tool_registry_artifact_tool(
-                    offloader=self.tool_offloader,
-                    registry=local_tools,
-                )
+            build_tool_registry_artifact_tool(
+                offloader=self.tool_offloader,
+                registry=registry,
+            )
+
         if self.enable_agent_skills and self.skill_manager:
-            if local_tools:
-                build_skill_tools(
-                    skill_manager=self.skill_manager,
-                    registry=local_tools,
-                )
-            else:
-                local_tools = self.register_internal_tool
-                build_skill_tools(
-                    skill_manager=self.skill_manager,
-                    registry=local_tools,
-                )
-        return local_tools
+            build_skill_tools(
+                skill_manager=self.skill_manager,
+                registry=registry,
+            )
+
+        return registry
 
     async def get_tools_registry(
         self, mcp_tools: dict = None, local_tools: Any = None
@@ -1145,7 +1126,6 @@ class BaseReactAgent:
             return p_desc if p_desc else "No description"
 
         try:
-            local_tools = await self.process_local_tools(local_tools=local_tools)
             if local_tools:
                 local_tools_list = local_tools.get_available_tools()
                 if local_tools_list:
@@ -1596,13 +1576,14 @@ class BaseReactAgent:
             session_id=session_id,
             metadata={"agent_name": self.agent_name},
         )
+        runtime_local_tools = await self.prepare_runtime_tools(local_tools=local_tools)
         await self.prepare_initial_messages(
             system_prompt=system_prompt,
             session_state=session_state,
             llm_connection=llm_connection,
             message_history=message_history,
             mcp_tools=mcp_tools,
-            local_tools=local_tools,
+            local_tools=runtime_local_tools,
             session_id=session_id,
             debug=debug,
             sub_agents=sub_agents,
@@ -1849,7 +1830,7 @@ class BaseReactAgent:
                                 mcp_tools=mcp_tools,
                                 debug=debug,
                                 sessions=sessions,
-                                local_tools=local_tools,
+                                local_tools=runtime_local_tools,
                                 session_id=session_id,
                                 event_router=event_router,
                                 sub_agents=sub_agents,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -188,3 +188,86 @@ async def test_act_records_one_tool_call_id_per_parallel_tool(agent):
     assert {call["id"] for call in tool_calls} == {
         item["metadata"]["tool_call_id"] for item in tool_messages
     }
+
+
+@pytest.mark.asyncio
+async def test_run_prepares_internal_tools_once_for_prompt_and_execution(monkeypatch):
+    agent = BaseReactAgent(
+        agent_name="test_agent",
+        max_steps=5,
+        tool_call_timeout=10,
+        enable_advanced_tool_use=True,
+    )
+    build_count = 0
+    history = []
+
+    async def fake_build_internal_tools(registry):
+        nonlocal build_count
+        build_count += 1
+
+        @registry.register_tool(
+            name="internal_ping",
+            inputSchema={
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            },
+            description="Internal ping tool.",
+        )
+        async def internal_ping(value: str):
+            return {"status": "success", "data": f"pong:{value}"}
+
+        return registry
+
+    monkeypatch.setattr(
+        "omnicoreagent.core.agents.base.build_tool_registry_advance_tools_use",
+        fake_build_internal_tools,
+    )
+
+    class FakeLLMConnection:
+        def __init__(self):
+            self.calls = 0
+
+        async def llm_call(self, messages):
+            self.calls += 1
+            if self.calls == 1:
+                assert "internal_ping" in messages[0].content
+                return """
+<thought>Need internal tool.</thought>
+<tool_call>
+  <tool_name>internal_ping</tool_name>
+  <parameters>
+    <value>runtime</value>
+  </parameters>
+</tool_call>
+"""
+            return "<final_answer>done</final_answer>"
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def message_history(agent_name, session_id):
+        return history
+
+    result = await agent.run(
+        system_prompt="system",
+        query="run internal ping",
+        llm_connection=FakeLLMConnection(),
+        add_message_to_history=add_message_to_history,
+        message_history=message_history,
+        session_id="chat791",
+    )
+
+    tool_messages = [item for item in history if item["role"] == "tool"]
+    assert result["answer"] == "done"
+    assert build_count == 1
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["metadata"]["tool"] == "internal_ping"
+    assert "pong:runtime" in tool_messages[0]["content"]


### PR DESCRIPTION
## Summary
- prepare local/internal runtime tools once at the start of `BaseReactAgent.run`
- pass the prepared registry into prompt construction and action execution
- remove tool registration side effects from registry formatting and tool-call validation
- add a regression test proving internal tools are built once, shown in the prompt, and executable from the same prepared registry

## Why
The ReAct loop was rebuilding or patching local/internal tools in multiple places. That made startup heavier, made the path harder to test, and could let the tool prompt and action validation disagree. Runtime tool setup is now an explicit single step.

## Validation
- uv run ruff check src tests
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_react_agent.py tests/test_mcp_response_guardrail.py tests/test_deep_agent.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check