### PR TITLE
Rename workspace memory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ agent_config = {
     "memory_config": {"mode": "sliding_window", "value": 10000},
     "enable_advanced_tool_use": True,   # BM25 tool retrieval
     "enable_agent_skills": True,        # Specialized packaged skills
-    "memory_tool_backend": "workspace"  # Memory files live in workspace
+    "enable_workspace_memory": True     # File memory: notes, logs, scratchpads
 }
 ```
 

--- a/docs/core-concepts/deep-agent.mdx
+++ b/docs/core-concepts/deep-agent.mdx
@@ -160,7 +160,7 @@ agent = DeepAgent(
         # These are the defaults (you can override):
         "max_steps": 50,  # More steps for orchestration
         "tool_call_timeout": 600,  # 10 min (subagents do deep work)
-        "memory_tool_backend": "workspace",
+        "enable_workspace_memory": True,
         "context_management": {"enabled": True},
         "tool_offload": {"enabled": True},
     }
@@ -169,7 +169,7 @@ agent = DeepAgent(
 
 ### Key Config Notes
 
-- **`memory_tool_backend`**: Use `"workspace"` so memory files live inside the active workspace backend
+- **`enable_workspace_memory`**: Enabled by default for file-style notes, logs, todos, scratchpads, and task progress inside the active workspace
 - **`max_steps`**: Increased to `50` to allow for multi-agent coordination
 - **`tool_call_timeout`**: Set to `600s` because subagents may do research, API calls, etc.
 

--- a/docs/core-concepts/overview.mdx
+++ b/docs/core-concepts/overview.mdx
@@ -60,7 +60,7 @@ agent = OmniCoreAgent(
         "max_steps": 20,
         "enable_advanced_tool_use": True,
         "enable_agent_skills": True,
-        "memory_tool_backend": "workspace",
+        "enable_workspace_memory": True,
         # Memory with summarization
         "memory_config": {
             "mode": "sliding_window",

--- a/docs/core-concepts/workspace-memory.mdx
+++ b/docs/core-concepts/workspace-memory.mdx
@@ -6,9 +6,9 @@ icon: 'folder-open'
 
 # Workspace Memory
 
-> Memory files live inside the same workspace backend used by artifacts and other workspace files.
+> Workspace memory is file-style agent memory for notes, scratchpads, logs, todos, task progress, generated code, and research files.
 
-Workspace memory gives agents a durable file area for notes, plans, research, and generated context. There is no separate memory storage backend: choose the workspace backend once, and memory uses `memories/` inside that workspace.
+Workspace memory gives agents a durable filesystem-like area inside the active workspace. There is no separate memory storage backend: choose the workspace backend once, and memory uses `memories/` inside that workspace.
 
 ---
 
@@ -24,7 +24,7 @@ Workspace memory gives agents a durable file area for notes, plans, research, an
 
 ## Quick Setup
 
-Enable the memory tools, then choose the workspace backend with environment variables.
+Enable workspace memory tools, then choose the workspace backend with environment variables.
 
 ```bash
 pip install "omnicoreagent[s3]"
@@ -32,7 +32,7 @@ pip install "omnicoreagent[s3]"
 
 ```python
 agent_config = {
-    "memory_tool_backend": "workspace"
+    "enable_workspace_memory": True
 }
 ```
 
@@ -71,17 +71,17 @@ R2_SECRET_ACCESS_KEY=your-r2-secret
 
 ---
 
-## Agent Memory Tools
+## Workspace Memory Tools
 
 When enabled, your agent automatically gets these tools:
 
 | Tool | Purpose |
 |------|---------|
-| `memory_view` | View/list files in memory workspace |
+| `memory_view` | View/list files in workspace memory |
 | `memory_create_update` | Create, append, or overwrite files |
 | `memory_str_replace` | Find and replace text within files |
 | `memory_insert` | Insert text at specific line numbers |
-| `memory_delete` | Delete files from workspace |
+| `memory_delete` | Delete files from workspace memory |
 | `memory_rename` | Rename or move files |
 | `memory_clear_all` | Clear entire workspace |
 
@@ -130,7 +130,7 @@ agent = OmniCoreAgent(
     system_instruction="You are a research assistant. Save your findings to memory.",
     model_config={"provider": "openai", "model": "gpt-4o"},
     agent_config={
-        "memory_tool_backend": "workspace",
+        "enable_workspace_memory": True,
         "max_steps": 50,
     }
 )

--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -105,7 +105,7 @@ class BaseReactAgent:
         request_limit: int = 0,
         total_tokens_limit: int = 0,
         enable_advanced_tool_use: bool = False,
-        memory_tool_backend: str = None,
+        enable_workspace_memory: bool = False,
         enable_agent_skills: bool = False,
         context_management_config: dict = None,
         tool_offload_config: dict = None,
@@ -124,7 +124,7 @@ class BaseReactAgent:
         self._limits_enabled = request_limit > 0 or total_tokens_limit > 0
         self.enable_advanced_tool_use = enable_advanced_tool_use
 
-        self.memory_tool_backend = memory_tool_backend
+        self.enable_workspace_memory = enable_workspace_memory
         self.enable_agent_skills = enable_agent_skills
         self.skill_manager = None
         self.usage_limits = UsageLimits(
@@ -1022,7 +1022,7 @@ class BaseReactAgent:
         registry = local_tools
         needs_internal_registry = (
             self.enable_advanced_tool_use
-            or self.memory_tool_backend
+            or self.enable_workspace_memory
             or self.tool_offloader.config.enabled
             or (self.enable_agent_skills and self.skill_manager)
         )
@@ -1036,9 +1036,9 @@ class BaseReactAgent:
         if self.enable_advanced_tool_use:
             await build_tool_registry_advance_tools_use(registry=registry)
 
-        if self.memory_tool_backend:
+        if self.enable_workspace_memory:
             build_tool_registry_memory_tool(
-                memory_tool_backend=None,
+                backend=None,
                 registry=registry,
             )
 
@@ -1247,7 +1247,7 @@ class BaseReactAgent:
         if sub_agents:
             updated_system_prompt += f"\n{sub_agents_additional_prompt}"
 
-        if self.memory_tool_backend:
+        if self.enable_workspace_memory:
             updated_system_prompt += f"\n{memory_tool_additional_prompt}"
 
         if self.tool_offloader.config.enabled:

--- a/src/omnicoreagent/core/agents/react_agent.py
+++ b/src/omnicoreagent/core/agents/react_agent.py
@@ -14,7 +14,7 @@ class ReactAgent(BaseReactAgent):
             request_limit=config.request_limit,
             total_tokens_limit=config.total_tokens_limit,
             enable_advanced_tool_use=config.enable_advanced_tool_use,
-            memory_tool_backend=config.memory_tool_backend,
+            enable_workspace_memory=config.enable_workspace_memory,
             enable_agent_skills=config.enable_agent_skills,
             context_management_config=config.context_management,
             tool_offload_config=getattr(config, "tool_offload", None),

--- a/src/omnicoreagent/core/tools/memory_tool/__init__.py
+++ b/src/omnicoreagent/core/tools/memory_tool/__init__.py
@@ -1,13 +1,14 @@
 """
-Memory Tool backends for OmniCoreAgent.
+Workspace memory tools for OmniCoreAgent.
 
-Provides pluggable storage backends for the memory tool:
-- WorkspaceMemoryBackend: memory files inside the active workspace storage
+Provides file-style workspace memory for notes, scratchpads, logs, todos,
+task progress, and generated files. Files live inside the active workspace
+storage under the memories namespace.
 
 Usage:
     # In agent config
     agent_config = {
-        "memory_tool_backend": "workspace",
+        "enable_workspace_memory": True,
     }
 """
 

--- a/src/omnicoreagent/core/tools/memory_tool/factory.py
+++ b/src/omnicoreagent/core/tools/memory_tool/factory.py
@@ -15,7 +15,7 @@ def create_memory_backend(
     use_cache: bool = True,
 ) -> AbstractMemoryBackend:
     """
-    Create the memory backend from the active workspace storage.
+    Create the workspace memory backend from the active workspace storage.
 
     Args:
         use_cache: If True (default), reuse cached backend instances
@@ -29,7 +29,7 @@ def create_memory_backend(
     if use_cache:
         with _cache_lock:
             if cache_key in _backend_cache:
-                logger.debug("Reusing cached workspace memory backend")
+                logger.debug("Reusing cached workspace memory storage")
                 return _backend_cache[cache_key]
 
     # Create new backend
@@ -76,7 +76,7 @@ def _backend_cache_key() -> tuple:
 
 def _create_backend_instance(storage) -> AbstractMemoryBackend:
     """Create a new backend instance (internal, no caching)."""
-    logger.info("Creating workspace memory backend")
+    logger.info("Creating workspace memory storage")
     return WorkspaceMemoryBackend(storage=storage)
 
 
@@ -84,4 +84,4 @@ def clear_backend_cache():
     """Clear the backend cache (useful for testing or reconfiguration)."""
     with _cache_lock:
         _backend_cache.clear()
-        logger.info("Memory backend cache cleared")
+        logger.info("Workspace memory cache cleared")

--- a/src/omnicoreagent/core/tools/memory_tool/memory_tool.py
+++ b/src/omnicoreagent/core/tools/memory_tool/memory_tool.py
@@ -63,17 +63,17 @@ class MemoryTool:
 
 
 def build_tool_registry_memory_tool(
-    memory_tool_backend: AbstractMemoryBackend | None,
+    backend: AbstractMemoryBackend | None,
     registry: ToolRegistry,
 ) -> ToolRegistry:
     """
     Register memory tool commands in a ToolRegistry.
 
     Args:
-        memory_tool_backend: Optional backend instance. None uses workspace storage.
+        backend: Optional backend instance. None uses workspace storage.
         registry: ToolRegistry to register commands with
     """
-    memory_tool = MemoryTool(backend=memory_tool_backend)
+    memory_tool = MemoryTool(backend=backend)
 
     @registry.register_tool(
         name="memory_view",

--- a/src/omnicoreagent/core/tools/memory_tool/storage.py
+++ b/src/omnicoreagent/core/tools/memory_tool/storage.py
@@ -7,7 +7,7 @@ from omnicoreagent.core.workspace_storage import WorkspaceStorage
 
 
 class WorkspaceMemoryBackend(AbstractMemoryBackend):
-    """Memory backend backed by the active workspace storage."""
+    """File-style memory rooted inside the active workspace storage."""
 
     def __init__(self, storage: WorkspaceStorage):
         self.storage = storage

--- a/src/omnicoreagent/core/types.py
+++ b/src/omnicoreagent/core/types.py
@@ -23,9 +23,12 @@ class AgentConfig(BaseModel):
         "summary": {"enabled": False, "retention_policy": "keep"},
     }
 
-    memory_tool_backend: str | None = Field(
-        default=None,
-        description="Enable the memory tool. Memory is always stored inside the active workspace backend.",
+    enable_workspace_memory: bool = Field(
+        default=False,
+        description=(
+            "Enable file-style workspace memory tools for notes, scratchpads, "
+            "logs, todos, task progress, and generated files."
+        ),
     )
 
     enable_agent_skills: bool = Field(
@@ -55,18 +58,6 @@ class AgentConfig(BaseModel):
         },
         description="Tool response offloading config to reduce context size from large tool outputs",
     )
-
-    @field_validator("memory_tool_backend")
-    @classmethod
-    def validate_backend(cls, v):
-        if v is None:
-            return v
-        allowed = {"workspace"}
-        if v not in allowed:
-            raise ValueError(
-                f"Invalid memory_tool_backend '{v}'. Must be one of {allowed}."
-            )
-        return v
 
     @field_validator("request_limit", "total_tokens_limit", mode="before")
     @classmethod

--- a/src/omnicoreagent/deep_agent/deep_agent.py
+++ b/src/omnicoreagent/deep_agent/deep_agent.py
@@ -33,7 +33,7 @@ from .subagent_factory import SubagentFactory, build_subagent_tools
 DEFAULT_DEEP_AGENT_CONFIG = {
     "tool_call_timeout": 600,
     "max_steps": 50,
-    "memory_tool_backend": "workspace",
+    "enable_workspace_memory": True,
     "memory_config": {
         "mode": "sliding_window",
         "value": 15000,
@@ -65,7 +65,7 @@ class DeepAgent:
     1. Custom DeepAgentPromptBuilder (clean prompt structure)
     2. Subagent spawning tools
     3. Full agent_config benefits (context_management, tool_offload, etc.)
-    4. Memory_tool_backend always local (required for orchestration)
+    4. Workspace-backed memory tools enabled by default
 
     NOTE: Task paths for memory organization are chosen dynamically by the
     lead agent when it spawns subagents - not hardcoded in base prompt.
@@ -137,9 +137,6 @@ class DeepAgent:
                     config[key] = {**config[key], **value}
                 else:
                     config[key] = value
-
-        if "memory_tool_backend" not in config:
-            config["memory_tool_backend"] = "workspace"
 
         return config
 

--- a/src/omnicoreagent/deep_agent/subagent_factory.py
+++ b/src/omnicoreagent/deep_agent/subagent_factory.py
@@ -73,8 +73,8 @@ class SubagentFactory:
 
         config["max_steps"] = min(config.get("max_steps", 15), 15)
 
-        if "memory_tool_backend" not in config:
-            config["memory_tool_backend"] = "workspace"
+        if "enable_workspace_memory" not in config:
+            config["enable_workspace_memory"] = True
 
         return config
 

--- a/src/omnicoreagent/runtime_config.py
+++ b/src/omnicoreagent/runtime_config.py
@@ -64,7 +64,7 @@ class AgentConfig:
             "summary": {"enabled": False, "retention_policy": "keep"},
         }
     )
-    memory_tool_backend: str | None = None
+    enable_workspace_memory: bool = False
     guardrail_config: dict[str, Any] | None = None
     guardrail_mode: str = "full"
     context_management: dict[str, Any] = field(

--- a/src/omnicoreagent/serve/cli.py
+++ b/src/omnicoreagent/serve/cli.py
@@ -347,7 +347,7 @@ def generate_dockerfile(file_path: str, output_dir: str):
     try:
         loaded_agent = _load_agent_from_file(file_path)
         if loaded_agent.agent_config and isinstance(loaded_agent.agent_config, dict):
-            memory_enabled = bool(loaded_agent.agent_config.get("memory_tool_backend"))
+            memory_enabled = bool(loaded_agent.agent_config.get("enable_workspace_memory"))
         console.print(f"[green]✓ Detected agent: {loaded_agent.name}[/green]")
         if memory_enabled:
             console.print("[dim]Workspace memory tools enabled[/dim]")

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -204,15 +204,15 @@ class TestDeepAgentInitialization:
 
     @pytest.mark.broken_upstream
     @pytest.mark.asyncio
-    async def test_memory_tool_backend_uses_workspace(self):
-        """Memory should always use the workspace backend."""
+    async def test_deep_agent_enables_workspace_memory(self):
+        """DeepAgent should enable workspace memory tools."""
         agent = DeepAgent(
             name="Test",
             system_instruction="Test",
             model_config={"provider": "openai", "model": "gpt-4"},
             agent_config={},
         )
-        assert agent.agent_config["memory_tool_backend"] == "workspace"
+        assert agent.agent_config["enable_workspace_memory"] is True
 
     @pytest.mark.asyncio
     async def test_prompt_builder_assigned(self, deep_agent):


### PR DESCRIPTION
## Summary
- replace the stale memory_tool_backend config name with enable_workspace_memory
- clarify workspace memory as file-style storage for notes, scratchpads, logs, todos, task progress, generated code, and research files
- update DeepAgent defaults, ReactAgent wiring, OmniServe detection, docs, and tests
- remove the old backend-value validator now that workspace memory is an enable flag

## Validation
- uv run ruff check src tests
- uv run pytest tests/test_deep_agent.py tests/test_memory_tool_backend.py tests/test_workspace.py tests/test_base.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check