### PR TITLE
Unify artifact offload with workspace storage

### DIFF
--- a/docs/core-concepts/context-engineering.mdx
+++ b/docs/core-concepts/context-engineering.mdx
@@ -61,8 +61,7 @@ agent_config = {
     "tool_offload": {
         "enabled": True,
         "threshold_tokens": 500,  # Offload responses > 500 tokens
-        "max_preview_tokens": 150,  # Show first 150 tokens in context
-        "storage_dir": "workspace/artifacts"
+        "max_preview_tokens": 150  # Show first 150 tokens in context
     }
 }
 ```

--- a/docs/core-concepts/workspace-memory.mdx
+++ b/docs/core-concepts/workspace-memory.mdx
@@ -83,7 +83,7 @@ When enabled, your agent automatically gets these tools:
 | `memory_insert` | Insert text at specific line numbers |
 | `memory_delete` | Delete files from workspace memory |
 | `memory_rename` | Rename or move files |
-| `memory_clear_all` | Clear entire workspace |
+| `memory_clear_all` | Clear the workspace memory namespace |
 
 ---
 
@@ -126,8 +126,8 @@ os.environ["AWS_REGION"] = "us-east-1"
 os.environ["AWS_ENDPOINT_URL"] = "https://s3.amazonaws.com"  # Optional
 
 agent = OmniCoreAgent(
-    name="research_agent",
-    system_instruction="You are a research assistant. Save your findings to memory.",
+    name="workspace_agent",
+    system_instruction="Save durable notes, logs, task progress, and final output to memory.",
     model_config={"provider": "openai", "model": "gpt-4o"},
     agent_config={
         "enable_workspace_memory": True,
@@ -140,7 +140,7 @@ agent = OmniCoreAgent(
 # - Multiple instances
 # - Different geographic locations
 result = await agent.run(
-    "Research the latest AI developments and save a summary to /notes/ai_trends_2024.md"
+    "Research recent AI developments and save a summary to /notes/ai_trends.md"
 )
 ```
 

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -292,28 +292,29 @@ docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver
 
 | Your Agent Uses | Dockerfile Sets |
 |-----------------|-----------------|
-| No memory tools | `AGENT_PATH`, `OMNICOREAGENT_ARTIFACTS_DIR` |
-| Local memory | + `OMNICOREAGENT_MEMORY_DIR=/tmp/memories` |
-| S3/R2 memory | Pass credentials at runtime with `-e` |
+| Local workspace | `AGENT_PATH`, `OMNICOREAGENT_WORKSPACE_BACKEND=local`, `OMNICOREAGENT_WORKSPACE_DIR=/tmp/workspace` |
+| S3/R2 workspace | Pass workspace backend and credentials at runtime with `-e` |
 
 ### Cloud deployment examples
 
 ```bash
-# Local memory (ephemeral)
+# Local workspace (ephemeral)
 docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver
 
-# AWS S3 memory (persistent)
+# AWS S3 workspace (persistent)
 docker run -p 8000:8000 \
   -e LLM_API_KEY=$LLM_API_KEY \
+  -e OMNICOREAGENT_WORKSPACE_BACKEND=s3 \
   -e AWS_S3_BUCKET=my-bucket \
   -e AWS_ACCESS_KEY_ID=... \
   -e AWS_SECRET_ACCESS_KEY=... \
   -e AWS_REGION=us-east-1 \
   omniserver
 
-# Cloudflare R2 memory (persistent)
+# Cloudflare R2 workspace (persistent)
 docker run -p 8000:8000 \
   -e LLM_API_KEY=$LLM_API_KEY \
+  -e OMNICOREAGENT_WORKSPACE_BACKEND=r2 \
   -e R2_BUCKET_NAME=my-bucket \
   -e R2_ACCOUNT_ID=... \
   -e R2_ACCESS_KEY_ID=... \

--- a/src/omnicoreagent/core/tool_response_offloader.py
+++ b/src/omnicoreagent/core/tool_response_offloader.py
@@ -11,20 +11,15 @@ Inspired by:
 """
 
 import json
-import os
 import hashlib
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
 
-from decouple import config as decouple_config
-
 from omnicoreagent.core.summarizer.tokenizer import count_tokens
 from omnicoreagent.core.utils import logger
-from omnicoreagent.core.workspace import get_artifacts_dir
 from omnicoreagent.core.workspace_storage import (
-    LocalWorkspaceStorage,
+    WorkspaceStorage,
     create_workspace_storage,
 )
 
@@ -38,14 +33,8 @@ class OffloadConfig:
     threshold_bytes: int = 2000
     max_preview_tokens: int = 150
     max_preview_lines: int = 10
-    storage_dir: str = None  # Set in __post_init__
     retention_days: int = 7
     include_metadata: bool = True
-
-    def __post_init__(self):
-        """Set defaults that depend on env vars."""
-        if self.storage_dir is None:
-            self.storage_dir = get_artifacts_dir()
 
     @classmethod
     def from_dict(cls, config: dict) -> "OffloadConfig":
@@ -59,7 +48,6 @@ class OffloadConfig:
             threshold_bytes=config.get("threshold_bytes", 2000),
             max_preview_tokens=config.get("max_preview_tokens", 150),
             max_preview_lines=config.get("max_preview_lines", 10),
-            storage_dir=config.get("storage_dir"),
             retention_days=config.get("retention_days", 7),
             include_metadata=config.get("include_metadata", True),
         )
@@ -108,23 +96,20 @@ class ToolResponseOffloader:
     The agent is given tools to read the full content on demand.
     """
 
-    def __init__(self, config: OffloadConfig | dict = None, base_dir: str = None):
+    def __init__(
+        self,
+        config: OffloadConfig | dict = None,
+        base_dir: str = None,
+        storage: WorkspaceStorage | None = None,
+    ):
         if isinstance(config, dict):
             config = OffloadConfig.from_dict(config)
         self.config = config or OffloadConfig()
 
-        self.base_dir = base_dir or os.getcwd()
-        self.storage_path = Path(self.base_dir) / self.config.storage_dir
-        workspace_backend = decouple_config(
-            "OMNICOREAGENT_WORKSPACE_BACKEND", default="local"
-        ).lower()
-        if workspace_backend == "local":
-            self.storage = LocalWorkspaceStorage(self.storage_path)
-        else:
-            self.storage = create_workspace_storage(
-                backend=workspace_backend,
-                namespace="artifacts",
-            )
+        self.storage = storage or create_workspace_storage(
+            namespace="artifacts",
+            workspace_dir=base_dir,
+        )
 
         if self.config.enabled:
             self._ensure_storage_dir()

--- a/src/omnicoreagent/core/types.py
+++ b/src/omnicoreagent/core/types.py
@@ -58,7 +58,6 @@ class AgentConfig(BaseModel):
             "threshold_tokens": 500,
             "threshold_bytes": 2000,
             "max_preview_tokens": 150,
-            "storage_dir": "workspace/artifacts",
         },
         description="Tool response offloading config to reduce context size from large tool outputs",
     )
@@ -135,10 +134,6 @@ class AgentConfig(BaseModel):
             raise ValueError(
                 f"tool_offload.max_preview_lines must be positive, got {max_preview_lines}"
             )
-
-        storage_dir = v.get("storage_dir", "workspace/artifacts")
-        if not isinstance(storage_dir, str) or not storage_dir:
-            raise ValueError("tool_offload.storage_dir must be a non-empty string")
 
         retention_days = v.get("retention_days")
         if retention_days is not None and retention_days < 0:

--- a/src/omnicoreagent/core/workspace.py
+++ b/src/omnicoreagent/core/workspace.py
@@ -5,8 +5,6 @@ from pathlib import Path
 
 _DEFAULT_WORKSPACE = "./workspace"
 _WORKSPACE_ENV = "OMNICOREAGENT_WORKSPACE_DIR"
-_ARTIFACTS_ENV = "OMNICOREAGENT_ARTIFACTS_DIR"
-_MEMORY_ENV = "OMNICOREAGENT_MEMORY_DIR"
 
 
 @dataclass(frozen=True)
@@ -25,16 +23,12 @@ class WorkspacePaths:
 def resolve_workspace_paths(
     *,
     workspace_dir: str | os.PathLike | None = None,
-    artifacts_dir: str | os.PathLike | None = None,
-    memories_dir: str | os.PathLike | None = None,
 ) -> WorkspacePaths:
     root = Path(workspace_dir or os.environ.get(_WORKSPACE_ENV, _DEFAULT_WORKSPACE))
-    artifacts = Path(artifacts_dir or os.environ.get(_ARTIFACTS_ENV, root / "artifacts"))
-    memories = Path(memories_dir or os.environ.get(_MEMORY_ENV, root / "memories"))
     return WorkspacePaths(
         root=root,
-        artifacts=artifacts,
-        memories=memories,
+        artifacts=root / "artifacts",
+        memories=root / "memories",
         config=root / "config",
     )
 

--- a/src/omnicoreagent/core/workspace_storage.py
+++ b/src/omnicoreagent/core/workspace_storage.py
@@ -450,6 +450,7 @@ def create_workspace_storage(
     *,
     backend: str | None = None,
     namespace: str | None = None,
+    workspace_dir: str | Path | None = None,
 ) -> WorkspaceStorage:
     backend = (backend or config("OMNICOREAGENT_WORKSPACE_BACKEND", default="local"))
     backend = backend.lower().strip()
@@ -458,7 +459,7 @@ def create_workspace_storage(
     if backend == "local":
         from omnicoreagent.core.workspace import resolve_workspace_paths
 
-        paths = resolve_workspace_paths()
+        paths = resolve_workspace_paths(workspace_dir=workspace_dir)
         root = paths.root / namespace if namespace else paths.root
         return LocalWorkspaceStorage(root)
 

--- a/src/omnicoreagent/runtime_config.py
+++ b/src/omnicoreagent/runtime_config.py
@@ -85,7 +85,6 @@ class AgentConfig:
             "threshold_bytes": 2000,
             "max_preview_tokens": 150,
             "max_preview_lines": 10,
-            "storage_dir": "workspace/artifacts",
         }
     )
 

--- a/src/omnicoreagent/serve/cli.py
+++ b/src/omnicoreagent/serve/cli.py
@@ -369,7 +369,6 @@ def generate_dockerfile(file_path: str, output_dir: str):
         "# Workspace storage for artifacts and memory files",
         "ENV OMNICOREAGENT_WORKSPACE_BACKEND=local",
         "ENV OMNICOREAGENT_WORKSPACE_DIR=/tmp/workspace",
-        "ENV OMNICOREAGENT_ARTIFACTS_DIR=/tmp/workspace/artifacts",
     ]
 
     env_block = "\n".join(env_lines)

--- a/tests/test_tool_response_offloader.py
+++ b/tests/test_tool_response_offloader.py
@@ -47,7 +47,6 @@ class TestOffloadConfig:
         assert config.threshold_bytes == 2000
         assert config.max_preview_tokens == 150
         assert config.max_preview_lines == 10
-        assert config.storage_dir == "workspace/artifacts"
         assert config.retention_days == 7
         assert config.include_metadata is True
 
@@ -65,14 +64,12 @@ class TestOffloadConfig:
                 "threshold_tokens": 1000,
                 "threshold_bytes": 5000,
                 "max_preview_tokens": 200,
-                "storage_dir": ".custom_artifacts",
             }
         )
         assert config.enabled is False
         assert config.threshold_tokens == 1000
         assert config.threshold_bytes == 5000
         assert config.max_preview_tokens == 200
-        assert config.storage_dir == ".custom_artifacts"
 
     def test_from_dict_partial(self):
         """Test partial config uses defaults for missing keys."""
@@ -144,17 +141,6 @@ class TestAgentConfigToolOffloadValidation:
                 tool_offload={"max_preview_tokens": -5},
             )
         assert "max_preview_tokens must be positive" in str(exc_info.value)
-
-    def test_empty_storage_dir_rejected(self):
-        """Test empty storage_dir raises ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
-            TypesAgentConfig(
-                agent_name="test",
-                max_steps=10,
-                tool_call_timeout=30,
-                tool_offload={"storage_dir": ""},
-            )
-        assert "storage_dir must be a non-empty string" in str(exc_info.value)
 
     def test_invalid_retention_days_rejected(self):
         """Test negative retention_days raises ValidationError."""
@@ -337,11 +323,7 @@ class TestOffload:
         content = "Content " * 50
         result = self.offloader.offload("test_tool", content, metadata={"key": "value"})
 
-        meta_path = (
-            Path(self.temp_dir)
-            / "workspace/artifacts"
-            / f"{result.artifact_id}.meta.json"
-        )
+        meta_path = Path(self.temp_dir) / "artifacts" / f"{result.artifact_id}.meta.json"
         assert meta_path.exists()
 
         with open(meta_path) as f:
@@ -393,6 +375,22 @@ class TestOffload:
         assert result.artifact_path == self.offloader.storage.location(
             result.storage_key
         )
+
+    def test_offload_uses_workspace_artifacts_namespace_from_env(
+        self, monkeypatch, tmp_path
+    ):
+        """Test default offload storage uses the active workspace artifacts namespace."""
+        workspace = tmp_path / "workspace"
+        monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_BACKEND", "local")
+        monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(workspace))
+
+        offloader = ToolResponseOffloader(
+            config={"enabled": True, "threshold_tokens": 10}
+        )
+        result = offloader.offload("env_tool", "Content " * 50)
+
+        assert Path(result.artifact_path).is_relative_to(workspace / "artifacts")
+        assert Path(result.artifact_path).read_text() == "Content " * 50
 
 
 # ============================================================================
@@ -599,7 +597,7 @@ class TestEdgeCases:
         """Test .gitignore is created in storage directory."""
         self.offloader.offload("test", "Content " * 50)
 
-        gitignore_path = Path(self.temp_dir) / "workspace/artifacts" / ".gitignore"
+        gitignore_path = Path(self.temp_dir) / "artifacts" / ".gitignore"
         assert gitignore_path.exists()
         assert "*" in gitignore_path.read_text()
 
@@ -715,7 +713,7 @@ class TestCleanup:
 
         self.offloader.cleanup_old_artifacts()
 
-        gitignore_path = Path(self.temp_dir) / "workspace/artifacts" / ".gitignore"
+        gitignore_path = Path(self.temp_dir) / "artifacts" / ".gitignore"
         assert gitignore_path.exists()
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from datetime import datetime
 
-from omnicoreagent.core.tool_response_offloader import OffloadConfig
 from omnicoreagent.core.tools.memory_tool.factory import (
     clear_backend_cache,
     create_memory_backend,
@@ -12,10 +11,10 @@ from omnicoreagent.core.workspace import (
     get_config_dir,
     get_memories_dir,
     get_workspace_dir,
-    resolve_workspace_paths,
 )
 from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
 from omnicoreagent.core.workspace_storage import S3WorkspaceStorage
+from omnicoreagent.core.workspace_storage import create_workspace_storage
 
 
 def test_workspace_paths_resolve_from_current_environment(monkeypatch, tmp_path):
@@ -28,20 +27,17 @@ def test_workspace_paths_resolve_from_current_environment(monkeypatch, tmp_path)
     assert Path(get_config_dir()) == workspace / "config"
 
 
-def test_workspace_paths_support_explicit_subdir_overrides(monkeypatch, tmp_path):
+def test_workspace_storage_namespaces_share_one_workspace_root(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"
-    artifacts = tmp_path / "artifact_store"
-    memories = tmp_path / "memory_store"
     monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(workspace))
-    monkeypatch.setenv("OMNICOREAGENT_ARTIFACTS_DIR", str(artifacts))
-    monkeypatch.setenv("OMNICOREAGENT_MEMORY_DIR", str(memories))
 
-    paths = resolve_workspace_paths()
+    artifacts = create_workspace_storage(namespace="artifacts")
+    memories = create_workspace_storage(namespace="memories")
 
-    assert paths.root == workspace
-    assert paths.artifacts == artifacts
-    assert paths.memories == memories
-    assert paths.config == workspace / "config"
+    assert isinstance(artifacts, LocalWorkspaceStorage)
+    assert isinstance(memories, LocalWorkspaceStorage)
+    assert artifacts.root == (workspace / "artifacts").resolve()
+    assert memories.root == (workspace / "memories").resolve()
 
 
 def test_ensure_workspace_creates_runtime_directories(monkeypatch, tmp_path):
@@ -54,22 +50,6 @@ def test_ensure_workspace_creates_runtime_directories(monkeypatch, tmp_path):
     assert paths.artifacts.is_dir()
     assert paths.memories.is_dir()
     assert paths.config.is_dir()
-
-
-def test_offload_config_reads_workspace_environment_at_instantiation(
-    monkeypatch, tmp_path
-):
-    first_workspace = tmp_path / "first"
-    second_workspace = tmp_path / "second"
-
-    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(first_workspace))
-    first = OffloadConfig()
-
-    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(second_workspace))
-    second = OffloadConfig()
-
-    assert Path(first.storage_dir) == first_workspace / "artifacts"
-    assert Path(second.storage_dir) == second_workspace / "artifacts"
 
 
 def test_local_memory_backend_cache_respects_workspace_changes(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- route tool response artifacts through the shared workspace storage abstraction
- remove the separate artifact/memory directory override path from runtime config
- keep one workspace root with derived namespaces for artifacts, memories, and config
- update OmniServe and docs to describe workspace storage instead of separate memory/artifact directories
- add regression coverage that tool offload writes into the active workspace artifacts namespace

## Verification
- uv run ruff check src tests
- uv run pytest tests/test_workspace.py tests/test_memory_tool_backend.py tests/test_tool_response_offloader.py tests/test_subagents.py -q
- uv run pytest -q
- uv run hatch build