### PR TITLE
Add shared local workspace storage

### DIFF
--- a/src/omnicoreagent/core/tool_response_offloader.py
+++ b/src/omnicoreagent/core/tool_response_offloader.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 from omnicoreagent.core.summarizer.tokenizer import count_tokens
 from omnicoreagent.core.utils import logger
 from omnicoreagent.core.workspace import get_artifacts_dir
+from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
 
 
 @dataclass
@@ -108,6 +109,7 @@ class ToolResponseOffloader:
 
         self.base_dir = base_dir or os.getcwd()
         self.storage_path = Path(self.base_dir) / self.config.storage_dir
+        self.storage = LocalWorkspaceStorage(self.storage_path)
 
         if self.config.enabled:
             self._ensure_storage_dir()
@@ -119,11 +121,11 @@ class ToolResponseOffloader:
 
     def _ensure_storage_dir(self):
         """Create storage directory if it doesn't exist."""
-        self.storage_path.mkdir(parents=True, exist_ok=True)
+        self.storage.ensure_root()
 
         gitignore_path = self.storage_path / ".gitignore"
         if not gitignore_path.exists():
-            gitignore_path.write_text("*\n!.gitignore\n")
+            self.storage.write_text(".gitignore", "*\n!.gitignore\n")
 
     def _generate_artifact_id(self, tool_name: str, content: str) -> str:
         """Generate a unique but readable artifact ID."""
@@ -219,7 +221,7 @@ class ToolResponseOffloader:
         preview = self.get_preview(response)
         preview_tokens = count_tokens(preview)
 
-        artifact_path.write_text(response, encoding="utf-8")
+        self.storage.write_text(filename, response)
 
         timestamp = datetime.now().isoformat()
         if self.config.include_metadata:
@@ -232,7 +234,10 @@ class ToolResponseOffloader:
                 "custom": metadata or {},
             }
             meta_path = self.storage_path / f"{artifact_id}.meta.json"
-            meta_path.write_text(json.dumps(meta, indent=2))
+            self.storage.write_text(
+                meta_path.relative_to(self.storage_path),
+                json.dumps(meta, indent=2),
+            )
 
         offloaded = OffloadedResponse(
             artifact_id=artifact_id,
@@ -290,7 +295,7 @@ class ToolResponseOffloader:
         for ext in [".txt", ".json", ".xml"]:
             path = self.storage_path / f"{artifact_id}{ext}"
             if path.exists():
-                return path.read_text(encoding="utf-8")
+                return self.storage.read_text(path.relative_to(self.storage_path))
 
         return None
 

--- a/src/omnicoreagent/core/tools/memory_tool/local_storage.py
+++ b/src/omnicoreagent/core/tools/memory_tool/local_storage.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-import urllib.parse
 import shutil
 from filelock import FileLock
 from omnicoreagent.core.tools.memory_tool.base import AbstractMemoryBackend
 from omnicoreagent.core.workspace import get_memories_dir
+from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
 import json
 from typing import Any
 
@@ -15,65 +15,29 @@ class LocalMemoryBackend(AbstractMemoryBackend):
     """
 
     def __init__(self, base_dir=None):
-        self.base_dir = Path(base_dir or get_memories_dir()).resolve()
-        self._ensure_base_dir()
+        self.storage = LocalWorkspaceStorage(base_dir or get_memories_dir())
+        self.base_dir = self.storage.root
 
     def _ensure_base_dir(self):
         """Ensure the base directory exists."""
-        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.storage.ensure_root()
 
     def _resolve_path(self, path: str | None) -> Path:
         """Resolve a relative path safely inside the base directory."""
-        self._ensure_base_dir()
-        if not path or path.strip() == "":
-            return self.base_dir
-
-        decoded = urllib.parse.unquote(path).strip()
-        decoded = decoded.lstrip("/")
-
-        if decoded.startswith("memories/"):
-            decoded = decoded[len("memories/") :]
-        elif decoded == "memories":
-            decoded = ""
-
-        candidate = (self.base_dir / decoded).resolve()
-
-        try:
-            candidate.relative_to(self.base_dir)
-        except ValueError:
-            raise ValueError(
-                f"Invalid path '{path}' → resolved outside base directory.\n"
-                f"Path traversal detected.\nAll paths must stay inside: {self.base_dir}"
-            )
-        return candidate
+        return self.storage.resolve(path, strip_prefixes=("memories",))
 
     def _describe_dir(self) -> str:
-        self._ensure_base_dir()
-        contents = list(self.base_dir.iterdir())
-        if not contents:
-            return "(empty)"
-        return "\n".join(p.name for p in contents)
+        return self.storage.describe_root()
 
     def _write_atomic(self, abs_path: Path, content: str):
         """Write to a file atomically with a lock."""
-        lock_path = abs_path.with_suffix(".lock")
-        with FileLock(lock_path):
-            tmp_path = abs_path.with_suffix(".tmp")
-            tmp_path.write_text(content, encoding="utf-8")
-            tmp_path.rename(abs_path)
+        relative_path = abs_path.relative_to(self.base_dir)
+        self.storage.write_text(relative_path, content)
 
     def _append_atomic(self, abs_path: Path, content: str):
         """Append to a file safely with a lock."""
-        lock_path = abs_path.with_suffix(".lock")
-        with FileLock(lock_path):
-            if abs_path.exists():
-                existing = abs_path.read_text(encoding="utf-8")
-                combined = existing.rstrip("\n") + "\n" + content
-            else:
-                combined = content
-            tmp_path = abs_path.with_suffix(".tmp")
-            tmp_path.write_text(combined, encoding="utf-8")
-            tmp_path.rename(abs_path)
+        relative_path = abs_path.relative_to(self.base_dir)
+        self.storage.append_text(relative_path, content)
 
     def view(self, path: str | None = None) -> str:
         try:
@@ -87,8 +51,8 @@ class LocalMemoryBackend(AbstractMemoryBackend):
                 "\n".join(p.name for p in contents) if contents else "(empty)"
             )
         elif abs_path.is_file():
-            with FileLock(abs_path.with_suffix(".lock")):
-                return f"Contents of file {abs_path}:\n{abs_path.read_text(encoding='utf-8')}"
+            content = self.storage.read_text(abs_path.relative_to(self.base_dir))
+            return f"Contents of file {abs_path}:\n{content}"
         else:
             return f"Path not found: {path}\nBase directory: {self.base_dir}\nCurrent contents:\n{self._describe_dir()}"
 
@@ -212,11 +176,10 @@ class LocalMemoryBackend(AbstractMemoryBackend):
         if not abs_old.exists():
             return f"Path not found: {old_path}"
 
-        abs_new.parent.mkdir(parents=True, exist_ok=True)
-        lock_old = abs_old.with_suffix(".lock")
-        lock_new = abs_new.with_suffix(".lock")
-        with FileLock(lock_old), FileLock(lock_new):
-            abs_old.rename(abs_new)
+        self.storage.rename(
+            abs_old.relative_to(self.base_dir),
+            abs_new.relative_to(self.base_dir),
+        )
         return f"Renamed {abs_old} → {abs_new}"
 
     def clear_all_memory(self) -> str:

--- a/src/omnicoreagent/core/workspace_storage.py
+++ b/src/omnicoreagent/core/workspace_storage.py
@@ -1,0 +1,136 @@
+import shutil
+import urllib.parse
+from pathlib import Path
+from typing import Iterable
+
+from filelock import FileLock
+
+
+class LocalWorkspaceStorage:
+    """Safe local storage rooted inside one workspace namespace."""
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root).resolve()
+        self.ensure_root()
+
+    def ensure_root(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def resolve(
+        self,
+        path: str | Path | None = None,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> Path:
+        self.ensure_root()
+        if path is None or str(path).strip() == "":
+            return self.root
+
+        decoded = urllib.parse.unquote(str(path)).strip().lstrip("/")
+        for prefix in strip_prefixes:
+            clean_prefix = prefix.strip("/")
+            if decoded == clean_prefix:
+                decoded = ""
+                break
+            if decoded.startswith(f"{clean_prefix}/"):
+                decoded = decoded[len(clean_prefix) + 1 :]
+                break
+
+        candidate = (self.root / decoded).resolve()
+        try:
+            candidate.relative_to(self.root)
+        except ValueError:
+            raise ValueError(
+                f"Invalid path '{path}' resolved outside workspace namespace.\n"
+                f"Path traversal detected.\nAll paths must stay inside: {self.root}"
+            )
+        return candidate
+
+    def describe_root(self) -> str:
+        self.ensure_root()
+        contents = list(self.root.iterdir())
+        if not contents:
+            return "(empty)"
+        return "\n".join(path.name for path in contents)
+
+    def read_text(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        resolved = self.resolve(path, strip_prefixes=strip_prefixes)
+        with FileLock(resolved.with_suffix(".lock")):
+            return resolved.read_text(encoding="utf-8")
+
+    def write_text(
+        self,
+        path: str | Path,
+        content: str,
+        *,
+        strip_prefixes: Iterable[str] = (),
+        atomic: bool = True,
+    ) -> Path:
+        resolved = self.resolve(path, strip_prefixes=strip_prefixes)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        if not atomic:
+            resolved.write_text(content, encoding="utf-8")
+            return resolved
+
+        with FileLock(resolved.with_suffix(".lock")):
+            tmp_path = resolved.with_suffix(".tmp")
+            tmp_path.write_text(content, encoding="utf-8")
+            tmp_path.rename(resolved)
+        return resolved
+
+    def append_text(
+        self,
+        path: str | Path,
+        content: str,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> Path:
+        resolved = self.resolve(path, strip_prefixes=strip_prefixes)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(resolved.with_suffix(".lock")):
+            if resolved.exists():
+                existing = resolved.read_text(encoding="utf-8")
+                content = existing.rstrip("\n") + "\n" + content
+            tmp_path = resolved.with_suffix(".tmp")
+            tmp_path.write_text(content, encoding="utf-8")
+            tmp_path.rename(resolved)
+        return resolved
+
+    def delete(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        resolved = self.resolve(path, strip_prefixes=strip_prefixes)
+        with FileLock(resolved.with_suffix(".lock")):
+            if resolved.is_file():
+                resolved.unlink()
+                return f"File deleted: {resolved}"
+            if resolved.is_dir():
+                shutil.rmtree(resolved)
+                return f"Directory deleted: {resolved}"
+            return f"Path not found: {path}"
+
+    def rename(
+        self,
+        old_path: str | Path,
+        new_path: str | Path,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> tuple[Path, Path]:
+        old_resolved = self.resolve(old_path, strip_prefixes=strip_prefixes)
+        new_resolved = self.resolve(new_path, strip_prefixes=strip_prefixes)
+        if not old_resolved.exists():
+            raise FileNotFoundError(str(old_path))
+
+        new_resolved.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(old_resolved.with_suffix(".lock")), FileLock(
+            new_resolved.with_suffix(".lock")
+        ):
+            old_resolved.rename(new_resolved)
+        return old_resolved, new_resolved
+
+    def clear(self) -> None:
+        self.ensure_root()
+        with FileLock(self.root.with_suffix(".lock")):
+            for item in list(self.root.iterdir()):
+                if item.is_file():
+                    item.unlink()
+                elif item.is_dir():
+                    shutil.rmtree(item)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13,6 +13,7 @@ from omnicoreagent.core.workspace import (
     get_workspace_dir,
     resolve_workspace_paths,
 )
+from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
 
 
 def test_workspace_paths_resolve_from_current_environment(monkeypatch, tmp_path):
@@ -85,3 +86,34 @@ def test_local_memory_backend_cache_respects_workspace_changes(monkeypatch, tmp_
     assert second.base_dir == (second_workspace / "memories").resolve()
 
     clear_backend_cache()
+
+
+def test_local_workspace_storage_keeps_paths_inside_root(tmp_path):
+    storage = LocalWorkspaceStorage(tmp_path / "workspace")
+
+    storage.write_text("nested/result.txt", "hello")
+
+    assert storage.read_text("nested/result.txt") == "hello"
+    assert (tmp_path / "workspace" / "nested" / "result.txt").is_file()
+
+
+def test_local_workspace_storage_rejects_path_traversal(tmp_path):
+    storage = LocalWorkspaceStorage(tmp_path / "workspace")
+
+    try:
+        storage.write_text("../outside.txt", "bad")
+    except ValueError as exc:
+        assert "outside workspace namespace" in str(exc)
+    else:
+        raise AssertionError("Path traversal should be rejected")
+
+    assert not (tmp_path / "outside.txt").exists()
+
+
+def test_local_workspace_storage_strips_namespace_prefix(tmp_path):
+    storage = LocalWorkspaceStorage(tmp_path / "workspace" / "memories")
+
+    storage.write_text("memories/notes/today.md", "note", strip_prefixes=("memories",))
+
+    assert storage.read_text("notes/today.md") == "note"
+    assert not (tmp_path / "workspace" / "memories" / "memories").exists()


### PR DESCRIPTION
## Summary
- add `LocalWorkspaceStorage` as a shared local workspace storage boundary
- move local memory path resolution, safe namespace stripping, atomic writes, and appends onto the shared storage layer
- move artifact offload directory creation and artifact writes onto the shared storage layer
- add tests for storage path safety, namespace prefix stripping, and workspace-root file writes

## Why
Memory and artifacts were both writing files inside the workspace, but they each implemented their own path resolution and write behavior. This PR starts collapsing those filesystem concerns into one workspace storage primitive. That is the foundation for the next step: one workspace storage backend that can be local today and S3/R2-backed later without every harness feature reinventing cloud/local storage.

## Validation
- uv run ruff check src tests
- uv run pytest tests/test_workspace.py tests/test_tool_response_offloader.py -q
- uv run pytest tests/test_memory_tool_backend.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check