### PR TITLE
Deduplicate tool execution error handling

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -104,6 +104,9 @@ TOOL_OUTPUT_OFFLOAD_EXCLUDED_TOOLS = frozenset(
         "memory_create_update",
     }
 )
+TOOL_CALL_TIMEOUT_MESSAGE = (
+    "Tool call timed out. Please try again or use a different approach."
+)
 
 
 class BaseReactAgent:
@@ -312,6 +315,68 @@ class BaseReactAgent:
             error_details = "\n\n".join(obs_lines)
             return f"Tool execution failed completely:\n{error_details}"
         return "\n\n".join(obs_lines) or "No valid tool results."
+
+    def _build_tool_error_results(
+        self,
+        tool_call_results: list[ToolCallResult],
+        error_message: str,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "tool_name": getattr(single_tool, "tool_name", "unknown"),
+                "args": getattr(single_tool, "tool_args", {}),
+                "status": "error",
+                "data": None,
+                "message": error_message,
+            }
+            for single_tool in tool_call_results
+        ]
+
+    async def _handle_tool_execution_error(
+        self,
+        tool_call_results: list[ToolCallResult],
+        error_message: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+        tool_batch_name: str,
+    ) -> list[dict[str, Any]]:
+        for single_tool in tool_call_results:
+            session_state.loop_detector.record_tool_call(
+                str(single_tool.tool_name),
+                str(single_tool.tool_args),
+                error_message,
+            )
+
+        for single_tool in tool_call_results:
+            await add_message_to_history(
+                role="tool",
+                content=error_message,
+                metadata={
+                    "tool_call_id": single_tool.tool_call_id,
+                    "tool": single_tool.tool_name,
+                    "args": single_tool.tool_args,
+                    "agent_name": self.agent_name,
+                },
+                session_id=session_id,
+            )
+
+        event = Event(
+            type=EventType.TOOL_CALL_ERROR,
+            payload=ToolCallErrorPayload(
+                tool_name=tool_batch_name,
+                error_message=error_message,
+            ),
+            agent_name=self.agent_name,
+        )
+        if event_router:
+            await event_router(session_id=session_id, event=event)
+
+        return self._build_tool_error_results(
+            tool_call_results=tool_call_results,
+            error_message=error_message,
+        )
 
     async def extract_action_or_answer(
         self,
@@ -841,95 +906,30 @@ class BaseReactAgent:
                     await event_router(session_id=session_id, event=event)
 
             except asyncio.TimeoutError:
-                obs_text = (
-                    "Tool call timed out. Please try again or use a different approach."
-                )
+                obs_text = TOOL_CALL_TIMEOUT_MESSAGE
                 logger.warning(obs_text)
-                for single_tool in tool_call_result:
-                    session_state.loop_detector.record_tool_call(
-                        str(single_tool.tool_name),
-                        str(single_tool.tool_args),
-                        obs_text,
-                    )
-
-                for single_tool in tool_call_result:
-                    tools_results.append(
-                        {
-                            "tool_name": getattr(single_tool, "tool_name", "unknown"),
-                            "args": getattr(single_tool, "tool_args", {}),
-                            "status": "error",
-                            "data": None,
-                            "message": obs_text,
-                        }
-                    )
-
-                for single_tool in tool_call_result:
-                    await add_message_to_history(
-                        role="tool",
-                        content=obs_text,
-                        metadata={
-                            "tool_call_id": single_tool.tool_call_id,
-                            "tool": single_tool.tool_name,
-                            "args": single_tool.tool_args,
-                            "agent_name": self.agent_name,
-                        },
-                        session_id=session_id,
-                    )
-
-                event = Event(
-                    type=EventType.TOOL_CALL_ERROR,
-                    payload=ToolCallErrorPayload(
-                        tool_name=tool_batch_name,
-                        error_message=obs_text,
-                    ),
-                    agent_name=self.agent_name,
+                tools_results = await self._handle_tool_execution_error(
+                    tool_call_results=list(tool_call_result),
+                    error_message=obs_text,
+                    session_state=session_state,
+                    add_message_to_history=add_message_to_history,
+                    session_id=session_id,
+                    event_router=event_router,
+                    tool_batch_name=tool_batch_name,
                 )
-                if event_router:
-                    await event_router(session_id=session_id, event=event)
 
             except Exception as e:
                 obs_text = f"Error executing tool: {str(e)}"
                 logger.error(obs_text)
-                for single_tool in tool_call_result:
-                    session_state.loop_detector.record_tool_call(
-                        str(single_tool.tool_name),
-                        str(single_tool.tool_args),
-                        obs_text,
-                    )
-
-                for single_tool in tool_call_result:
-                    tools_results.append(
-                        {
-                            "tool_name": getattr(single_tool, "tool_name", "unknown"),
-                            "args": getattr(single_tool, "tool_args", {}),
-                            "status": "error",
-                            "data": None,
-                            "message": obs_text,
-                        }
-                    )
-
-                for single_tool in tool_call_result:
-                    await add_message_to_history(
-                        role="tool",
-                        content=obs_text,
-                        metadata={
-                            "tool_call_id": single_tool.tool_call_id,
-                            "tool": single_tool.tool_name,
-                            "args": single_tool.tool_args,
-                            "agent_name": self.agent_name,
-                        },
-                        session_id=session_id,
-                    )
-                event = Event(
-                    type=EventType.TOOL_CALL_ERROR,
-                    payload=ToolCallErrorPayload(
-                        tool_name=tool_batch_name,
-                        error_message=obs_text,
-                    ),
-                    agent_name=self.agent_name,
+                tools_results = await self._handle_tool_execution_error(
+                    tool_call_results=list(tool_call_result),
+                    error_message=obs_text,
+                    session_state=session_state,
+                    add_message_to_history=add_message_to_history,
+                    session_id=session_id,
+                    event_router=event_router,
+                    tool_batch_name=tool_batch_name,
                 )
-                if event_router:
-                    await event_router(session_id=session_id, event=event)
 
         if debug:
             show_tool_response(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,8 @@
 from unittest.mock import AsyncMock
 import pytest
 import json
-from omnicoreagent.core.agents.base import BaseReactAgent
+from omnicoreagent.core.agents.base import BaseReactAgent, TOOL_CALL_TIMEOUT_MESSAGE
+from omnicoreagent.core.events.base import EventType
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.types import ParsedResponse, ToolCallResult
@@ -346,3 +347,74 @@ def test_build_tool_results_observation_formats_parallel_results(agent):
     )
 
     assert observation == "Partial success:\nalpha#1: alpha result\n\nbeta#1 ERROR: beta failed"
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_execution_error_records_history_and_event(agent):
+    history = []
+    events = []
+    session_state = agent._get_session_state(session_id="chat795", debug=False)
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=None,
+            tool_name="alpha",
+            tool_args={"value": "one"},
+            tool_call_id="tool-call-alpha",
+        ),
+        ToolCallResult(
+            tool_executor=None,
+            tool_name="beta",
+            tool_args={"value": "two"},
+            tool_call_id="tool-call-beta",
+        ),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    results = await agent._handle_tool_execution_error(
+        tool_call_results=tool_calls,
+        error_message=TOOL_CALL_TIMEOUT_MESSAGE,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat795",
+        event_router=event_router,
+        tool_batch_name="alpha, beta",
+    )
+
+    assert [item["role"] for item in history] == ["tool", "tool"]
+    assert [item["metadata"]["tool"] for item in history] == ["alpha", "beta"]
+    assert {item["metadata"]["tool_call_id"] for item in history} == {
+        "tool-call-alpha",
+        "tool-call-beta",
+    }
+    assert results == [
+        {
+            "tool_name": "alpha",
+            "args": {"value": "one"},
+            "status": "error",
+            "data": None,
+            "message": TOOL_CALL_TIMEOUT_MESSAGE,
+        },
+        {
+            "tool_name": "beta",
+            "args": {"value": "two"},
+            "status": "error",
+            "data": None,
+            "message": TOOL_CALL_TIMEOUT_MESSAGE,
+        },
+    ]
+    assert len(events) == 1
+    assert events[0]["session_id"] == "chat795"
+    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
+    assert events[0]["event"].payload.tool_name == "alpha, beta"


### PR DESCRIPTION
## Summary
- centralize tool timeout and execution exception handling in the ReAct agent
- keep per-tool history writes and batch error events in one path
- add focused coverage for the error helper contract

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py tests/test_base.py
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build

Note: one initial targeted pytest invocation aborted during third-party litellm import collection; the same command passed on rerun.