### PR TITLE
Extract tool failure handling

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -33,9 +33,9 @@ from omnicoreagent.core.types import (
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.tools.tool_batch_runner import ToolBatchRunner
 from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
+from omnicoreagent.core.tools.tool_failure_handler import ToolFailureHandler
 from omnicoreagent.core.utils import (
     RobustLoopDetector,
-    handle_stuck_state,
     logger,
     show_tool_response,
     track,
@@ -49,7 +49,6 @@ from datetime import datetime
 from omnicoreagent.core.events.base import (
     Event,
     EventType,
-    ToolCallErrorPayload,
     FinalAnswerPayload,
     AgentMessagePayload,
     UserMessagePayload,
@@ -141,6 +140,7 @@ class BaseReactAgent:
             guardrail=self.guardrail,
         )
         self.tool_call_resolver = ToolCallResolver(guardrail=self.guardrail)
+        self.tool_failure_handler = ToolFailureHandler(agent_name=self.agent_name)
         self.tool_batch_runner = ToolBatchRunner(
             agent_name=self.agent_name,
             tool_call_timeout=self.tool_call_timeout,
@@ -167,140 +167,6 @@ class BaseReactAgent:
                 pending_tool_responses=[],
             )
         return self._session_states[key]
-
-    def _build_tool_validation_error_results(
-        self,
-        tool_errors: list[ToolError],
-        fallback_message: str,
-    ) -> list[dict[str, Any]]:
-        return [
-            {
-                "tool_name": getattr(single_tool, "tool_name", "unknown"),
-                "args": getattr(single_tool, "tool_args", {}),
-                "status": "error",
-                "data": None,
-                "message": getattr(single_tool, "observation", fallback_message),
-            }
-            for single_tool in tool_errors
-        ]
-
-    async def _handle_tool_validation_error(
-        self,
-        tool_error: ToolError,
-        session_state: SessionState,
-        session_id: str | None,
-        event_router: Callable[[str, Event], Any] | None,
-    ) -> tuple[str, list[dict[str, Any]], str, list[dict[str, Any]]]:
-        obs_text = tool_error.observation
-        tool_errors = [tool_error]
-
-        for single_tool in tool_errors:
-            tool_name = getattr(single_tool, "tool_name", "unknown")
-            tool_args = getattr(single_tool, "tool_args", {})
-            error_message = getattr(single_tool, "observation", obs_text)
-
-            event = Event(
-                type=EventType.TOOL_CALL_ERROR,
-                payload=ToolCallErrorPayload(
-                    tool_name=tool_name,
-                    error_message=error_message,
-                ),
-                agent_name=self.agent_name,
-            )
-
-            if event_router:
-                await event_router(session_id=session_id, event=event)
-            session_state.loop_detector.record_tool_call(
-                str(tool_name),
-                str(tool_args),
-                str(error_message),
-            )
-
-        tool_batch_name = ", ".join(
-            [getattr(t, "tool_name", "unknown") for t in tool_errors]
-        )
-        tool_batch_args = [getattr(t, "tool_args", {}) for t in tool_errors]
-
-        logger.error(
-            f"Tool call validation failed for: {tool_batch_name} "
-            f"args={tool_batch_args} -> {obs_text}"
-        )
-
-        return (
-            tool_batch_name,
-            tool_batch_args,
-            obs_text,
-            self._build_tool_validation_error_results(
-                tool_errors=tool_errors,
-                fallback_message=obs_text,
-            ),
-        )
-
-    async def _handle_tool_loop_state(
-        self,
-        tool_call_results: list[Any],
-        session_state: SessionState,
-        system_prompt: str,
-        session_id: str | None,
-        event_router: Callable[[str, Event], Any] | None,
-        debug: bool,
-    ) -> None:
-        for single_tool in tool_call_results:
-            tool_name = getattr(single_tool, "tool_name", None)
-            if not tool_name:
-                if isinstance(single_tool, (list, tuple)) and len(single_tool) >= 1:
-                    tool_name = single_tool[0]
-                else:
-                    logger.warning(
-                        "Skipping malformed tool_call_result item: %s", single_tool
-                    )
-                    continue
-
-            if not session_state.loop_detector.is_looping(tool_name):
-                continue
-
-            loop_type = session_state.loop_detector.get_loop_type(tool_name)
-            logger.warning(f"Tool call loop detected for '{tool_name}': {loop_type}")
-
-            new_system_prompt = handle_stuck_state(system_prompt)
-            session_state.messages = await self.reset_system_prompt(
-                messages=session_state.messages,
-                system_prompt=new_system_prompt,
-            )
-
-            loop_message = (
-                f"Observation:\n"
-                f"⚠️ Tool call loop detected for '{tool_name}': {loop_type}\n\n"
-                "Current approach is not working. You MUST now provide a final answer to the user.\n"
-                "Please:\n"
-                "1. Stop trying the same approach\n"
-                "2. Provide your best response to the user based on what you know\n"
-                "3. Use <final_answer>Your response here</final_answer> format\n"
-                "4. Be helpful and explain any limitations if needed\n"
-                "5. Do NOT continue with more tool calls\n"
-                "\nYou MUST respond with <final_answer> tags now.\n"
-            )
-
-            event = Event(
-                type=EventType.TOOL_CALL_ERROR,
-                payload=ToolCallErrorPayload(
-                    tool_name=tool_name,
-                    error_message=loop_message,
-                ),
-                agent_name=self.agent_name,
-            )
-            if event_router:
-                await event_router(session_id=session_id, event=event)
-
-            session_state.messages.append(Message(role="user", content=loop_message))
-
-            if debug:
-                logger.info(
-                    f"Agent state changed from {session_state.state} to {AgentState.STUCK}"
-                )
-
-            session_state.state = AgentState.STUCK
-            session_state.loop_detector.reset(tool_name)
 
     async def extract_action_or_answer(
         self,
@@ -452,7 +318,7 @@ class BaseReactAgent:
                 tool_batch_args,
                 obs_text,
                 tools_results,
-            ) = await self._handle_tool_validation_error(
+            ) = await self.tool_failure_handler.handle_validation_error(
                 tool_error=tool_call_result,
                 session_state=session_state,
                 session_id=session_id,
@@ -503,13 +369,14 @@ class BaseReactAgent:
         else:
             tool_call_results = [tool_call_result]
 
-        await self._handle_tool_loop_state(
+        await self.tool_failure_handler.handle_loop_state(
             tool_call_results=tool_call_results,
             session_state=session_state,
             system_prompt=system_prompt,
             session_id=session_id,
             event_router=event_router,
             debug=debug,
+            reset_system_prompt=self.reset_system_prompt,
         )
 
     async def reset_system_prompt(self, messages: list, system_prompt: str):

--- a/src/omnicoreagent/core/tools/tool_failure_handler.py
+++ b/src/omnicoreagent/core/tools/tool_failure_handler.py
@@ -1,0 +1,152 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from omnicoreagent.core.events.base import (
+    Event,
+    EventType,
+    ToolCallErrorPayload,
+)
+from omnicoreagent.core.types import AgentState, Message, SessionState, ToolError
+from omnicoreagent.core.utils import handle_stuck_state, logger
+
+
+class ToolFailureHandler:
+    """Handle failed tool resolution and repeated tool-call loops."""
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    def build_validation_error_results(
+        self,
+        tool_errors: list[ToolError],
+        fallback_message: str,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "tool_name": getattr(single_tool, "tool_name", "unknown"),
+                "args": getattr(single_tool, "tool_args", {}),
+                "status": "error",
+                "data": None,
+                "message": getattr(single_tool, "observation", fallback_message),
+            }
+            for single_tool in tool_errors
+        ]
+
+    async def handle_validation_error(
+        self,
+        tool_error: ToolError,
+        session_state: SessionState,
+        session_id: str | None,
+        event_router: Callable[[str | None, Event], Awaitable[Any]] | None,
+    ) -> tuple[str, list[dict[str, Any]], str, list[dict[str, Any]]]:
+        obs_text = tool_error.observation
+        tool_errors = [tool_error]
+
+        for single_tool in tool_errors:
+            tool_name = getattr(single_tool, "tool_name", "unknown")
+            tool_args = getattr(single_tool, "tool_args", {})
+            error_message = getattr(single_tool, "observation", obs_text)
+
+            event = Event(
+                type=EventType.TOOL_CALL_ERROR,
+                payload=ToolCallErrorPayload(
+                    tool_name=tool_name,
+                    error_message=error_message,
+                ),
+                agent_name=self.agent_name,
+            )
+
+            if event_router:
+                await event_router(session_id=session_id, event=event)
+            session_state.loop_detector.record_tool_call(
+                str(tool_name),
+                str(tool_args),
+                str(error_message),
+            )
+
+        tool_batch_name = ", ".join(
+            [getattr(tool, "tool_name", "unknown") for tool in tool_errors]
+        )
+        tool_batch_args = [getattr(tool, "tool_args", {}) for tool in tool_errors]
+
+        logger.error(
+            f"Tool call validation failed for: {tool_batch_name} "
+            f"args={tool_batch_args} -> {obs_text}"
+        )
+
+        return (
+            tool_batch_name,
+            tool_batch_args,
+            obs_text,
+            self.build_validation_error_results(
+                tool_errors=tool_errors,
+                fallback_message=obs_text,
+            ),
+        )
+
+    async def handle_loop_state(
+        self,
+        tool_call_results: list[Any],
+        session_state: SessionState,
+        system_prompt: str,
+        session_id: str | None,
+        event_router: Callable[[str | None, Event], Awaitable[Any]] | None,
+        debug: bool,
+        reset_system_prompt: Callable[..., Awaitable[list[Message]]],
+    ) -> None:
+        for single_tool in tool_call_results:
+            tool_name = getattr(single_tool, "tool_name", None)
+            if not tool_name:
+                if isinstance(single_tool, (list, tuple)) and len(single_tool) >= 1:
+                    tool_name = single_tool[0]
+                else:
+                    logger.warning(
+                        "Skipping malformed tool_call_result item: %s", single_tool
+                    )
+                    continue
+
+            if not session_state.loop_detector.is_looping(tool_name):
+                continue
+
+            loop_type = session_state.loop_detector.get_loop_type(tool_name)
+            logger.warning(f"Tool call loop detected for '{tool_name}': {loop_type}")
+
+            new_system_prompt = handle_stuck_state(system_prompt)
+            session_state.messages = await reset_system_prompt(
+                messages=session_state.messages,
+                system_prompt=new_system_prompt,
+            )
+
+            loop_message = (
+                f"Observation:\n"
+                f"⚠️ Tool call loop detected for '{tool_name}': {loop_type}\n\n"
+                "Current approach is not working. You MUST now provide a final answer to the user.\n"
+                "Please:\n"
+                "1. Stop trying the same approach\n"
+                "2. Provide your best response to the user based on what you know\n"
+                "3. Use <final_answer>Your response here</final_answer> format\n"
+                "4. Be helpful and explain any limitations if needed\n"
+                "5. Do NOT continue with more tool calls\n"
+                "\nYou MUST respond with <final_answer> tags now.\n"
+            )
+
+            event = Event(
+                type=EventType.TOOL_CALL_ERROR,
+                payload=ToolCallErrorPayload(
+                    tool_name=tool_name,
+                    error_message=loop_message,
+                ),
+                agent_name=self.agent_name,
+            )
+            if event_router:
+                await event_router(session_id=session_id, event=event)
+
+            session_state.messages.append(Message(role="user", content=loop_message))
+
+            if debug:
+                logger.info(
+                    f"Agent state changed from {session_state.state} to {AgentState.STUCK}"
+                )
+
+            session_state.state = AgentState.STUCK
+            session_state.loop_detector.reset(tool_name)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,9 +2,8 @@ from unittest.mock import AsyncMock
 import pytest
 import json
 from omnicoreagent.core.agents.base import BaseReactAgent
-from omnicoreagent.core.events.base import EventType
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
-from omnicoreagent.core.types import AgentState, Message, ParsedResponse, ToolCallResult, ToolError
+from omnicoreagent.core.types import ParsedResponse
 
 
 @pytest.fixture
@@ -272,92 +271,3 @@ async def test_run_prepares_internal_tools_once_for_prompt_and_execution(monkeyp
     assert len(tool_messages) == 1
     assert tool_messages[0]["metadata"]["tool"] == "internal_ping"
     assert "pong:runtime" in tool_messages[0]["content"]
-
-
-@pytest.mark.asyncio
-async def test_handle_tool_validation_error_records_loop_and_event(agent):
-    events = []
-    session_state = agent._get_session_state(session_id="chat796", debug=False)
-
-    async def event_router(session_id, event):
-        events.append({"session_id": session_id, "event": event})
-
-    tool_batch_name, tool_batch_args, obs_text, results = (
-        await agent._handle_tool_validation_error(
-            tool_error=ToolError(
-                observation="The tool named 'missing_tool' does not exist.",
-                tool_name="missing_tool",
-                tool_args={"query": "runtime"},
-            ),
-            session_state=session_state,
-            session_id="chat796",
-            event_router=event_router,
-        )
-    )
-
-    assert tool_batch_name == "missing_tool"
-    assert tool_batch_args == [{"query": "runtime"}]
-    assert obs_text == "The tool named 'missing_tool' does not exist."
-    assert results == [
-        {
-            "tool_name": "missing_tool",
-            "args": {"query": "runtime"},
-            "status": "error",
-            "data": None,
-            "message": "The tool named 'missing_tool' does not exist.",
-        }
-    ]
-    assert len(events) == 1
-    assert events[0]["session_id"] == "chat796"
-    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
-    assert events[0]["event"].payload.tool_name == "missing_tool"
-
-
-@pytest.mark.asyncio
-async def test_handle_tool_loop_state_marks_session_stuck(agent):
-    events = []
-    session_state = agent._get_session_state(session_id="chat800", debug=False)
-    session_state.messages = [Message(role="system", content="system")]
-
-    class FakeLoopDetector:
-        def __init__(self):
-            self.reset_tool_name = None
-
-        def is_looping(self, tool_name):
-            return tool_name == "alpha"
-
-        def get_loop_type(self, tool_name):
-            return ["consecutive_calls"]
-
-        def reset(self, tool_name=None):
-            self.reset_tool_name = tool_name
-
-    session_state.loop_detector = FakeLoopDetector()
-
-    async def event_router(session_id, event):
-        events.append({"session_id": session_id, "event": event})
-
-    await agent._handle_tool_loop_state(
-        tool_call_results=[
-            ToolCallResult(
-                tool_executor=None,
-                tool_name="alpha",
-                tool_args={},
-                tool_call_id="tool-call-alpha",
-            )
-        ],
-        session_state=session_state,
-        system_prompt="system",
-        session_id="chat800",
-        event_router=event_router,
-        debug=False,
-    )
-
-    assert session_state.state == AgentState.STUCK
-    assert session_state.loop_detector.reset_tool_name == "alpha"
-    assert session_state.messages[0].role == "system"
-    assert "Tool call loop detected" in session_state.messages[-1].content
-    assert len(events) == 1
-    assert events[0]["session_id"] == "chat800"
-    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
-    assert events[0]["event"].payload.tool_name == "alpha"

--- a/tests/test_tool_failure_handler.py
+++ b/tests/test_tool_failure_handler.py
@@ -1,0 +1,202 @@
+import json
+
+import pytest
+
+from omnicoreagent.core.agents.base import BaseReactAgent
+from omnicoreagent.core.events.base import EventType
+from omnicoreagent.core.tools.tool_failure_handler import ToolFailureHandler
+from omnicoreagent.core.types import (
+    AgentState,
+    Message,
+    ParsedResponse,
+    SessionState,
+    ToolCallResult,
+    ToolError,
+)
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+@pytest.fixture
+def handler():
+    return ToolFailureHandler(agent_name="test_agent")
+
+
+@pytest.fixture
+def session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_validation_error_records_loop_and_event(handler, session_state):
+    events = []
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    tool_batch_name, tool_batch_args, obs_text, results = (
+        await handler.handle_validation_error(
+            tool_error=ToolError(
+                observation="The tool named 'missing_tool' does not exist.",
+                tool_name="missing_tool",
+                tool_args={"query": "runtime"},
+            ),
+            session_state=session_state,
+            session_id="chat796",
+            event_router=event_router,
+        )
+    )
+
+    assert tool_batch_name == "missing_tool"
+    assert tool_batch_args == [{"query": "runtime"}]
+    assert obs_text == "The tool named 'missing_tool' does not exist."
+    assert results == [
+        {
+            "tool_name": "missing_tool",
+            "args": {"query": "runtime"},
+            "status": "error",
+            "data": None,
+            "message": "The tool named 'missing_tool' does not exist.",
+        }
+    ]
+    assert len(events) == 1
+    assert events[0]["session_id"] == "chat796"
+    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
+    assert events[0]["event"].payload.tool_name == "missing_tool"
+
+
+@pytest.mark.asyncio
+async def test_handle_loop_state_marks_session_stuck(handler, session_state):
+    events = []
+    session_state.messages = [Message(role="system", content="system")]
+
+    class FakeLoopDetector:
+        def __init__(self):
+            self.reset_tool_name = None
+
+        def is_looping(self, tool_name):
+            return tool_name == "alpha"
+
+        def get_loop_type(self, tool_name):
+            return ["consecutive_calls"]
+
+        def reset(self, tool_name=None):
+            self.reset_tool_name = tool_name
+
+    session_state.loop_detector = FakeLoopDetector()
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    async def reset_system_prompt(messages, system_prompt):
+        old_messages = messages[1:]
+        return [Message(role="system", content=system_prompt), *old_messages]
+
+    await handler.handle_loop_state(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=None,
+                tool_name="alpha",
+                tool_args={},
+                tool_call_id="tool-call-alpha",
+            )
+        ],
+        session_state=session_state,
+        system_prompt="system",
+        session_id="chat800",
+        event_router=event_router,
+        debug=False,
+        reset_system_prompt=reset_system_prompt,
+    )
+
+    assert session_state.state == AgentState.STUCK
+    assert session_state.loop_detector.reset_tool_name == "alpha"
+    assert session_state.messages[0].role == "system"
+    assert "Tool call loop detected" in session_state.messages[-1].content
+    assert len(events) == 1
+    assert events[0]["session_id"] == "chat800"
+    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
+    assert events[0]["event"].payload.tool_name == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_handle_loop_state_ignores_malformed_tool_call_results(
+    handler, session_state
+):
+    session_state.messages = [Message(role="system", content="system")]
+
+    class FakeLoopDetector:
+        def is_looping(self, tool_name):
+            raise AssertionError("Malformed tool calls should be skipped")
+
+    session_state.loop_detector = FakeLoopDetector()
+
+    async def reset_system_prompt(messages, system_prompt):
+        raise AssertionError("System prompt should not reset")
+
+    await handler.handle_loop_state(
+        tool_call_results=[object()],
+        session_state=session_state,
+        system_prompt="system",
+        session_id="chat800",
+        event_router=None,
+        debug=False,
+        reset_system_prompt=reset_system_prompt,
+    )
+
+    assert session_state.state == AgentState.IDLE
+    assert session_state.messages == [Message(role="system", content="system")]
+
+
+@pytest.mark.asyncio
+async def test_act_routes_tool_validation_error_through_failure_handler():
+    agent = BaseReactAgent(
+        agent_name="test_agent",
+        max_steps=5,
+        tool_call_timeout=10,
+    )
+    history = []
+    events = []
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    parsed_response = ParsedResponse(
+        action=True,
+        tool_calls=True,
+        data=json.dumps([{"tool": "missing_tool", "parameters": {"query": "x"}}]),
+    )
+
+    await agent.act(
+        parsed_response=parsed_response,
+        response="<tool_call><tool_name>missing_tool</tool_name></tool_call>",
+        add_message_to_history=add_message_to_history,
+        system_prompt="system",
+        sessions={},
+        local_tools=None,
+        session_id="chat802",
+        event_router=event_router,
+    )
+
+    observation_messages = [item for item in history if item["role"] == "user"]
+
+    assert observation_messages
+    assert "missing_tool" in observation_messages[-1]["content"]
+    assert events
+    assert events[0]["event"].type == EventType.TOOL_CALL_ERROR
+    assert events[0]["event"].payload.tool_name == "missing_tool"


### PR DESCRIPTION
## Summary
- add ToolFailureHandler for tool validation errors and loop/stuck-state handling
- remove validation-error and loop-state helper blocks from BaseReactAgent
- add focused tests for validation errors, loop-triggered stuck state, malformed tool-call inputs, and an act() integration path for missing-tool errors

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py src/omnicoreagent/core/tools/tool_failure_handler.py tests/test_base.py tests/test_tool_failure_handler.py
- uv run pytest tests/test_tool_failure_handler.py tests/test_base.py tests/test_tool_batch_runner.py tests/test_tool_observation.py -q
- uv run pytest tests/test_tool_failure_handler.py tests/test_tool_observation.py tests/test_tool_batch_runner.py tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run ruff check .
- uv run pytest -q
- uv run hatch build
- git diff --check