### PR TITLE
Extract tool observation and loop handling

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -587,6 +587,102 @@ class BaseReactAgent:
             )
             return obs_text, tools_results
 
+    async def _append_tool_observations(
+        self,
+        tools_results: list[dict[str, Any]],
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        debug: bool,
+    ) -> str:
+        scrubbed_results = self._scrub_tool_results(tools_results)
+        xml_obs_block = build_xml_observations_block(scrubbed_results)
+        session_state.messages.append(
+            Message(
+                role="user",
+                content=xml_obs_block,
+            )
+        )
+        await add_message_to_history(
+            role="user",
+            content=xml_obs_block,
+            session_id=session_id,
+            metadata={"agent_name": self.agent_name},
+        )
+
+        if debug:
+            logger.info(
+                f"Agent state changed from {session_state.state} to {AgentState.OBSERVING}"
+            )
+        session_state.state = AgentState.OBSERVING
+        return xml_obs_block
+
+    async def _handle_tool_loop_state(
+        self,
+        tool_call_results: list[Any],
+        session_state: SessionState,
+        system_prompt: str,
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+        debug: bool,
+    ) -> None:
+        for single_tool in tool_call_results:
+            tool_name = getattr(single_tool, "tool_name", None)
+            if not tool_name:
+                if isinstance(single_tool, (list, tuple)) and len(single_tool) >= 1:
+                    tool_name = single_tool[0]
+                else:
+                    logger.warning(
+                        "Skipping malformed tool_call_result item: %s", single_tool
+                    )
+                    continue
+
+            if not session_state.loop_detector.is_looping(tool_name):
+                continue
+
+            loop_type = session_state.loop_detector.get_loop_type(tool_name)
+            logger.warning(f"Tool call loop detected for '{tool_name}': {loop_type}")
+
+            new_system_prompt = handle_stuck_state(system_prompt)
+            session_state.messages = await self.reset_system_prompt(
+                messages=session_state.messages,
+                system_prompt=new_system_prompt,
+            )
+
+            loop_message = (
+                f"Observation:\n"
+                f"⚠️ Tool call loop detected for '{tool_name}': {loop_type}\n\n"
+                "Current approach is not working. You MUST now provide a final answer to the user.\n"
+                "Please:\n"
+                "1. Stop trying the same approach\n"
+                "2. Provide your best response to the user based on what you know\n"
+                "3. Use <final_answer>Your response here</final_answer> format\n"
+                "4. Be helpful and explain any limitations if needed\n"
+                "5. Do NOT continue with more tool calls\n"
+                "\nYou MUST respond with <final_answer> tags now.\n"
+            )
+
+            event = Event(
+                type=EventType.TOOL_CALL_ERROR,
+                payload=ToolCallErrorPayload(
+                    tool_name=tool_name,
+                    error_message=loop_message,
+                ),
+                agent_name=self.agent_name,
+            )
+            if event_router:
+                await event_router(session_id=session_id, event=event)
+
+            session_state.messages.append(Message(role="user", content=loop_message))
+
+            if debug:
+                logger.info(
+                    f"Agent state changed from {session_state.state} to {AgentState.STUCK}"
+                )
+
+            session_state.state = AgentState.STUCK
+            session_state.loop_detector.reset(tool_name)
+
     async def extract_action_or_answer(
         self,
         response: str,
@@ -1002,90 +1098,27 @@ class BaseReactAgent:
                 observation=obs_text,
             )
 
-        tools_results = self._scrub_tool_results(tools_results)
-        xml_obs_block = build_xml_observations_block(tools_results)
-        session_state.messages.append(
-            Message(
-                role="user",
-                content=xml_obs_block,
-            )
-        )
-        await add_message_to_history(
-            role="user",
-            content=xml_obs_block,
+        await self._append_tool_observations(
+            tools_results=tools_results,
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
             session_id=session_id,
-            metadata={"agent_name": self.agent_name},
+            debug=debug,
         )
-
-        if debug:
-            logger.info(
-                f"Agent state changed from {session_state.state} to {AgentState.OBSERVING}"
-            )
-        session_state.state = AgentState.OBSERVING
 
         if isinstance(tool_call_result, (list, tuple)):
             tool_call_results = list(tool_call_result)
         else:
             tool_call_results = [tool_call_result]
 
-        for single_tool in tool_call_results:
-            tool_name = getattr(single_tool, "tool_name", None)
-            if not tool_name:
-                if isinstance(single_tool, (list, tuple)) and len(single_tool) >= 1:
-                    tool_name = single_tool[0]
-                else:
-                    logger.warning(
-                        "Skipping malformed tool_call_result item: %s", single_tool
-                    )
-                    continue
-
-            if session_state.loop_detector.is_looping(tool_name):
-                loop_type = session_state.loop_detector.get_loop_type(tool_name)
-                logger.warning(
-                    f"Tool call loop detected for '{tool_name}': {loop_type}"
-                )
-
-                new_system_prompt = handle_stuck_state(system_prompt)
-                session_state.messages = await self.reset_system_prompt(
-                    messages=session_state.messages,
-                    system_prompt=new_system_prompt,
-                )
-
-                loop_message = (
-                    f"Observation:\n"
-                    f"⚠️ Tool call loop detected for '{tool_name}': {loop_type}\n\n"
-                    "Current approach is not working. You MUST now provide a final answer to the user.\n"
-                    "Please:\n"
-                    "1. Stop trying the same approach\n"
-                    "2. Provide your best response to the user based on what you know\n"
-                    "3. Use <final_answer>Your response here</final_answer> format\n"
-                    "4. Be helpful and explain any limitations if needed\n"
-                    "5. Do NOT continue with more tool calls\n"
-                    "\nYou MUST respond with <final_answer> tags now.\n"
-                )
-
-                event = Event(
-                    type=EventType.TOOL_CALL_ERROR,
-                    payload=ToolCallErrorPayload(
-                        tool_name=tool_name,
-                        error_message=loop_message,
-                    ),
-                    agent_name=self.agent_name,
-                )
-                if event_router:
-                    await event_router(session_id=session_id, event=event)
-
-                session_state.messages.append(
-                    Message(role="user", content=loop_message)
-                )
-
-                if debug:
-                    logger.info(
-                        f"Agent state changed from {session_state.state} to {AgentState.STUCK}"
-                    )
-
-                session_state.state = AgentState.STUCK
-                session_state.loop_detector.reset(tool_name)
+        await self._handle_tool_loop_state(
+            tool_call_results=tool_call_results,
+            session_state=session_state,
+            system_prompt=system_prompt,
+            session_id=session_id,
+            event_router=event_router,
+            debug=debug,
+        )
 
     async def reset_system_prompt(self, messages: list, system_prompt: str):
         old_messages = messages[1:]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,7 @@ from omnicoreagent.core.agents.base import BaseReactAgent, TOOL_CALL_TIMEOUT_MES
 from omnicoreagent.core.events.base import EventType
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
-from omnicoreagent.core.types import ParsedResponse, ToolCallResult, ToolError
+from omnicoreagent.core.types import AgentState, Message, ParsedResponse, ToolCallResult, ToolError
 
 
 @pytest.fixture
@@ -588,3 +588,98 @@ async def test_execute_tool_call_batch_returns_observation_and_result_event(agen
     assert len(events) == 1
     assert events[0]["event"].type == EventType.TOOL_CALL_RESULT
     assert events[0]["event"].payload.tool_name == "alpha, beta"
+
+
+@pytest.mark.asyncio
+async def test_append_tool_observations_writes_history_and_sets_observing(agent):
+    history = []
+    session_state = agent._get_session_state(session_id="chat799", debug=False)
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    xml_obs_block = await agent._append_tool_observations(
+        tools_results=[
+            {
+                "tool_name": "alpha",
+                "args": {},
+                "status": "success",
+                "data": "alpha result",
+                "message": None,
+            }
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat799",
+        debug=False,
+    )
+
+    assert 'tool_name="alpha#1"' in xml_obs_block
+    assert session_state.messages[-1].role == "user"
+    assert session_state.messages[-1].content == xml_obs_block
+    assert session_state.state == AgentState.OBSERVING
+    assert history == [
+        {
+            "role": "user",
+            "content": xml_obs_block,
+            "metadata": {"agent_name": "test_agent"},
+            "session_id": "chat799",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_loop_state_marks_session_stuck(agent):
+    events = []
+    session_state = agent._get_session_state(session_id="chat800", debug=False)
+    session_state.messages = [Message(role="system", content="system")]
+
+    class FakeLoopDetector:
+        def __init__(self):
+            self.reset_tool_name = None
+
+        def is_looping(self, tool_name):
+            return tool_name == "alpha"
+
+        def get_loop_type(self, tool_name):
+            return ["consecutive_calls"]
+
+        def reset(self, tool_name=None):
+            self.reset_tool_name = tool_name
+
+    session_state.loop_detector = FakeLoopDetector()
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    await agent._handle_tool_loop_state(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=None,
+                tool_name="alpha",
+                tool_args={},
+                tool_call_id="tool-call-alpha",
+            )
+        ],
+        session_state=session_state,
+        system_prompt="system",
+        session_id="chat800",
+        event_router=event_router,
+        debug=False,
+    )
+
+    assert session_state.state == AgentState.STUCK
+    assert session_state.loop_detector.reset_tool_name == "alpha"
+    assert session_state.messages[0].role == "system"
+    assert "Tool call loop detected" in session_state.messages[-1].content
+    assert len(events) == 1
+    assert events[0]["session_id"] == "chat800"
+    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
+    assert events[0]["event"].payload.tool_name == "alpha"


### PR DESCRIPTION
## Summary
- move tool observation persistence out of BaseReactAgent.act
- move post-tool loop/stuck handling into a focused helper
- add focused tests for observation history/state updates and stuck loop handling

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py tests/test_base.py
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build