### PR TITLE
Extract tool request parsing

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -906,6 +906,29 @@ class BaseReactAgent:
             tool_args=normalize_tool_args(tool_data.get("tool_args")),
         )
 
+    def _parse_tool_actions(
+        self, parsed_response: ParsedResponse
+    ) -> ToolError | list[dict[str, Any]]:
+        if not parsed_response.data:
+            return ToolError(
+                observation="Invalid tool call request: No data provided",
+                tool_name="unknown",
+                tool_args={},
+            )
+
+        actions = json.loads(parsed_response.data)
+        if not isinstance(actions, list):
+            actions = [actions]
+        return actions
+
+    def _mcp_tools_for_action(
+        self, action: dict[str, Any], mcp_tools: dict | None
+    ) -> dict | None:
+        tool_name = action.get("tool", "").strip()
+        if tool_name == "tools_retriever":
+            return None
+        return mcp_tools
+
     async def resolve_tool_call_request(
         self,
         parsed_response: ParsedResponse,
@@ -915,27 +938,21 @@ class BaseReactAgent:
         sub_agents: list = None,
     ) -> ToolError | list[ToolCallResult]:
         try:
-            if not parsed_response.data:
-                return ToolError(
-                    observation="Invalid tool call request: No data provided",
-                    tool_name="unknown",
-                    tool_args={},
-                )
-
-            actions = json.loads(parsed_response.data)
-            if not isinstance(actions, list):
-                actions = [actions]
+            actions = self._parse_tool_actions(parsed_response)
+            if isinstance(actions, ToolError):
+                return actions
 
             results: list[ToolCallResult] = []
 
             for action in actions:
-                tool_name = action.get("tool", "").strip()
-                if tool_name == "tools_retriever":
-                    mcp_tools = None
+                action_mcp_tools = self._mcp_tools_for_action(
+                    action=action,
+                    mcp_tools=mcp_tools,
+                )
                 resolved = await self._resolve_single_tool_action(
                     action=action,
                     sessions=sessions,
-                    mcp_tools=mcp_tools,
+                    mcp_tools=action_mcp_tools,
                     local_tools=local_tools,
                     sub_agents=sub_agents,
                 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -754,3 +754,74 @@ async def test_resolve_single_tool_action_rejects_tool_call_to_sub_agent(agent):
     assert isinstance(resolved, ToolError)
     assert resolved.tool_name == "N/A"
     assert "is a sub-agent, not a tool" in resolved.observation
+
+
+def test_parse_tool_actions_handles_empty_and_single_action(agent):
+    empty = agent._parse_tool_actions(ParsedResponse(action=True, data=None))
+    assert isinstance(empty, ToolError)
+    assert empty.observation == "Invalid tool call request: No data provided"
+
+    parsed = agent._parse_tool_actions(
+        ParsedResponse(
+            action=True,
+            data=json.dumps({"tool": "local_ping", "parameters": {"value": "one"}}),
+        )
+    )
+    assert parsed == [{"tool": "local_ping", "parameters": {"value": "one"}}]
+
+
+def test_mcp_tools_for_action_disables_mcp_only_for_tools_retriever(agent):
+    mcp_tools = {"server": [SimpleNamespace(name="search")]}
+
+    assert (
+        agent._mcp_tools_for_action(
+            {"tool": "tools_retriever", "parameters": {"query": "mail"}},
+            mcp_tools=mcp_tools,
+        )
+        is None
+    )
+    assert (
+        agent._mcp_tools_for_action(
+            {"tool": "search", "parameters": {"query": "runtime"}},
+            mcp_tools=mcp_tools,
+        )
+        is mcp_tools
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_tool_call_request_keeps_mcp_available_after_tools_retriever(agent):
+    registry = ToolRegistry()
+
+    @registry.register_tool(
+        name="tools_retriever",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        description="Retrieve tools.",
+    )
+    async def tools_retriever(query: str):
+        return {"status": "success", "data": query}
+
+    resolved = await agent.resolve_tool_call_request(
+        parsed_response=ParsedResponse(
+            action=True,
+            tool_calls=True,
+            data=json.dumps(
+                [
+                    {"tool": "tools_retriever", "parameters": {"query": "search"}},
+                    {"tool": "search", "parameters": {"query": "runtime"}},
+                ]
+            ),
+        ),
+        sessions={"server": {"session": object()}},
+        mcp_tools={"server": [SimpleNamespace(name="search")]},
+        local_tools=registry,
+    )
+
+    assert not isinstance(resolved, ToolError)
+    assert [tool.tool_name for tool in resolved] == ["tools_retriever", "search"]
+    assert resolved[0].tool_executor.tool_handler.local_tools is registry
+    assert resolved[1].tool_executor.tool_handler.server_name == "server"


### PR DESCRIPTION
## Summary
- move tool request JSON parsing into a focused helper
- move the tools_retriever MCP bypass rule into a named helper
- avoid leaking tools_retriever MCP bypass into later tool calls in the same batch
- add focused tests for empty/single action parsing and mixed tools_retriever + MCP resolution

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py tests/test_base.py
- uv run pytest tests/test_base.py -q
- uv run pytest tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build

Also cleaned obsolete untracked OmniRuntime files from the main worktree; main is clean.