### PR TITLE
Move tool batch execution into runner

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 
 import json
-import uuid
 from collections.abc import Callable
 from collections import defaultdict
 from contextlib import asynccontextmanager
@@ -28,14 +27,12 @@ from omnicoreagent.core.types import (
     AgentState,
     Message,
     ParsedResponse,
-    ToolCall,
-    ToolCallMetadata,
     ToolCallResult,
     ToolError,
-    ToolFunction,
     SessionState,
 )
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.tools.tool_batch_runner import ToolBatchRunner
 from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
 from omnicoreagent.core.utils import (
     RobustLoopDetector,
@@ -55,8 +52,6 @@ from omnicoreagent.core.events.base import (
     Event,
     EventType,
     ToolCallErrorPayload,
-    ToolCallStartedPayload,
-    ToolCallResultPayload,
     FinalAnswerPayload,
     AgentMessagePayload,
     UserMessagePayload,
@@ -99,10 +94,6 @@ TOOL_OUTPUT_OFFLOAD_EXCLUDED_TOOLS = frozenset(
         "memory_create_update",
     }
 )
-TOOL_CALL_TIMEOUT_MESSAGE = (
-    "Tool call timed out. Please try again or use a different approach."
-)
-
 
 class BaseReactAgent:
     """Autonomous agent implementing the ReAct paradigm for task solving through iterative reasoning and tool usage."""
@@ -157,6 +148,10 @@ class BaseReactAgent:
         )
         self.guardrail = guardrail
         self.tool_call_resolver = ToolCallResolver(guardrail=self.guardrail)
+        self.tool_batch_runner = ToolBatchRunner(
+            agent_name=self.agent_name,
+            tool_call_timeout=self.tool_call_timeout,
+        )
 
     def init_skills(self):
         if self.enable_agent_skills:
@@ -312,68 +307,6 @@ class BaseReactAgent:
             return f"Tool execution failed completely:\n{error_details}"
         return "\n\n".join(obs_lines) or "No valid tool results."
 
-    def _build_tool_error_results(
-        self,
-        tool_call_results: list[ToolCallResult],
-        error_message: str,
-    ) -> list[dict[str, Any]]:
-        return [
-            {
-                "tool_name": getattr(single_tool, "tool_name", "unknown"),
-                "args": getattr(single_tool, "tool_args", {}),
-                "status": "error",
-                "data": None,
-                "message": error_message,
-            }
-            for single_tool in tool_call_results
-        ]
-
-    async def _handle_tool_execution_error(
-        self,
-        tool_call_results: list[ToolCallResult],
-        error_message: str,
-        session_state: SessionState,
-        add_message_to_history: Callable[[str, str, dict | None], Any],
-        session_id: str | None,
-        event_router: Callable[[str, Event], Any] | None,
-        tool_batch_name: str,
-    ) -> list[dict[str, Any]]:
-        for single_tool in tool_call_results:
-            session_state.loop_detector.record_tool_call(
-                str(single_tool.tool_name),
-                str(single_tool.tool_args),
-                error_message,
-            )
-
-        for single_tool in tool_call_results:
-            await add_message_to_history(
-                role="tool",
-                content=error_message,
-                metadata={
-                    "tool_call_id": single_tool.tool_call_id,
-                    "tool": single_tool.tool_name,
-                    "args": single_tool.tool_args,
-                    "agent_name": self.agent_name,
-                },
-                session_id=session_id,
-            )
-
-        event = Event(
-            type=EventType.TOOL_CALL_ERROR,
-            payload=ToolCallErrorPayload(
-                tool_name=tool_batch_name,
-                error_message=error_message,
-            ),
-            agent_name=self.agent_name,
-        )
-        if event_router:
-            await event_router(session_id=session_id, event=event)
-
-        return self._build_tool_error_results(
-            tool_call_results=tool_call_results,
-            error_message=error_message,
-        )
-
     def _build_tool_validation_error_results(
         self,
         tool_errors: list[ToolError],
@@ -441,147 +374,6 @@ class BaseReactAgent:
                 fallback_message=obs_text,
             ),
         )
-
-    async def _start_tool_call_batch(
-        self,
-        tool_call_results: list[ToolCallResult],
-        response: str,
-        session_state: SessionState,
-        add_message_to_history: Callable[[str, str, dict | None], Any],
-        session_id: str | None,
-        event_router: Callable[[str, Event], Any] | None,
-    ) -> tuple[str, list[dict[str, Any]]]:
-        tool_batch_name = ", ".join([t.tool_name for t in tool_call_results])
-        tool_batch_args = [t.tool_args for t in tool_call_results]
-
-        for single_tool in tool_call_results:
-            single_tool.tool_call_id = str(uuid.uuid4())
-
-        tool_calls_metadata = ToolCallMetadata(
-            agent_name=self.agent_name,
-            has_tool_calls=True,
-            tool_call_id=tool_call_results[0].tool_call_id,
-            tool_calls=[
-                ToolCall(
-                    id=single_tool.tool_call_id,
-                    function=ToolFunction(
-                        name=single_tool.tool_name,
-                        arguments=json.dumps(single_tool.tool_args),
-                    ),
-                )
-                for single_tool in tool_call_results
-            ],
-        )
-
-        event = Event(
-            type=EventType.TOOL_CALL_STARTED,
-            payload=ToolCallStartedPayload(
-                tool_name=tool_batch_name,
-                tool_args=json.dumps(tool_batch_args),
-                tool_call_id=tool_call_results[0].tool_call_id,
-            ),
-            agent_name=self.agent_name,
-        )
-        if event_router:
-            await event_router(session_id=session_id, event=event)
-
-        await add_message_to_history(
-            role="assistant",
-            content=response,
-            metadata=tool_calls_metadata.model_dump(),
-            session_id=session_id,
-        )
-        session_state.messages.append(Message(role="assistant", content=response))
-
-        return tool_batch_name, tool_batch_args
-
-    async def _execute_tool_call_batch(
-        self,
-        tool_call_results: list[ToolCallResult],
-        session_state: SessionState,
-        add_message_to_history: Callable[[str, str, dict | None], Any],
-        session_id: str | None,
-        event_router: Callable[[str, Event], Any] | None,
-        tool_batch_name: str,
-        tool_batch_args: list[dict[str, Any]],
-    ) -> tuple[str, list[dict[str, Any]]]:
-        try:
-            async with asyncio.timeout(self.tool_call_timeout):
-                tool_outputs = await asyncio.gather(
-                    *[
-                        single_tool.tool_executor.execute(
-                            agent_name=self.agent_name,
-                            tool_args=single_tool.tool_args,
-                            tool_name=single_tool.tool_name,
-                            tool_call_id=single_tool.tool_call_id,
-                            add_message_to_history=add_message_to_history,
-                            session_id=session_id,
-                        )
-                        for single_tool in tool_call_results
-                    ]
-                )
-
-            observation = await self.parse_tool_observation(
-                {
-                    "status": (
-                        "error"
-                        if any(result.get("status") == "error" for result in tool_outputs)
-                        else "success"
-                    ),
-                    "tools_results": tool_outputs,
-                }
-            )
-
-            tools_results = observation.get("tools_results", [])
-            obs_text = self._build_tool_results_observation(
-                tool_call_results=tool_call_results,
-                tools_results=tools_results,
-                session_state=session_state,
-                session_id=session_id,
-            )
-
-            event = Event(
-                type=EventType.TOOL_CALL_RESULT,
-                payload=ToolCallResultPayload(
-                    tool_name=tool_batch_name,
-                    tool_args=json.dumps(tool_batch_args),
-                    result=obs_text,
-                    tool_call_id=tool_call_results[0].tool_call_id,
-                ),
-                agent_name=self.agent_name,
-            )
-            if event_router:
-                await event_router(session_id=session_id, event=event)
-
-            return obs_text, tools_results
-
-        except asyncio.TimeoutError:
-            obs_text = TOOL_CALL_TIMEOUT_MESSAGE
-            logger.warning(obs_text)
-            tools_results = await self._handle_tool_execution_error(
-                tool_call_results=tool_call_results,
-                error_message=obs_text,
-                session_state=session_state,
-                add_message_to_history=add_message_to_history,
-                session_id=session_id,
-                event_router=event_router,
-                tool_batch_name=tool_batch_name,
-            )
-            return obs_text, tools_results
-
-        except Exception as e:
-            obs_text = f"Error executing tool: {str(e)}"
-            logger.error(obs_text)
-            tools_results = await self._handle_tool_execution_error(
-                tool_call_results=tool_call_results,
-                error_message=obs_text,
-                session_state=session_state,
-                add_message_to_history=add_message_to_history,
-                session_id=session_id,
-                event_router=event_router,
-                tool_batch_name=tool_batch_name,
-            )
-            return obs_text, tools_results
 
     async def _append_tool_observations(
         self,
@@ -967,7 +759,7 @@ class BaseReactAgent:
             )
         else:
             tool_call_result = list(tool_call_result)
-            tool_batch_name, tool_batch_args = await self._start_tool_call_batch(
+            tool_batch_name, tool_batch_args = await self.tool_batch_runner.start(
                 tool_call_results=tool_call_result,
                 response=response,
                 session_state=session_state,
@@ -975,7 +767,7 @@ class BaseReactAgent:
                 session_id=session_id,
                 event_router=event_router,
             )
-            obs_text, tools_results = await self._execute_tool_call_batch(
+            obs_text, tools_results = await self.tool_batch_runner.execute(
                 tool_call_results=tool_call_result,
                 session_state=session_state,
                 add_message_to_history=add_message_to_history,
@@ -983,6 +775,8 @@ class BaseReactAgent:
                 event_router=event_router,
                 tool_batch_name=tool_batch_name,
                 tool_batch_args=tool_batch_args,
+                parse_tool_observation=self.parse_tool_observation,
+                build_tool_results_observation=self._build_tool_results_observation,
             )
 
         if debug:

--- a/src/omnicoreagent/core/tools/tool_batch_runner.py
+++ b/src/omnicoreagent/core/tools/tool_batch_runner.py
@@ -1,0 +1,242 @@
+import asyncio
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from omnicoreagent.core.events.base import (
+    Event,
+    EventType,
+    ToolCallErrorPayload,
+    ToolCallResultPayload,
+    ToolCallStartedPayload,
+)
+from omnicoreagent.core.types import (
+    Message,
+    SessionState,
+    ToolCall,
+    ToolCallMetadata,
+    ToolCallResult,
+    ToolFunction,
+)
+from omnicoreagent.core.utils import logger
+
+TOOL_CALL_TIMEOUT_MESSAGE = (
+    "Tool call timed out. Please try again or use a different approach."
+)
+
+
+class ToolBatchRunner:
+    """Run resolved tool calls as a single parallel batch."""
+
+    def __init__(self, agent_name: str, tool_call_timeout: int):
+        self.agent_name = agent_name
+        self.tool_call_timeout = tool_call_timeout
+
+    def build_error_results(
+        self,
+        tool_call_results: list[ToolCallResult],
+        error_message: str,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "tool_name": getattr(single_tool, "tool_name", "unknown"),
+                "args": getattr(single_tool, "tool_args", {}),
+                "status": "error",
+                "data": None,
+                "message": error_message,
+            }
+            for single_tool in tool_call_results
+        ]
+
+    async def handle_execution_error(
+        self,
+        tool_call_results: list[ToolCallResult],
+        error_message: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+        tool_batch_name: str,
+    ) -> list[dict[str, Any]]:
+        for single_tool in tool_call_results:
+            session_state.loop_detector.record_tool_call(
+                str(single_tool.tool_name),
+                str(single_tool.tool_args),
+                error_message,
+            )
+
+        for single_tool in tool_call_results:
+            await add_message_to_history(
+                role="tool",
+                content=error_message,
+                metadata={
+                    "tool_call_id": single_tool.tool_call_id,
+                    "tool": single_tool.tool_name,
+                    "args": single_tool.tool_args,
+                    "agent_name": self.agent_name,
+                },
+                session_id=session_id,
+            )
+
+        event = Event(
+            type=EventType.TOOL_CALL_ERROR,
+            payload=ToolCallErrorPayload(
+                tool_name=tool_batch_name,
+                error_message=error_message,
+            ),
+            agent_name=self.agent_name,
+        )
+        if event_router:
+            await event_router(session_id=session_id, event=event)
+
+        return self.build_error_results(
+            tool_call_results=tool_call_results,
+            error_message=error_message,
+        )
+
+    async def start(
+        self,
+        tool_call_results: list[ToolCallResult],
+        response: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+    ) -> tuple[str, list[dict[str, Any]]]:
+        tool_batch_name = ", ".join([t.tool_name for t in tool_call_results])
+        tool_batch_args = [t.tool_args for t in tool_call_results]
+
+        for single_tool in tool_call_results:
+            single_tool.tool_call_id = str(uuid.uuid4())
+
+        tool_calls_metadata = ToolCallMetadata(
+            agent_name=self.agent_name,
+            has_tool_calls=True,
+            tool_call_id=tool_call_results[0].tool_call_id,
+            tool_calls=[
+                ToolCall(
+                    id=single_tool.tool_call_id,
+                    function=ToolFunction(
+                        name=single_tool.tool_name,
+                        arguments=json.dumps(single_tool.tool_args),
+                    ),
+                )
+                for single_tool in tool_call_results
+            ],
+        )
+
+        event = Event(
+            type=EventType.TOOL_CALL_STARTED,
+            payload=ToolCallStartedPayload(
+                tool_name=tool_batch_name,
+                tool_args=json.dumps(tool_batch_args),
+                tool_call_id=tool_call_results[0].tool_call_id,
+            ),
+            agent_name=self.agent_name,
+        )
+        if event_router:
+            await event_router(session_id=session_id, event=event)
+
+        await add_message_to_history(
+            role="assistant",
+            content=response,
+            metadata=tool_calls_metadata.model_dump(),
+            session_id=session_id,
+        )
+        session_state.messages.append(Message(role="assistant", content=response))
+
+        return tool_batch_name, tool_batch_args
+
+    async def execute(
+        self,
+        tool_call_results: list[ToolCallResult],
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str, Event], Any] | None,
+        tool_batch_name: str,
+        tool_batch_args: list[dict[str, Any]],
+        parse_tool_observation: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]],
+        build_tool_results_observation: Callable[
+            [list[ToolCallResult], list[dict[str, Any]], SessionState, str | None],
+            str,
+        ],
+    ) -> tuple[str, list[dict[str, Any]]]:
+        try:
+            async with asyncio.timeout(self.tool_call_timeout):
+                tool_outputs = await asyncio.gather(
+                    *[
+                        single_tool.tool_executor.execute(
+                            agent_name=self.agent_name,
+                            tool_args=single_tool.tool_args,
+                            tool_name=single_tool.tool_name,
+                            tool_call_id=single_tool.tool_call_id,
+                            add_message_to_history=add_message_to_history,
+                            session_id=session_id,
+                        )
+                        for single_tool in tool_call_results
+                    ]
+                )
+
+            observation = await parse_tool_observation(
+                {
+                    "status": (
+                        "error"
+                        if any(result.get("status") == "error" for result in tool_outputs)
+                        else "success"
+                    ),
+                    "tools_results": tool_outputs,
+                }
+            )
+
+            tools_results = observation.get("tools_results", [])
+            obs_text = build_tool_results_observation(
+                tool_call_results,
+                tools_results,
+                session_state,
+                session_id,
+            )
+
+            event = Event(
+                type=EventType.TOOL_CALL_RESULT,
+                payload=ToolCallResultPayload(
+                    tool_name=tool_batch_name,
+                    tool_args=json.dumps(tool_batch_args),
+                    result=obs_text,
+                    tool_call_id=tool_call_results[0].tool_call_id,
+                ),
+                agent_name=self.agent_name,
+            )
+            if event_router:
+                await event_router(session_id=session_id, event=event)
+
+            return obs_text, tools_results
+
+        except asyncio.TimeoutError:
+            obs_text = TOOL_CALL_TIMEOUT_MESSAGE
+            logger.warning(obs_text)
+            tools_results = await self.handle_execution_error(
+                tool_call_results=tool_call_results,
+                error_message=obs_text,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                event_router=event_router,
+                tool_batch_name=tool_batch_name,
+            )
+            return obs_text, tools_results
+
+        except Exception as e:
+            obs_text = f"Error executing tool: {str(e)}"
+            logger.error(obs_text)
+            tools_results = await self.handle_execution_error(
+                tool_call_results=tool_call_results,
+                error_message=obs_text,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                event_router=event_router,
+                tool_batch_name=tool_batch_name,
+            )
+            return obs_text, tools_results

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock
 import pytest
 import json
-from omnicoreagent.core.agents.base import BaseReactAgent, TOOL_CALL_TIMEOUT_MESSAGE
+from omnicoreagent.core.agents.base import BaseReactAgent
 from omnicoreagent.core.events.base import EventType
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
@@ -350,77 +350,6 @@ def test_build_tool_results_observation_formats_parallel_results(agent):
 
 
 @pytest.mark.asyncio
-async def test_handle_tool_execution_error_records_history_and_event(agent):
-    history = []
-    events = []
-    session_state = agent._get_session_state(session_id="chat795", debug=False)
-    tool_calls = [
-        ToolCallResult(
-            tool_executor=None,
-            tool_name="alpha",
-            tool_args={"value": "one"},
-            tool_call_id="tool-call-alpha",
-        ),
-        ToolCallResult(
-            tool_executor=None,
-            tool_name="beta",
-            tool_args={"value": "two"},
-            tool_call_id="tool-call-beta",
-        ),
-    ]
-
-    async def add_message_to_history(role, content, metadata=None, session_id=None):
-        history.append(
-            {
-                "role": role,
-                "content": content,
-                "metadata": metadata or {},
-                "session_id": session_id,
-            }
-        )
-
-    async def event_router(session_id, event):
-        events.append({"session_id": session_id, "event": event})
-
-    results = await agent._handle_tool_execution_error(
-        tool_call_results=tool_calls,
-        error_message=TOOL_CALL_TIMEOUT_MESSAGE,
-        session_state=session_state,
-        add_message_to_history=add_message_to_history,
-        session_id="chat795",
-        event_router=event_router,
-        tool_batch_name="alpha, beta",
-    )
-
-    assert [item["role"] for item in history] == ["tool", "tool"]
-    assert [item["metadata"]["tool"] for item in history] == ["alpha", "beta"]
-    assert {item["metadata"]["tool_call_id"] for item in history} == {
-        "tool-call-alpha",
-        "tool-call-beta",
-    }
-    assert results == [
-        {
-            "tool_name": "alpha",
-            "args": {"value": "one"},
-            "status": "error",
-            "data": None,
-            "message": TOOL_CALL_TIMEOUT_MESSAGE,
-        },
-        {
-            "tool_name": "beta",
-            "args": {"value": "two"},
-            "status": "error",
-            "data": None,
-            "message": TOOL_CALL_TIMEOUT_MESSAGE,
-        },
-    ]
-    assert len(events) == 1
-    assert events[0]["session_id"] == "chat795"
-    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
-    assert events[0]["event"].payload.tool_name == "alpha, beta"
-
-
-@pytest.mark.asyncio
 async def test_handle_tool_validation_error_records_loop_and_event(agent):
     events = []
     session_state = agent._get_session_state(session_id="chat796", debug=False)
@@ -457,137 +386,6 @@ async def test_handle_tool_validation_error_records_loop_and_event(agent):
     assert events[0]["session_id"] == "chat796"
     assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
     assert events[0]["event"].payload.tool_name == "missing_tool"
-
-
-@pytest.mark.asyncio
-async def test_start_tool_call_batch_records_assistant_and_started_event(agent):
-    history = []
-    events = []
-    session_state = agent._get_session_state(session_id="chat797", debug=False)
-    tool_calls = [
-        ToolCallResult(tool_executor=None, tool_name="alpha", tool_args={"value": "1"}),
-        ToolCallResult(tool_executor=None, tool_name="beta", tool_args={"value": "2"}),
-    ]
-
-    async def add_message_to_history(role, content, metadata=None, session_id=None):
-        history.append(
-            {
-                "role": role,
-                "content": content,
-                "metadata": metadata or {},
-                "session_id": session_id,
-            }
-        )
-
-    async def event_router(session_id, event):
-        events.append({"session_id": session_id, "event": event})
-
-    tool_batch_name, tool_batch_args = await agent._start_tool_call_batch(
-        tool_call_results=tool_calls,
-        response="<tool_calls>...</tool_calls>",
-        session_state=session_state,
-        add_message_to_history=add_message_to_history,
-        session_id="chat797",
-        event_router=event_router,
-    )
-
-    assert tool_batch_name == "alpha, beta"
-    assert tool_batch_args == [{"value": "1"}, {"value": "2"}]
-    assert all(tool.tool_call_id for tool in tool_calls)
-    assert len({tool.tool_call_id for tool in tool_calls}) == 2
-    assert history[0]["role"] == "assistant"
-    assert [call["function"]["name"] for call in history[0]["metadata"]["tool_calls"]] == [
-        "alpha",
-        "beta",
-    ]
-    assert session_state.messages[-1].role == "assistant"
-    assert len(events) == 1
-    assert events[0]["event"].type == EventType.TOOL_CALL_STARTED
-    assert events[0]["event"].payload.tool_name == "alpha, beta"
-
-
-@pytest.mark.asyncio
-async def test_execute_tool_call_batch_returns_observation_and_result_event(agent):
-    history = []
-    events = []
-    session_state = agent._get_session_state(session_id="chat798", debug=False)
-
-    class FakeExecutor:
-        async def execute(
-            self,
-            agent_name,
-            tool_args,
-            tool_name,
-            tool_call_id,
-            add_message_to_history,
-            session_id,
-        ):
-            await add_message_to_history(
-                role="tool",
-                content=f"{tool_name}:{tool_args['value']}",
-                metadata={
-                    "tool_call_id": tool_call_id,
-                    "tool": tool_name,
-                    "args": tool_args,
-                    "agent_name": agent_name,
-                },
-                session_id=session_id,
-            )
-            return {
-                "tool_name": tool_name,
-                "args": tool_args,
-                "status": "success",
-                "data": f"{tool_name}:{tool_args['value']}",
-                "message": None,
-            }
-
-    tool_calls = [
-        ToolCallResult(
-            tool_executor=FakeExecutor(),
-            tool_name="alpha",
-            tool_args={"value": "one"},
-            tool_call_id="tool-call-alpha",
-        ),
-        ToolCallResult(
-            tool_executor=FakeExecutor(),
-            tool_name="beta",
-            tool_args={"value": "two"},
-            tool_call_id="tool-call-beta",
-        ),
-    ]
-
-    async def add_message_to_history(role, content, metadata=None, session_id=None):
-        history.append(
-            {
-                "role": role,
-                "content": content,
-                "metadata": metadata or {},
-                "session_id": session_id,
-            }
-        )
-
-    async def event_router(session_id, event):
-        events.append({"session_id": session_id, "event": event})
-
-    obs_text, tools_results = await agent._execute_tool_call_batch(
-        tool_call_results=tool_calls,
-        session_state=session_state,
-        add_message_to_history=add_message_to_history,
-        session_id="chat798",
-        event_router=event_router,
-        tool_batch_name="alpha, beta",
-        tool_batch_args=[{"value": "one"}, {"value": "two"}],
-    )
-
-    assert obs_text == "alpha#1: alpha:one\n\nbeta#1: beta:two"
-    assert [result["tool_name"] for result in tools_results] == ["alpha", "beta"]
-    assert [item["metadata"]["tool_call_id"] for item in history] == [
-        "tool-call-alpha",
-        "tool-call-beta",
-    ]
-    assert len(events) == 1
-    assert events[0]["event"].type == EventType.TOOL_CALL_RESULT
-    assert events[0]["event"].payload.tool_name == "alpha, beta"
 
 
 @pytest.mark.asyncio
@@ -683,4 +481,3 @@ async def test_handle_tool_loop_state_marks_session_stuck(agent):
     assert events[0]["session_id"] == "chat800"
     assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
     assert events[0]["event"].payload.tool_name == "alpha"
-

--- a/tests/test_tool_batch_runner.py
+++ b/tests/test_tool_batch_runner.py
@@ -1,0 +1,236 @@
+import pytest
+
+from omnicoreagent.core.events.base import EventType
+from omnicoreagent.core.tools.tool_batch_runner import (
+    TOOL_CALL_TIMEOUT_MESSAGE,
+    ToolBatchRunner,
+)
+from omnicoreagent.core.types import AgentState, SessionState, ToolCallResult
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+@pytest.fixture
+def runner():
+    return ToolBatchRunner(agent_name="test_agent", tool_call_timeout=10)
+
+
+@pytest.fixture
+def session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_execution_error_records_history_and_event(runner, session_state):
+    history = []
+    events = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=None,
+            tool_name="alpha",
+            tool_args={"value": "one"},
+            tool_call_id="tool-call-alpha",
+        ),
+        ToolCallResult(
+            tool_executor=None,
+            tool_name="beta",
+            tool_args={"value": "two"},
+            tool_call_id="tool-call-beta",
+        ),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    results = await runner.handle_execution_error(
+        tool_call_results=tool_calls,
+        error_message=TOOL_CALL_TIMEOUT_MESSAGE,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat795",
+        event_router=event_router,
+        tool_batch_name="alpha, beta",
+    )
+
+    assert [item["role"] for item in history] == ["tool", "tool"]
+    assert [item["metadata"]["tool"] for item in history] == ["alpha", "beta"]
+    assert {item["metadata"]["tool_call_id"] for item in history} == {
+        "tool-call-alpha",
+        "tool-call-beta",
+    }
+    assert results == [
+        {
+            "tool_name": "alpha",
+            "args": {"value": "one"},
+            "status": "error",
+            "data": None,
+            "message": TOOL_CALL_TIMEOUT_MESSAGE,
+        },
+        {
+            "tool_name": "beta",
+            "args": {"value": "two"},
+            "status": "error",
+            "data": None,
+            "message": TOOL_CALL_TIMEOUT_MESSAGE,
+        },
+    ]
+    assert len(events) == 1
+    assert events[0]["session_id"] == "chat795"
+    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
+    assert events[0]["event"].payload.tool_name == "alpha, beta"
+
+
+@pytest.mark.asyncio
+async def test_start_records_assistant_and_started_event(runner, session_state):
+    history = []
+    events = []
+    tool_calls = [
+        ToolCallResult(tool_executor=None, tool_name="alpha", tool_args={"value": "1"}),
+        ToolCallResult(tool_executor=None, tool_name="beta", tool_args={"value": "2"}),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    tool_batch_name, tool_batch_args = await runner.start(
+        tool_call_results=tool_calls,
+        response="<tool_calls>...</tool_calls>",
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat797",
+        event_router=event_router,
+    )
+
+    assert tool_batch_name == "alpha, beta"
+    assert tool_batch_args == [{"value": "1"}, {"value": "2"}]
+    assert all(tool.tool_call_id for tool in tool_calls)
+    assert len({tool.tool_call_id for tool in tool_calls}) == 2
+    assert history[0]["role"] == "assistant"
+    assert [call["function"]["name"] for call in history[0]["metadata"]["tool_calls"]] == [
+        "alpha",
+        "beta",
+    ]
+    assert session_state.messages[-1].role == "assistant"
+    assert len(events) == 1
+    assert events[0]["event"].type == EventType.TOOL_CALL_STARTED
+    assert events[0]["event"].payload.tool_name == "alpha, beta"
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_observation_and_result_event(runner, session_state):
+    history = []
+    events = []
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            await add_message_to_history(
+                role="tool",
+                content=f"{tool_name}:{tool_args['value']}",
+                metadata={
+                    "tool_call_id": tool_call_id,
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "agent_name": agent_name,
+                },
+                session_id=session_id,
+            )
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": f"{tool_name}:{tool_args['value']}",
+                "message": None,
+            }
+
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=FakeExecutor(),
+            tool_name="alpha",
+            tool_args={"value": "one"},
+            tool_call_id="tool-call-alpha",
+        ),
+        ToolCallResult(
+            tool_executor=FakeExecutor(),
+            tool_name="beta",
+            tool_args={"value": "two"},
+            tool_call_id="tool-call-beta",
+        ),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return "\n\n".join(
+            f"{result['tool_name']}#1: {result['data']}" for result in tools_results
+        )
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat798",
+        event_router=event_router,
+        tool_batch_name="alpha, beta",
+        tool_batch_args=[{"value": "one"}, {"value": "two"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert obs_text == "alpha#1: alpha:one\n\nbeta#1: beta:two"
+    assert [result["tool_name"] for result in tools_results] == ["alpha", "beta"]
+    assert [item["metadata"]["tool_call_id"] for item in history] == [
+        "tool-call-alpha",
+        "tool-call-beta",
+    ]
+    assert len(events) == 1
+    assert events[0]["event"].type == EventType.TOOL_CALL_RESULT
+    assert events[0]["event"].payload.tool_name == "alpha, beta"


### PR DESCRIPTION
## Summary
- add ToolBatchRunner for tool batch startup, parallel execution, timeout/error handling, and batch result events
- remove tool batch execution helpers from BaseReactAgent
- keep observation parsing/formatting as callbacks so that boundary can be moved separately next
- move batch-runner tests out of test_base.py

## Verification
- uv run ruff check .
- uv run pytest tests/test_tool_batch_runner.py tests/test_base.py -q
- uv run pytest tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run pytest -q
- uv run hatch build