### PR TITLE
Extract tool batch execution flow

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -446,6 +446,147 @@ class BaseReactAgent:
             ),
         )
 
+    async def _start_tool_call_batch(
+        self,
+        tool_call_results: list[ToolCallResult],
+        response: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+    ) -> tuple[str, list[dict[str, Any]]]:
+        tool_batch_name = ", ".join([t.tool_name for t in tool_call_results])
+        tool_batch_args = [t.tool_args for t in tool_call_results]
+
+        for single_tool in tool_call_results:
+            single_tool.tool_call_id = str(uuid.uuid4())
+
+        tool_calls_metadata = ToolCallMetadata(
+            agent_name=self.agent_name,
+            has_tool_calls=True,
+            tool_call_id=tool_call_results[0].tool_call_id,
+            tool_calls=[
+                ToolCall(
+                    id=single_tool.tool_call_id,
+                    function=ToolFunction(
+                        name=single_tool.tool_name,
+                        arguments=json.dumps(single_tool.tool_args),
+                    ),
+                )
+                for single_tool in tool_call_results
+            ],
+        )
+
+        event = Event(
+            type=EventType.TOOL_CALL_STARTED,
+            payload=ToolCallStartedPayload(
+                tool_name=tool_batch_name,
+                tool_args=json.dumps(tool_batch_args),
+                tool_call_id=tool_call_results[0].tool_call_id,
+            ),
+            agent_name=self.agent_name,
+        )
+        if event_router:
+            await event_router(session_id=session_id, event=event)
+
+        await add_message_to_history(
+            role="assistant",
+            content=response,
+            metadata=tool_calls_metadata.model_dump(),
+            session_id=session_id,
+        )
+        session_state.messages.append(Message(role="assistant", content=response))
+
+        return tool_batch_name, tool_batch_args
+
+    async def _execute_tool_call_batch(
+        self,
+        tool_call_results: list[ToolCallResult],
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+        tool_batch_name: str,
+        tool_batch_args: list[dict[str, Any]],
+    ) -> tuple[str, list[dict[str, Any]]]:
+        try:
+            async with asyncio.timeout(self.tool_call_timeout):
+                tool_outputs = await asyncio.gather(
+                    *[
+                        single_tool.tool_executor.execute(
+                            agent_name=self.agent_name,
+                            tool_args=single_tool.tool_args,
+                            tool_name=single_tool.tool_name,
+                            tool_call_id=single_tool.tool_call_id,
+                            add_message_to_history=add_message_to_history,
+                            session_id=session_id,
+                        )
+                        for single_tool in tool_call_results
+                    ]
+                )
+
+            observation = await self.parse_tool_observation(
+                {
+                    "status": (
+                        "error"
+                        if any(result.get("status") == "error" for result in tool_outputs)
+                        else "success"
+                    ),
+                    "tools_results": tool_outputs,
+                }
+            )
+
+            tools_results = observation.get("tools_results", [])
+            obs_text = self._build_tool_results_observation(
+                tool_call_results=tool_call_results,
+                tools_results=tools_results,
+                session_state=session_state,
+                session_id=session_id,
+            )
+
+            event = Event(
+                type=EventType.TOOL_CALL_RESULT,
+                payload=ToolCallResultPayload(
+                    tool_name=tool_batch_name,
+                    tool_args=json.dumps(tool_batch_args),
+                    result=obs_text,
+                    tool_call_id=tool_call_results[0].tool_call_id,
+                ),
+                agent_name=self.agent_name,
+            )
+            if event_router:
+                await event_router(session_id=session_id, event=event)
+
+            return obs_text, tools_results
+
+        except asyncio.TimeoutError:
+            obs_text = TOOL_CALL_TIMEOUT_MESSAGE
+            logger.warning(obs_text)
+            tools_results = await self._handle_tool_execution_error(
+                tool_call_results=tool_call_results,
+                error_message=obs_text,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                event_router=event_router,
+                tool_batch_name=tool_batch_name,
+            )
+            return obs_text, tools_results
+
+        except Exception as e:
+            obs_text = f"Error executing tool: {str(e)}"
+            logger.error(obs_text)
+            tools_results = await self._handle_tool_execution_error(
+                tool_call_results=tool_call_results,
+                error_message=obs_text,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                event_router=event_router,
+                tool_batch_name=tool_batch_name,
+            )
+            return obs_text, tools_results
+
     async def extract_action_or_answer(
         self,
         response: str,
@@ -834,128 +975,24 @@ class BaseReactAgent:
                 event_router=event_router,
             )
         else:
-            tool_batch_name = ", ".join([t.tool_name for t in tool_call_result])
-            tool_batch_args = [t.tool_args for t in tool_call_result]
-            for single_tool in tool_call_result:
-                single_tool.tool_call_id = str(uuid.uuid4())
-
-            tool_calls_metadata = ToolCallMetadata(
-                agent_name=self.agent_name,
-                has_tool_calls=True,
-                tool_call_id=tool_call_result[0].tool_call_id,
-                tool_calls=[
-                    ToolCall(
-                        id=single_tool.tool_call_id,
-                        function=ToolFunction(
-                            name=single_tool.tool_name,
-                            arguments=json.dumps(single_tool.tool_args),
-                        ),
-                    )
-                    for single_tool in tool_call_result
-                ],
-            )
-
-            event = Event(
-                type=EventType.TOOL_CALL_STARTED,
-                payload=ToolCallStartedPayload(
-                    tool_name=tool_batch_name,
-                    tool_args=json.dumps(tool_batch_args),
-                    tool_call_id=tool_call_result[0].tool_call_id,
-                ),
-                agent_name=self.agent_name,
-            )
-            if event_router:
-                await event_router(session_id=session_id, event=event)
-
-            await add_message_to_history(
-                role="assistant",
-                content=response,
-                metadata=tool_calls_metadata.model_dump(),
+            tool_call_result = list(tool_call_result)
+            tool_batch_name, tool_batch_args = await self._start_tool_call_batch(
+                tool_call_results=tool_call_result,
+                response=response,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
                 session_id=session_id,
+                event_router=event_router,
             )
-            session_state.messages.append(Message(role="assistant", content=response))
-
-            tools_results = []
-            try:
-                async with asyncio.timeout(self.tool_call_timeout):
-                    tool_outputs = await asyncio.gather(
-                        *[
-                            single_tool.tool_executor.execute(
-                                agent_name=self.agent_name,
-                                tool_args=single_tool.tool_args,
-                                tool_name=single_tool.tool_name,
-                                tool_call_id=single_tool.tool_call_id,
-                                add_message_to_history=add_message_to_history,
-                                session_id=session_id,
-                            )
-                            for single_tool in tool_call_result
-                        ]
-                    )
-
-                observation = await self.parse_tool_observation(
-                    {
-                        "status": (
-                            "error"
-                            if any(
-                                result.get("status") == "error"
-                                for result in tool_outputs
-                            )
-                            else "success"
-                        ),
-                        "tools_results": tool_outputs,
-                    }
-                )
-
-                tools_results = observation.get("tools_results", [])
-
-                if not isinstance(tool_call_result, (list, tuple)):
-                    tool_call_result = [tool_call_result]
-
-                obs_text = self._build_tool_results_observation(
-                    tool_call_results=list(tool_call_result),
-                    tools_results=tools_results,
-                    session_state=session_state,
-                    session_id=session_id,
-                )
-
-                event = Event(
-                    type=EventType.TOOL_CALL_RESULT,
-                    payload=ToolCallResultPayload(
-                        tool_name=tool_batch_name,
-                        tool_args=json.dumps(tool_batch_args),
-                        result=obs_text,
-                        tool_call_id=tool_call_result[0].tool_call_id,
-                    ),
-                    agent_name=self.agent_name,
-                )
-                if event_router:
-                    await event_router(session_id=session_id, event=event)
-
-            except asyncio.TimeoutError:
-                obs_text = TOOL_CALL_TIMEOUT_MESSAGE
-                logger.warning(obs_text)
-                tools_results = await self._handle_tool_execution_error(
-                    tool_call_results=list(tool_call_result),
-                    error_message=obs_text,
-                    session_state=session_state,
-                    add_message_to_history=add_message_to_history,
-                    session_id=session_id,
-                    event_router=event_router,
-                    tool_batch_name=tool_batch_name,
-                )
-
-            except Exception as e:
-                obs_text = f"Error executing tool: {str(e)}"
-                logger.error(obs_text)
-                tools_results = await self._handle_tool_execution_error(
-                    tool_call_results=list(tool_call_result),
-                    error_message=obs_text,
-                    session_state=session_state,
-                    add_message_to_history=add_message_to_history,
-                    session_id=session_id,
-                    event_router=event_router,
-                    tool_batch_name=tool_batch_name,
-                )
+            obs_text, tools_results = await self._execute_tool_call_batch(
+                tool_call_results=tool_call_result,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                event_router=event_router,
+                tool_batch_name=tool_batch_name,
+                tool_batch_args=tool_batch_args,
+            )
 
         if debug:
             show_tool_response(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -457,3 +457,134 @@ async def test_handle_tool_validation_error_records_loop_and_event(agent):
     assert events[0]["session_id"] == "chat796"
     assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
     assert events[0]["event"].payload.tool_name == "missing_tool"
+
+
+@pytest.mark.asyncio
+async def test_start_tool_call_batch_records_assistant_and_started_event(agent):
+    history = []
+    events = []
+    session_state = agent._get_session_state(session_id="chat797", debug=False)
+    tool_calls = [
+        ToolCallResult(tool_executor=None, tool_name="alpha", tool_args={"value": "1"}),
+        ToolCallResult(tool_executor=None, tool_name="beta", tool_args={"value": "2"}),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    tool_batch_name, tool_batch_args = await agent._start_tool_call_batch(
+        tool_call_results=tool_calls,
+        response="<tool_calls>...</tool_calls>",
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat797",
+        event_router=event_router,
+    )
+
+    assert tool_batch_name == "alpha, beta"
+    assert tool_batch_args == [{"value": "1"}, {"value": "2"}]
+    assert all(tool.tool_call_id for tool in tool_calls)
+    assert len({tool.tool_call_id for tool in tool_calls}) == 2
+    assert history[0]["role"] == "assistant"
+    assert [call["function"]["name"] for call in history[0]["metadata"]["tool_calls"]] == [
+        "alpha",
+        "beta",
+    ]
+    assert session_state.messages[-1].role == "assistant"
+    assert len(events) == 1
+    assert events[0]["event"].type == EventType.TOOL_CALL_STARTED
+    assert events[0]["event"].payload.tool_name == "alpha, beta"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_batch_returns_observation_and_result_event(agent):
+    history = []
+    events = []
+    session_state = agent._get_session_state(session_id="chat798", debug=False)
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            await add_message_to_history(
+                role="tool",
+                content=f"{tool_name}:{tool_args['value']}",
+                metadata={
+                    "tool_call_id": tool_call_id,
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "agent_name": agent_name,
+                },
+                session_id=session_id,
+            )
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": f"{tool_name}:{tool_args['value']}",
+                "message": None,
+            }
+
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=FakeExecutor(),
+            tool_name="alpha",
+            tool_args={"value": "one"},
+            tool_call_id="tool-call-alpha",
+        ),
+        ToolCallResult(
+            tool_executor=FakeExecutor(),
+            tool_name="beta",
+            tool_args={"value": "two"},
+            tool_call_id="tool-call-beta",
+        ),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    obs_text, tools_results = await agent._execute_tool_call_batch(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat798",
+        event_router=event_router,
+        tool_batch_name="alpha, beta",
+        tool_batch_args=[{"value": "one"}, {"value": "two"}],
+    )
+
+    assert obs_text == "alpha#1: alpha:one\n\nbeta#1: beta:two"
+    assert [result["tool_name"] for result in tools_results] == ["alpha", "beta"]
+    assert [item["metadata"]["tool_call_id"] for item in history] == [
+        "tool-call-alpha",
+        "tool-call-beta",
+    ]
+    assert len(events) == 1
+    assert events[0]["event"].type == EventType.TOOL_CALL_RESULT
+    assert events[0]["event"].payload.tool_name == "alpha, beta"


### PR DESCRIPTION
## Summary
- move successful tool batch startup out of BaseReactAgent.act
- move parallel tool execution, observation parsing, and result/error event routing into a helper
- keep validation, execution-error, and successful execution paths separate and testable
- add focused tests for batch startup and execution result behavior

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py tests/test_base.py
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build