### PR TITLE
Extract tool call resolution helpers

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -783,6 +783,129 @@ class BaseReactAgent:
                 session_state.assistant_with_tool_calls = None
                 session_state.pending_tool_responses = []
 
+    def _build_sub_agent_tool_error(
+        self, tool_name: str, tool_args: dict[str, Any]
+    ) -> ToolError:
+        return ToolError(
+            observation=(
+                f"INVOCATION ERROR: '{tool_name}' is a sub-agent, not a tool.\n\n"
+                f"❌ You used (WRONG):\n"
+                f"   <tool_call><tool_name>{tool_name}</tool_name><parameters>...</parameters></tool_call>\n\n"
+                f"✓ Must use (CORRECT):\n"
+                f"   <agent_call><agent_name>{tool_name}</agent_name><parameters>...</parameters></agent_call>\n\n"
+                f"ACTION REQUIRED:\n"
+                f"1. Check AVAILABLE SUB AGENT REGISTRY for '{tool_name}' parameter requirements\n"
+                f"2. Retry using <agent_call> with <agent_name> tags\n"
+                f"3. Ensure parameters match registry definition exactly"
+            ),
+            tool_name="N/A",
+            tool_args=tool_args,
+        )
+
+    async def _resolve_mcp_tool_action(
+        self,
+        action: dict[str, Any],
+        sessions: dict,
+        mcp_tools: dict | None,
+    ) -> tuple[bool, ToolExecutor | None, dict[str, Any]]:
+        if not mcp_tools:
+            return False, None, {}
+
+        tool_name = action.get("tool", "").strip()
+        for _server_name, tools in mcp_tools.items():
+            for tool in tools:
+                if tool.name.lower() != tool_name.lower():
+                    continue
+
+                mcp_tool_handler = MCPToolHandler(
+                    sessions=sessions,
+                    tool_data=json.dumps(action),
+                    mcp_tools=mcp_tools,
+                    guardrail=self.guardrail,
+                )
+                tool_executor = ToolExecutor(tool_handler=mcp_tool_handler)
+                tool_data = await mcp_tool_handler.validate_tool_call_request(
+                    tool_data=json.dumps(action),
+                    mcp_tools=mcp_tools,
+                )
+                return True, tool_executor, tool_data
+
+        return False, None, {}
+
+    async def _resolve_local_tool_action(
+        self,
+        action: dict[str, Any],
+        local_tools: Any = None,
+    ) -> tuple[ToolExecutor | None, dict[str, Any]]:
+        if not local_tools:
+            return None, {}
+
+        local_tool_handler = LocalToolHandler(local_tools=local_tools)
+        tool_executor = ToolExecutor(tool_handler=local_tool_handler)
+        tool_data = await local_tool_handler.validate_tool_call_request(
+            tool_data=json.dumps(action),
+            local_tools=local_tools,
+        )
+        return tool_executor, tool_data
+
+    async def _resolve_single_tool_action(
+        self,
+        action: dict[str, Any],
+        sessions: dict,
+        mcp_tools: dict | None,
+        local_tools: Any = None,
+        sub_agents: list = None,
+    ) -> ToolError | ToolCallResult:
+        tool_name = action.get("tool", "").strip()
+        tool_args = action.get("parameters", {})
+
+        if sub_agents:
+            sub_agent_names = [sub_agent.name for sub_agent in sub_agents]
+            if tool_name in sub_agent_names:
+                return self._build_sub_agent_tool_error(
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                )
+
+        if not tool_name:
+            return ToolError(
+                observation="No tool name provided in the request",
+                tool_name="N/A",
+                tool_args=tool_args,
+            )
+
+        mcp_tool_found, tool_executor, tool_data = await self._resolve_mcp_tool_action(
+            action=action,
+            sessions=sessions,
+            mcp_tools=mcp_tools,
+        )
+
+        if not mcp_tool_found and local_tools:
+            tool_executor, tool_data = await self._resolve_local_tool_action(
+                action=action,
+                local_tools=local_tools,
+            )
+
+        if not mcp_tool_found and not local_tools:
+            return ToolError(
+                observation=f"The tool named '{tool_name}' does not exist in the available tools.",
+                tool_name=tool_name,
+                tool_args=tool_args,
+            )
+
+        if not tool_data.get("action"):
+            return ToolError(
+                observation=tool_data.get("error", "Tool validation failed"),
+                tool_name=tool_name,
+                tool_args=tool_args,
+            )
+
+        return ToolCallResult(
+            tool_executor=tool_executor,
+            tool_name=tool_data.get("tool_name"),
+            tool_args=normalize_tool_args(tool_data.get("tool_args")),
+        )
+
     async def resolve_tool_call_request(
         self,
         parsed_response: ParsedResponse,
@@ -809,90 +932,16 @@ class BaseReactAgent:
                 tool_name = action.get("tool", "").strip()
                 if tool_name == "tools_retriever":
                     mcp_tools = None
-                tool_args = action.get("parameters", {})
-                if sub_agents:
-                    sub_agent_names = [sub_agent.name for sub_agent in sub_agents]
-                    if tool_name in sub_agent_names:
-                        return ToolError(
-                            observation=(
-                                f"INVOCATION ERROR: '{tool_name}' is a sub-agent, not a tool.\n\n"
-                                f"❌ You used (WRONG):\n"
-                                f"   <tool_call><tool_name>{tool_name}</tool_name><parameters>...</parameters></tool_call>\n\n"
-                                f"✓ Must use (CORRECT):\n"
-                                f"   <agent_call><agent_name>{tool_name}</agent_name><parameters>...</parameters></agent_call>\n\n"
-                                f"ACTION REQUIRED:\n"
-                                f"1. Check AVAILABLE SUB AGENT REGISTRY for '{tool_name}' parameter requirements\n"
-                                f"2. Retry using <agent_call> with <agent_name> tags\n"
-                                f"3. Ensure parameters match registry definition exactly"
-                            ),
-                            tool_name="N/A",
-                            tool_args=tool_args,
-                        )
-
-                if not tool_name:
-                    return ToolError(
-                        observation="No tool name provided in the request",
-                        tool_name="N/A",
-                        tool_args=tool_args,
-                    )
-
-                mcp_tool_found = False
-                tool_executor = None
-                tool_data = {}
-
-                if mcp_tools:
-                    for server_name, tools in mcp_tools.items():
-                        for tool in tools:
-                            if tool.name.lower() == tool_name.lower():
-                                mcp_tool_handler = MCPToolHandler(
-                                    sessions=sessions,
-                                    tool_data=json.dumps(action),
-                                    mcp_tools=mcp_tools,
-                                    guardrail=self.guardrail,
-                                )
-                                tool_executor = ToolExecutor(
-                                    tool_handler=mcp_tool_handler
-                                )
-                                tool_data = (
-                                    await mcp_tool_handler.validate_tool_call_request(
-                                        tool_data=json.dumps(action),
-                                        mcp_tools=mcp_tools,
-                                    )
-                                )
-                                mcp_tool_found = True
-                                break
-                        if mcp_tool_found:
-                            break
-
-                if not mcp_tool_found and local_tools:
-                    local_tool_handler = LocalToolHandler(local_tools=local_tools)
-                    tool_executor = ToolExecutor(tool_handler=local_tool_handler)
-                    tool_data = await local_tool_handler.validate_tool_call_request(
-                        tool_data=json.dumps(action),
-                        local_tools=local_tools,
-                    )
-
-                if not mcp_tool_found and not local_tools:
-                    return ToolError(
-                        observation=f"The tool named '{tool_name}' does not exist in the available tools.",
-                        tool_name=tool_name,
-                        tool_args=tool_args,
-                    )
-
-                if not tool_data.get("action"):
-                    return ToolError(
-                        observation=tool_data.get("error", "Tool validation failed"),
-                        tool_name=tool_name,
-                        tool_args=tool_args,
-                    )
-
-                results.append(
-                    ToolCallResult(
-                        tool_executor=tool_executor,
-                        tool_name=tool_data.get("tool_name"),
-                        tool_args=normalize_tool_args(tool_data.get("tool_args")),
-                    )
+                resolved = await self._resolve_single_tool_action(
+                    action=action,
+                    sessions=sessions,
+                    mcp_tools=mcp_tools,
+                    local_tools=local_tools,
+                    sub_agents=sub_agents,
                 )
+                if isinstance(resolved, ToolError):
+                    return resolved
+                results.append(resolved)
 
             return results
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock
+from types import SimpleNamespace
 import pytest
 import json
 from omnicoreagent.core.agents.base import BaseReactAgent, TOOL_CALL_TIMEOUT_MESSAGE
@@ -683,3 +684,73 @@ async def test_handle_tool_loop_state_marks_session_stuck(agent):
     assert events[0]["session_id"] == "chat800"
     assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
     assert events[0]["event"].payload.tool_name == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_resolve_single_tool_action_uses_local_registry(agent):
+    registry = ToolRegistry()
+
+    @registry.register_tool(
+        name="local_ping",
+        inputSchema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        description="Local ping tool.",
+    )
+    async def local_ping(value: str):
+        return {"status": "success", "data": value}
+
+    resolved = await agent._resolve_single_tool_action(
+        action={"tool": "local_ping", "parameters": {"value": "runtime"}},
+        sessions={},
+        mcp_tools=None,
+        local_tools=registry,
+    )
+
+    assert isinstance(resolved, ToolCallResult)
+    assert resolved.tool_name == "local_ping"
+    assert resolved.tool_args == {"value": "runtime"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_single_tool_action_uses_mcp_tools_before_local(agent):
+    registry = ToolRegistry()
+
+    @registry.register_tool(
+        name="search",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        description="Local search fallback.",
+    )
+    async def search():
+        return {"status": "success", "data": "local"}
+
+    resolved = await agent._resolve_single_tool_action(
+        action={"tool": "search", "parameters": {"query": "runtime"}},
+        sessions={"server": {"session": object()}},
+        mcp_tools={"server": [SimpleNamespace(name="search")]},
+        local_tools=registry,
+    )
+
+    assert isinstance(resolved, ToolCallResult)
+    assert resolved.tool_name == "search"
+    assert resolved.tool_args == {"query": "runtime"}
+    assert resolved.tool_executor.tool_handler.server_name == "server"
+
+
+@pytest.mark.asyncio
+async def test_resolve_single_tool_action_rejects_tool_call_to_sub_agent(agent):
+    sub_agent = SimpleNamespace(name="research_agent")
+
+    resolved = await agent._resolve_single_tool_action(
+        action={"tool": "research_agent", "parameters": {"task": "inspect"}},
+        sessions={},
+        mcp_tools=None,
+        local_tools=None,
+        sub_agents=[sub_agent],
+    )
+
+    assert isinstance(resolved, ToolError)
+    assert resolved.tool_name == "N/A"
+    assert "is a sub-agent, not a tool" in resolved.observation


### PR DESCRIPTION
## Summary
- split MCP, local, and single-action tool resolution out of resolve_tool_call_request
- keep sub-agent misuse detection in a named helper
- add focused coverage for local resolution, MCP-first resolution, and sub-agent tool-call rejection

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py tests/test_base.py
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build