### PR TITLE
Add workspace backend storage

### DIFF
--- a/src/omnicoreagent/core/tool_response_offloader.py
+++ b/src/omnicoreagent/core/tool_response_offloader.py
@@ -18,10 +18,15 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
 
+from decouple import config as decouple_config
+
 from omnicoreagent.core.summarizer.tokenizer import count_tokens
 from omnicoreagent.core.utils import logger
 from omnicoreagent.core.workspace import get_artifacts_dir
-from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
+from omnicoreagent.core.workspace_storage import (
+    LocalWorkspaceStorage,
+    create_workspace_storage,
+)
 
 
 @dataclass
@@ -110,7 +115,16 @@ class ToolResponseOffloader:
 
         self.base_dir = base_dir or os.getcwd()
         self.storage_path = Path(self.base_dir) / self.config.storage_dir
-        self.storage = LocalWorkspaceStorage(self.storage_path)
+        workspace_backend = decouple_config(
+            "OMNICOREAGENT_WORKSPACE_BACKEND", default="local"
+        ).lower()
+        if workspace_backend == "local":
+            self.storage = LocalWorkspaceStorage(self.storage_path)
+        else:
+            self.storage = create_workspace_storage(
+                backend=workspace_backend,
+                namespace="artifacts",
+            )
 
         if self.config.enabled:
             self._ensure_storage_dir()
@@ -124,8 +138,7 @@ class ToolResponseOffloader:
         """Create storage directory if it doesn't exist."""
         self.storage.ensure_root()
 
-        gitignore_path = self.storage_path / ".gitignore"
-        if not gitignore_path.exists():
+        if not self.storage.exists(".gitignore"):
             self.storage.write_text(".gitignore", "*\n!.gitignore\n")
 
     def _generate_artifact_id(self, tool_name: str, content: str) -> str:

--- a/src/omnicoreagent/core/workspace_storage.py
+++ b/src/omnicoreagent/core/workspace_storage.py
@@ -3,9 +3,12 @@ import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable, Protocol
 
+from decouple import config
 from filelock import FileLock
+
+from omnicoreagent._optional import load_optional
 
 
 @dataclass(frozen=True)
@@ -13,6 +16,51 @@ class WorkspaceFile:
     path: str
     name: str
     modified_at: datetime
+
+
+class WorkspaceStorage(Protocol):
+    def ensure_root(self) -> None: ...
+
+    def read_text(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        ...
+
+    def exists(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> bool:
+        ...
+
+    def location(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        ...
+
+    def list_files(self) -> list[WorkspaceFile]: ...
+
+    def write_text(
+        self,
+        path: str | Path,
+        content: str,
+        *,
+        strip_prefixes: Iterable[str] = (),
+        atomic: bool = True,
+    ) -> Any: ...
+
+    def append_text(
+        self,
+        path: str | Path,
+        content: str,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> Any: ...
+
+    def delete(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        ...
+
+    def rename(
+        self,
+        old_path: str | Path,
+        new_path: str | Path,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> Any: ...
+
+    def clear(self) -> None: ...
 
 
 class LocalWorkspaceStorage:
@@ -164,3 +212,261 @@ class LocalWorkspaceStorage:
                     item.unlink()
                 elif item.is_dir():
                     shutil.rmtree(item)
+
+
+class S3WorkspaceStorage:
+    """S3-compatible workspace storage rooted at a key prefix."""
+
+    def __init__(
+        self,
+        *,
+        bucket_name: str,
+        prefix: str = "workspace/",
+        region: str | None = None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        endpoint_url: str | None = None,
+        enable_encryption: bool = True,
+        client: Any = None,
+    ):
+        self.bucket = bucket_name
+        self.prefix = prefix.strip("/")
+        self.prefix = f"{self.prefix}/" if self.prefix else ""
+        self.enable_encryption = enable_encryption
+
+        if client is not None:
+            self.s3 = client
+            return
+
+        boto3 = load_optional("S3 workspace storage", "s3", lambda: __import__("boto3"))
+        Config = load_optional(
+            "S3 workspace storage",
+            "s3",
+            lambda: __import__("botocore.config", fromlist=["Config"]).Config,
+        )
+        client_params = {
+            "service_name": "s3",
+            "config": Config(region_name=region),
+        }
+        if endpoint_url:
+            client_params["endpoint_url"] = endpoint_url
+        if aws_access_key_id and aws_secret_access_key:
+            client_params["aws_access_key_id"] = aws_access_key_id
+            client_params["aws_secret_access_key"] = aws_secret_access_key
+        self.s3 = boto3.client(**client_params)
+
+    def ensure_root(self) -> None:
+        return None
+
+    def _normalize_key(
+        self,
+        path: str | Path | None = None,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> str:
+        if path is None or str(path).strip() == "":
+            return self.prefix
+
+        decoded = urllib.parse.unquote(str(path)).strip().lstrip("/")
+        for prefix in strip_prefixes:
+            clean_prefix = prefix.strip("/")
+            if decoded == clean_prefix:
+                decoded = ""
+                break
+            if decoded.startswith(f"{clean_prefix}/"):
+                decoded = decoded[len(clean_prefix) + 1 :]
+                break
+
+        parts = [part for part in decoded.split("/") if part]
+        if any(part == ".." for part in parts):
+            raise ValueError(
+                f"Invalid path '{path}' resolved outside workspace namespace."
+            )
+        return f"{self.prefix}{'/'.join(parts)}" if parts else self.prefix
+
+    def _put_params(self) -> dict[str, Any]:
+        if not self.enable_encryption:
+            return {}
+        return {"ServerSideEncryption": "AES256"}
+
+    def read_text(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        key = self._normalize_key(path, strip_prefixes=strip_prefixes)
+        response = self.s3.get_object(Bucket=self.bucket, Key=key)
+        return response["Body"].read().decode("utf-8")
+
+    def exists(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> bool:
+        key = self._normalize_key(path, strip_prefixes=strip_prefixes)
+        try:
+            self.s3.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except Exception:
+            return False
+
+    def location(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        key = self._normalize_key(path, strip_prefixes=strip_prefixes)
+        return f"s3://{self.bucket}/{key}"
+
+    def list_files(self) -> list[WorkspaceFile]:
+        response = self.s3.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix)
+        files = []
+        for item in response.get("Contents", []):
+            key = item["Key"]
+            if key == self.prefix or key.endswith("/"):
+                continue
+            name = key[len(self.prefix) :]
+            if "/" in name:
+                continue
+            files.append(
+                WorkspaceFile(
+                    path=name,
+                    name=name,
+                    modified_at=item["LastModified"],
+                )
+            )
+        return files
+
+    def write_text(
+        self,
+        path: str | Path,
+        content: str,
+        *,
+        strip_prefixes: Iterable[str] = (),
+        atomic: bool = True,
+    ) -> str:
+        key = self._normalize_key(path, strip_prefixes=strip_prefixes)
+        self.s3.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=content.encode("utf-8"),
+            **self._put_params(),
+        )
+        return key
+
+    def append_text(
+        self,
+        path: str | Path,
+        content: str,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> str:
+        if self.exists(path, strip_prefixes=strip_prefixes):
+            content = (
+                self.read_text(path, strip_prefixes=strip_prefixes).rstrip("\n")
+                + "\n"
+                + content
+            )
+        return self.write_text(path, content, strip_prefixes=strip_prefixes)
+
+    def delete(self, path: str | Path, *, strip_prefixes: Iterable[str] = ()) -> str:
+        key = self._normalize_key(path, strip_prefixes=strip_prefixes)
+        self.s3.delete_object(Bucket=self.bucket, Key=key)
+        return f"File deleted: s3://{self.bucket}/{key}"
+
+    def rename(
+        self,
+        old_path: str | Path,
+        new_path: str | Path,
+        *,
+        strip_prefixes: Iterable[str] = (),
+    ) -> tuple[str, str]:
+        old_key = self._normalize_key(old_path, strip_prefixes=strip_prefixes)
+        new_key = self._normalize_key(new_path, strip_prefixes=strip_prefixes)
+        self.s3.copy_object(
+            Bucket=self.bucket,
+            CopySource={"Bucket": self.bucket, "Key": old_key},
+            Key=new_key,
+            **self._put_params(),
+        )
+        self.s3.delete_object(Bucket=self.bucket, Key=old_key)
+        return old_key, new_key
+
+    def clear(self) -> None:
+        response = self.s3.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix)
+        objects = [{"Key": item["Key"]} for item in response.get("Contents", [])]
+        if objects:
+            self.s3.delete_objects(Bucket=self.bucket, Delete={"Objects": objects})
+
+
+class R2WorkspaceStorage(S3WorkspaceStorage):
+    def __init__(
+        self,
+        *,
+        bucket_name: str,
+        account_id: str,
+        access_key_id: str,
+        secret_access_key: str,
+        prefix: str = "workspace/",
+        client: Any = None,
+    ):
+        endpoint_url = f"https://{account_id}.r2.cloudflarestorage.com"
+        super().__init__(
+            bucket_name=bucket_name,
+            prefix=prefix,
+            region="auto",
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            endpoint_url=endpoint_url,
+            enable_encryption=False,
+            client=client,
+        )
+
+
+def create_workspace_storage(
+    *,
+    backend: str | None = None,
+    namespace: str | None = None,
+) -> WorkspaceStorage:
+    backend = (backend or config("OMNICOREAGENT_WORKSPACE_BACKEND", default="local"))
+    backend = backend.lower().strip()
+    namespace = (namespace or "").strip("/")
+
+    if backend == "local":
+        from omnicoreagent.core.workspace import resolve_workspace_paths
+
+        paths = resolve_workspace_paths()
+        root = paths.root / namespace if namespace else paths.root
+        return LocalWorkspaceStorage(root)
+
+    if backend == "s3":
+        bucket_name = config("AWS_S3_BUCKET", default=None)
+        if not bucket_name:
+            raise ValueError("S3 workspace backend requires AWS_S3_BUCKET")
+        prefix = config("OMNICOREAGENT_WORKSPACE_PREFIX", default="workspace").strip("/")
+        if namespace:
+            prefix = f"{prefix}/{namespace}"
+        return S3WorkspaceStorage(
+            bucket_name=bucket_name,
+            prefix=prefix,
+            region=config("AWS_REGION", default=None),
+            aws_access_key_id=config("AWS_ACCESS_KEY_ID", default=None),
+            aws_secret_access_key=config("AWS_SECRET_ACCESS_KEY", default=None),
+            endpoint_url=config("AWS_ENDPOINT_URL", default=None),
+        )
+
+    if backend == "r2":
+        missing = [
+            name
+            for name in (
+                "R2_BUCKET_NAME",
+                "R2_ACCOUNT_ID",
+                "R2_ACCESS_KEY_ID",
+                "R2_SECRET_ACCESS_KEY",
+            )
+            if not config(name, default=None)
+        ]
+        if missing:
+            raise ValueError(
+                f"R2 workspace backend requires environment variables: {', '.join(missing)}"
+            )
+        prefix = config("OMNICOREAGENT_WORKSPACE_PREFIX", default="workspace").strip("/")
+        if namespace:
+            prefix = f"{prefix}/{namespace}"
+        return R2WorkspaceStorage(
+            bucket_name=config("R2_BUCKET_NAME"),
+            account_id=config("R2_ACCOUNT_ID"),
+            access_key_id=config("R2_ACCESS_KEY_ID"),
+            secret_access_key=config("R2_SECRET_ACCESS_KEY"),
+            prefix=prefix,
+        )
+
+    raise ValueError("workspace backend must be one of: local, s3, r2")

--- a/tests/test_tool_response_offloader.py
+++ b/tests/test_tool_response_offloader.py
@@ -384,6 +384,16 @@ class TestOffload:
 
         assert result.artifact_path.endswith(".txt")
 
+    def test_offload_uses_workspace_storage_for_location(self):
+        """Test artifact paths come from the workspace storage boundary."""
+        content = "Storage boundary content " * 50
+        result = self.offloader.offload("storage_tool", content)
+
+        assert result.storage_key.endswith(".txt")
+        assert result.artifact_path == self.offloader.storage.location(
+            result.storage_key
+        )
+
 
 # ============================================================================
 # Artifact Retrieval Tests

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 from omnicoreagent.core.tool_response_offloader import OffloadConfig
 from omnicoreagent.core.tools.memory_tool.factory import (
@@ -14,6 +15,7 @@ from omnicoreagent.core.workspace import (
     resolve_workspace_paths,
 )
 from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
+from omnicoreagent.core.workspace_storage import S3WorkspaceStorage
 
 
 def test_workspace_paths_resolve_from_current_environment(monkeypatch, tmp_path):
@@ -117,3 +119,95 @@ def test_local_workspace_storage_strips_namespace_prefix(tmp_path):
 
     assert storage.read_text("notes/today.md") == "note"
     assert not (tmp_path / "workspace" / "memories" / "memories").exists()
+
+
+class FakeS3Body:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+
+class FakeS3Client:
+    def __init__(self):
+        self.objects = {}
+
+    def put_object(self, Bucket, Key, Body, **kwargs):
+        self.objects[(Bucket, Key)] = {
+            "Body": Body,
+            "LastModified": datetime(2026, 1, 1),
+        }
+
+    def get_object(self, Bucket, Key):
+        item = self.objects[(Bucket, Key)]
+        return {"Body": FakeS3Body(item["Body"])}
+
+    def head_object(self, Bucket, Key):
+        if (Bucket, Key) not in self.objects:
+            raise KeyError(Key)
+        return {}
+
+    def list_objects_v2(self, Bucket, Prefix):
+        contents = []
+        for (bucket, key), item in self.objects.items():
+            if bucket == Bucket and key.startswith(Prefix):
+                contents.append(
+                    {
+                        "Key": key,
+                        "LastModified": item["LastModified"],
+                    }
+                )
+        return {"Contents": contents}
+
+    def delete_object(self, Bucket, Key):
+        self.objects.pop((Bucket, Key), None)
+
+    def copy_object(self, Bucket, CopySource, Key, **kwargs):
+        source = self.objects[(CopySource["Bucket"], CopySource["Key"])]
+        self.objects[(Bucket, Key)] = dict(source)
+
+    def delete_objects(self, Bucket, Delete):
+        for item in Delete["Objects"]:
+            self.delete_object(Bucket=Bucket, Key=item["Key"])
+
+
+def test_s3_workspace_storage_reads_writes_and_lists_files():
+    client = FakeS3Client()
+    storage = S3WorkspaceStorage(
+        bucket_name="bucket",
+        prefix="workspace/artifacts",
+        client=client,
+    )
+
+    storage.write_text("result.txt", "hello")
+
+    assert storage.exists("result.txt")
+    assert storage.read_text("result.txt") == "hello"
+    assert storage.location("result.txt") == "s3://bucket/workspace/artifacts/result.txt"
+    assert [item.name for item in storage.list_files()] == ["result.txt"]
+
+
+def test_s3_workspace_storage_rejects_path_traversal():
+    storage = S3WorkspaceStorage(bucket_name="bucket", client=FakeS3Client())
+
+    try:
+        storage.write_text("../outside.txt", "bad")
+    except ValueError as exc:
+        assert "outside workspace namespace" in str(exc)
+    else:
+        raise AssertionError("Path traversal should be rejected")
+
+
+def test_s3_workspace_storage_delete_and_rename():
+    client = FakeS3Client()
+    storage = S3WorkspaceStorage(bucket_name="bucket", prefix="workspace", client=client)
+
+    storage.write_text("old.txt", "content")
+    storage.rename("old.txt", "new.txt")
+
+    assert not storage.exists("old.txt")
+    assert storage.read_text("new.txt") == "content"
+
+    storage.delete("new.txt")
+    assert not storage.exists("new.txt")


### PR DESCRIPTION
## Summary
- add a shared WorkspaceStorage protocol with local, S3, and R2 implementations
- route tool response artifacts through the configured workspace backend instead of hardcoding local artifact paths
- add storage boundary tests for S3-compatible read/write/list/delete/rename behavior and artifact location handling

## Validation
- uv run ruff check src tests
- uv run pytest tests/test_workspace.py tests/test_tool_response_offloader.py tests/test_memory_tool_backend.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check

## Notes
This keeps the PR focused on the storage boundary and artifact routing. Memory still has its existing backend-specific implementation and should be collapsed onto the workspace storage abstraction in the next PR.