### PR TITLE
Make workspace paths runtime resolved

### DIFF
--- a/src/omnicoreagent/core/tool_response_offloader.py
+++ b/src/omnicoreagent/core/tool_response_offloader.py
@@ -23,11 +23,6 @@ from omnicoreagent.core.utils import logger
 from omnicoreagent.core.workspace import get_artifacts_dir
 
 
-# Default artifacts directory - resolved from workspace module
-# Override with OMNICOREAGENT_ARTIFACTS_DIR or OMNICOREAGENT_WORKSPACE_DIR env vars
-DEFAULT_ARTIFACTS_DIR = get_artifacts_dir()
-
-
 @dataclass
 class OffloadConfig:
     """Configuration for tool response offloading."""
@@ -44,7 +39,7 @@ class OffloadConfig:
     def __post_init__(self):
         """Set defaults that depend on env vars."""
         if self.storage_dir is None:
-            self.storage_dir = DEFAULT_ARTIFACTS_DIR
+            self.storage_dir = get_artifacts_dir()
 
     @classmethod
     def from_dict(cls, config: dict) -> "OffloadConfig":
@@ -58,7 +53,7 @@ class OffloadConfig:
             threshold_bytes=config.get("threshold_bytes", 2000),
             max_preview_tokens=config.get("max_preview_tokens", 150),
             max_preview_lines=config.get("max_preview_lines", 10),
-            storage_dir=config.get("storage_dir", DEFAULT_ARTIFACTS_DIR),
+            storage_dir=config.get("storage_dir"),
             retention_days=config.get("retention_days", 7),
             include_metadata=config.get("include_metadata", True),
         )

--- a/src/omnicoreagent/core/tools/memory_tool/factory.py
+++ b/src/omnicoreagent/core/tools/memory_tool/factory.py
@@ -9,19 +9,16 @@ from omnicoreagent.core.tools.memory_tool.base import AbstractMemoryBackend
 from omnicoreagent.core.tools.memory_tool.local_storage import LocalMemoryBackend
 from decouple import config
 from omnicoreagent.core.utils import logger
-from omnicoreagent.core.workspace import get_memories_dir
 from threading import Lock
+from omnicoreagent.core.workspace import get_memories_dir
 
-# Resolved from workspace module
-# Override with OMNICOREAGENT_MEMORY_DIR or OMNICOREAGENT_WORKSPACE_DIR env vars
-LOCAL_MEMORY_BASE_DIR = get_memories_dir()
-
-# Cache for backend instances to avoid re-initialization
 _backend_cache: dict = {}
 _cache_lock = Lock()
 
 
-def create_memory_backend(backend_type: str, use_cache: bool = True) -> AbstractMemoryBackend:
+def create_memory_backend(
+    backend_type: str, use_cache: bool = True
+) -> AbstractMemoryBackend:
     """
     Create a memory backend from a string type.
     
@@ -47,13 +44,14 @@ def create_memory_backend(backend_type: str, use_cache: bool = True) -> Abstract
             - R2_SECRET_ACCESS_KEY (required)
     """
     backend_type = backend_type.lower().strip()
+    cache_key = _backend_cache_key(backend_type)
     
     # Check cache first
     if use_cache:
         with _cache_lock:
-            if backend_type in _backend_cache:
+            if cache_key in _backend_cache:
                 logger.debug(f"Reusing cached {backend_type} memory backend")
-                return _backend_cache[backend_type]
+                return _backend_cache[cache_key]
     
     # Create new backend
     backend = _create_backend_instance(backend_type)
@@ -61,17 +59,37 @@ def create_memory_backend(backend_type: str, use_cache: bool = True) -> Abstract
     # Cache it
     if use_cache:
         with _cache_lock:
-            _backend_cache[backend_type] = backend
+            _backend_cache[cache_key] = backend
     
     return backend
+
+
+def _backend_cache_key(backend_type: str) -> tuple:
+    if backend_type == "local":
+        return (backend_type, get_memories_dir())
+    if backend_type == "s3":
+        return (
+            backend_type,
+            config("AWS_S3_BUCKET", default=None),
+            config("AWS_REGION", default=None),
+            config("AWS_ENDPOINT_URL", default=None),
+        )
+    if backend_type == "r2":
+        return (
+            backend_type,
+            config("R2_BUCKET_NAME", default=None),
+            config("R2_ACCOUNT_ID", default=None),
+        )
+    return (backend_type,)
 
 
 def _create_backend_instance(backend_type: str) -> AbstractMemoryBackend:
     """Create a new backend instance (internal, no caching)."""
     
     if backend_type == "local":
-        logger.info(f"Creating local memory backend at: {LOCAL_MEMORY_BASE_DIR}")
-        return LocalMemoryBackend(base_dir=LOCAL_MEMORY_BASE_DIR)
+        base_dir = get_memories_dir()
+        logger.info(f"Creating local memory backend at: {base_dir}")
+        return LocalMemoryBackend(base_dir=base_dir)
     
     elif backend_type == "s3":
         bucket_name = config("AWS_S3_BUCKET", default=None)

--- a/src/omnicoreagent/core/workspace.py
+++ b/src/omnicoreagent/core/workspace.py
@@ -1,78 +1,59 @@
-"""
-Workspace Path Resolver
-
-Central module for all agent runtime data paths.
-All data directories live under a single workspace root so the entire
-workspace can be mounted on cloud storage (S3 FUSE, R2, GCS, NFS, etc.)
-and everything works transparently as if it were local.
-
-Directory Layout:
-    workspace/
-    ├── artifacts/     # offloaded tool responses
-    ├── memories/      # memory tool local storage
-    └── config/        # agent runtime config files
-
-Environment Variables:
-    OMNICOREAGENT_WORKSPACE_DIR   – override workspace root (default: ./workspace)
-    OMNICOREAGENT_ARTIFACTS_DIR   – explicit override for artifacts path
-    OMNICOREAGENT_MEMORY_DIR      – explicit override for memories path
-"""
-
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 
-# ---------------------------------------------------------------------------
-# Workspace root
-# ---------------------------------------------------------------------------
-
 _DEFAULT_WORKSPACE = "./workspace"
-WORKSPACE_DIR = os.environ.get("OMNICOREAGENT_WORKSPACE_DIR", _DEFAULT_WORKSPACE)
+_WORKSPACE_ENV = "OMNICOREAGENT_WORKSPACE_DIR"
+_ARTIFACTS_ENV = "OMNICOREAGENT_ARTIFACTS_DIR"
+_MEMORY_ENV = "OMNICOREAGENT_MEMORY_DIR"
+
+
+@dataclass(frozen=True)
+class WorkspacePaths:
+    root: Path
+    artifacts: Path
+    memories: Path
+    config: Path
+
+    def ensure(self) -> "WorkspacePaths":
+        for path in (self.root, self.artifacts, self.memories, self.config):
+            path.mkdir(parents=True, exist_ok=True)
+        return self
+
+
+def resolve_workspace_paths(
+    *,
+    workspace_dir: str | os.PathLike | None = None,
+    artifacts_dir: str | os.PathLike | None = None,
+    memories_dir: str | os.PathLike | None = None,
+) -> WorkspacePaths:
+    root = Path(workspace_dir or os.environ.get(_WORKSPACE_ENV, _DEFAULT_WORKSPACE))
+    artifacts = Path(artifacts_dir or os.environ.get(_ARTIFACTS_ENV, root / "artifacts"))
+    memories = Path(memories_dir or os.environ.get(_MEMORY_ENV, root / "memories"))
+    return WorkspacePaths(
+        root=root,
+        artifacts=artifacts,
+        memories=memories,
+        config=root / "config",
+    )
 
 
 def get_workspace_dir() -> str:
-    """Return the workspace root directory path."""
-    return WORKSPACE_DIR
+    return str(resolve_workspace_paths().root)
 
-
-# ---------------------------------------------------------------------------
-# Sub-directory resolvers
-# ---------------------------------------------------------------------------
 
 def get_artifacts_dir() -> str:
-    """
-    Return the artifacts directory path.
-
-    Precedence:
-      1. OMNICOREAGENT_ARTIFACTS_DIR env var (explicit override)
-      2. <workspace>/artifacts
-    """
-    explicit = os.environ.get("OMNICOREAGENT_ARTIFACTS_DIR")
-    if explicit:
-        return explicit
-    return str(Path(WORKSPACE_DIR) / "artifacts")
+    return str(resolve_workspace_paths().artifacts)
 
 
 def get_memories_dir() -> str:
-    """
-    Return the memories directory path.
-
-    Precedence:
-      1. OMNICOREAGENT_MEMORY_DIR env var (explicit override)
-      2. <workspace>/memories
-    """
-    explicit = os.environ.get("OMNICOREAGENT_MEMORY_DIR")
-    if explicit:
-        return explicit
-    return str(Path(WORKSPACE_DIR) / "memories")
+    return str(resolve_workspace_paths().memories)
 
 
 def get_config_dir() -> str:
-    """Return the config directory path (<workspace>/config)."""
-    return str(Path(WORKSPACE_DIR) / "config")
+    return str(resolve_workspace_paths().config)
 
 
-def ensure_workspace():
-    """Create the workspace directory structure if it doesn't exist."""
-    for dir_path in [get_workspace_dir(), get_artifacts_dir(), get_memories_dir(), get_config_dir()]:
-        Path(dir_path).mkdir(parents=True, exist_ok=True)
+def ensure_workspace() -> WorkspacePaths:
+    return resolve_workspace_paths().ensure()

--- a/tests/test_memory_tool_backend.py
+++ b/tests/test_memory_tool_backend.py
@@ -1069,7 +1069,7 @@ class TestMemoryToolIntegration:
         from omnicoreagent.core.tools.memory_tool.memory_tool import MemoryTool
 
         factory._backend_cache.clear()
-        with patch.object(factory, "LOCAL_MEMORY_BASE_DIR", temp_dir):
+        with patch.dict(os.environ, {"OMNICOREAGENT_WORKSPACE_DIR": temp_dir}):
             tool = MemoryTool(backend="local")
 
             # Test all operations

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from omnicoreagent.core.tool_response_offloader import OffloadConfig
+from omnicoreagent.core.tools.memory_tool.factory import (
+    clear_backend_cache,
+    create_memory_backend,
+)
+from omnicoreagent.core.workspace import (
+    ensure_workspace,
+    get_artifacts_dir,
+    get_config_dir,
+    get_memories_dir,
+    get_workspace_dir,
+    resolve_workspace_paths,
+)
+
+
+def test_workspace_paths_resolve_from_current_environment(monkeypatch, tmp_path):
+    workspace = tmp_path / "agent_workspace"
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(workspace))
+
+    assert Path(get_workspace_dir()) == workspace
+    assert Path(get_artifacts_dir()) == workspace / "artifacts"
+    assert Path(get_memories_dir()) == workspace / "memories"
+    assert Path(get_config_dir()) == workspace / "config"
+
+
+def test_workspace_paths_support_explicit_subdir_overrides(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    artifacts = tmp_path / "artifact_store"
+    memories = tmp_path / "memory_store"
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(workspace))
+    monkeypatch.setenv("OMNICOREAGENT_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.setenv("OMNICOREAGENT_MEMORY_DIR", str(memories))
+
+    paths = resolve_workspace_paths()
+
+    assert paths.root == workspace
+    assert paths.artifacts == artifacts
+    assert paths.memories == memories
+    assert paths.config == workspace / "config"
+
+
+def test_ensure_workspace_creates_runtime_directories(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(workspace))
+
+    paths = ensure_workspace()
+
+    assert paths.root.is_dir()
+    assert paths.artifacts.is_dir()
+    assert paths.memories.is_dir()
+    assert paths.config.is_dir()
+
+
+def test_offload_config_reads_workspace_environment_at_instantiation(
+    monkeypatch, tmp_path
+):
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(first_workspace))
+    first = OffloadConfig()
+
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(second_workspace))
+    second = OffloadConfig()
+
+    assert Path(first.storage_dir) == first_workspace / "artifacts"
+    assert Path(second.storage_dir) == second_workspace / "artifacts"
+
+
+def test_local_memory_backend_cache_respects_workspace_changes(monkeypatch, tmp_path):
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+    clear_backend_cache()
+
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(first_workspace))
+    first = create_memory_backend("local")
+
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(second_workspace))
+    second = create_memory_backend("local")
+
+    assert first is not second
+    assert first.base_dir == (first_workspace / "memories").resolve()
+    assert second.base_dir == (second_workspace / "memories").resolve()
+
+    clear_backend_cache()


### PR DESCRIPTION
## Summary
- make workspace paths resolve from the current runtime environment instead of import-time globals
- add a `WorkspacePaths` resolver so workspace, artifacts, memories, and config share one entrypoint
- make tool offload defaults read the current workspace at config instantiation time
- make local memory backend creation and cache keys respect workspace/backend configuration
- add workspace tests for env-based resolution, explicit subdir overrides, directory creation, offload defaults, and memory cache behavior

## Why
Workspace has to become the root harness primitive for files, memory, artifacts, compaction state, and future cloud-backed storage. The old implementation froze workspace paths when modules imported, so memory/artifacts could drift or use stale paths across tests, processes, and deployments.

This PR does not yet unify S3/R2 artifacts. It lays the foundation by making local workspace resolution deterministic and runtime-owned first.

## Validation
- uv run ruff check src tests
- uv run pytest tests/test_workspace.py tests/test_tool_response_offloader.py tests/test_memory_tool_backend.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check