### PR TITLE
Extract tool runtime registry

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -34,6 +34,7 @@ from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.tools.tool_batch_runner import ToolBatchRunner
 from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
 from omnicoreagent.core.tools.tool_failure_handler import ToolFailureHandler
+from omnicoreagent.core.tools.tool_runtime_registry import ToolRuntimeRegistry
 from omnicoreagent.core.utils import (
     RobustLoopDetector,
     logger,
@@ -57,16 +58,6 @@ from omnicoreagent.core.events.base import (
     SubAgentCallResultPayload,
     SubAgentCallErrorPayload,
 )
-from omnicoreagent.core.tools.advance_tools_use import (
-    build_tool_registry_advance_tools_use,
-)
-from omnicoreagent.core.tools.memory_tool.memory_tool import (
-    build_tool_registry_memory_tool,
-)
-from omnicoreagent.core.tools.artifact_tool import (
-    build_tool_registry_artifact_tool,
-)
-from omnicoreagent.core.skills.tools import build_skill_tools
 from omnicoreagent.core.context_manager import (
     AgentLoopContextManager,
     ContextManagementConfig,
@@ -144,6 +135,15 @@ class BaseReactAgent:
         self.tool_batch_runner = ToolBatchRunner(
             agent_name=self.agent_name,
             tool_call_timeout=self.tool_call_timeout,
+        )
+        self.tool_runtime_registry = ToolRuntimeRegistry(
+            register_internal_tool=self.register_internal_tool,
+            tool_offloader=self.tool_offloader,
+            enable_advanced_tool_use=self.enable_advanced_tool_use,
+            enable_subagents=self.enable_subagents,
+            enable_workspace_memory=self.enable_workspace_memory,
+            enable_agent_skills=self.enable_agent_skills,
+            skill_manager=self.skill_manager,
         )
 
     def init_skills(self):
@@ -404,169 +404,6 @@ class BaseReactAgent:
         finally:
             session_state.state = previous_state
 
-    async def prepare_runtime_tools(self, local_tools: Any = None):
-        registry = local_tools
-        needs_internal_registry = (
-            self.enable_advanced_tool_use
-            or self.enable_subagents
-            or self.enable_workspace_memory
-            or self.tool_offloader.config.enabled
-            or (self.enable_agent_skills and self.skill_manager)
-        )
-
-        if registry is None and needs_internal_registry:
-            registry = self.register_internal_tool
-
-        if registry is None:
-            return None
-
-        if self.enable_advanced_tool_use:
-            await build_tool_registry_advance_tools_use(registry=registry)
-
-        if self.enable_workspace_memory:
-            build_tool_registry_memory_tool(
-                backend=None,
-                registry=registry,
-            )
-
-        if self.tool_offloader.config.enabled:
-            build_tool_registry_artifact_tool(
-                offloader=self.tool_offloader,
-                registry=registry,
-            )
-
-        if self.enable_agent_skills and self.skill_manager:
-            build_skill_tools(
-                skill_manager=self.skill_manager,
-                registry=registry,
-            )
-
-        return registry
-
-    async def get_tools_registry(
-        self, mcp_tools: dict = None, local_tools: Any = None
-    ) -> str:
-        lines = ["Available tools:"]
-
-        def format_param_type(param_info: dict) -> str:
-            """Format parameter type with nested structure details."""
-            p_type = param_info.get("type", "any")
-
-            if p_type == "array":
-                items = param_info.get("items", {})
-                if items:
-                    item_type = items.get("type", "any")
-                    if item_type == "object":
-                        props = items.get("properties", {})
-                        if props:
-                            fields = ", ".join(
-                                [
-                                    f'"{k}": {v.get("type", "any")}'
-                                    for k, v in props.items()
-                                ]
-                            )
-                            return f"array of objects ({{{fields}}})"
-                        return "array of objects"
-                    else:
-                        return f"array of {item_type}s"
-                return "array"
-
-            elif p_type == "object":
-                props = param_info.get("properties", {})
-                if props:
-                    fields = ", ".join(
-                        [f'"{k}": {v.get("type", "any")}' for k, v in props.items()]
-                    )
-                    return f"object ({{{fields}}})"
-                return "object"
-
-            return p_type
-
-        def format_param_description(param_info: dict) -> str:
-            """Format parameter description with structure examples."""
-            p_desc = param_info.get("description", "").replace("\n", " ").strip()
-            p_type = param_info.get("type", "any")
-
-            if p_type == "array":
-                items = param_info.get("items", {})
-                if items.get("type") == "object":
-                    props = items.get("properties", {})
-                    if props:
-                        example_fields = []
-                        for k, v in props.items():
-                            v_type = v.get("type", "any")
-                            if v_type == "string":
-                                example_fields.append(f'"{k}": "..."')
-                            elif v_type == "number":
-                                example_fields.append(f'"{k}": 0')
-                            elif v_type == "boolean":
-                                example_fields.append(f'"{k}": true')
-                            else:
-                                example_fields.append(f'"{k}": ...')
-
-                        example = "{" + ", ".join(example_fields) + "}"
-                        if p_desc:
-                            p_desc += f". Example: {example}"
-                        else:
-                            p_desc = f"Example: {example}"
-
-            return p_desc if p_desc else "No description"
-
-        try:
-            if local_tools:
-                local_tools_list = local_tools.get_available_tools()
-                if local_tools_list:
-                    for tool in local_tools_list:
-                        if isinstance(tool, dict):
-                            name = tool.get("name", "unknown")
-                            desc = (
-                                tool.get("description", "").replace("\n", " ").strip()
-                            )
-                            lines.append(f"\n{name}: {desc}")
-                            input_schema = tool.get("inputSchema", {})
-                            params = input_schema.get("properties", {})
-                            required = input_schema.get("required", [])
-                            if params:
-                                for param_name, param_info in params.items():
-                                    p_type = format_param_type(param_info)
-                                    p_desc = format_param_description(param_info)
-                                    is_req = (
-                                        " (required)" if param_name in required else ""
-                                    )
-                                    lines.append(
-                                        f"  - {param_name}: {p_type}{is_req} — {p_desc}"
-                                    )
-
-            if mcp_tools and not self.enable_advanced_tool_use:
-                for server_name, tools in mcp_tools.items():
-                    if not tools:
-                        continue
-                    for tool in tools:
-                        if hasattr(tool, "name"):
-                            name = str(tool.name)
-                            desc = str(tool.description).replace("\n", " ").strip()
-                            lines.append(f"\n{name}: {desc}")
-                            if hasattr(tool, "inputSchema") and tool.inputSchema:
-                                params = tool.inputSchema.get("properties", {})
-                                required = tool.inputSchema.get("required", [])
-                                for param_name, param_info in params.items():
-                                    p_type = format_param_type(param_info)
-                                    p_desc = format_param_description(param_info)
-                                    is_req = (
-                                        " (required)" if param_name in required else ""
-                                    )
-                                    lines.append(
-                                        f"  - {param_name}: {p_type}{is_req} — {p_desc}"
-                                    )
-
-            if len(lines) == 1:
-                return "No tools available"
-        except Exception as e:
-            logger.error(f"Error building compact tool registry: {e}")
-            return "No tools available"
-
-        return "\n".join(lines)
-
     async def prepare_initial_messages(
         self,
         session_state,
@@ -587,7 +424,7 @@ class BaseReactAgent:
         """
         tasks = {}
 
-        tasks["tools"] = self.get_tools_registry(
+        tasks["tools"] = self.tool_runtime_registry.render_prompt_registry(
             mcp_tools=mcp_tools, local_tools=local_tools
         )
 
@@ -966,7 +803,9 @@ class BaseReactAgent:
             session_id=session_id,
             metadata={"agent_name": self.agent_name},
         )
-        runtime_local_tools = await self.prepare_runtime_tools(local_tools=local_tools)
+        runtime_local_tools = await self.tool_runtime_registry.prepare_tools(
+            local_tools=local_tools
+        )
         await self.prepare_initial_messages(
             system_prompt=system_prompt,
             session_state=session_state,

--- a/src/omnicoreagent/core/tools/tool_runtime_registry.py
+++ b/src/omnicoreagent/core/tools/tool_runtime_registry.py
@@ -1,0 +1,204 @@
+from typing import Any
+
+from omnicoreagent.core.skills.tools import build_skill_tools
+from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
+from omnicoreagent.core.tools.advance_tools_use import (
+    build_tool_registry_advance_tools_use,
+)
+from omnicoreagent.core.tools.artifact_tool import build_tool_registry_artifact_tool
+from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.tools.memory_tool.memory_tool import (
+    build_tool_registry_memory_tool,
+)
+from omnicoreagent.core.utils import logger
+
+
+class ToolRuntimeRegistry:
+    """Prepare executable runtime tools and render tool schemas for prompts."""
+
+    def __init__(
+        self,
+        register_internal_tool: ToolRegistry,
+        tool_offloader: ToolResponseOffloader,
+        enable_advanced_tool_use: bool = False,
+        enable_subagents: bool = False,
+        enable_workspace_memory: bool = False,
+        enable_agent_skills: bool = False,
+        skill_manager: Any = None,
+    ):
+        self.register_internal_tool = register_internal_tool
+        self.tool_offloader = tool_offloader
+        self.enable_advanced_tool_use = enable_advanced_tool_use
+        self.enable_subagents = enable_subagents
+        self.enable_workspace_memory = enable_workspace_memory
+        self.enable_agent_skills = enable_agent_skills
+        self.skill_manager = skill_manager
+
+    async def prepare_tools(self, local_tools: Any = None):
+        registry = local_tools
+        needs_internal_registry = (
+            self.enable_advanced_tool_use
+            or self.enable_subagents
+            or self.enable_workspace_memory
+            or self.tool_offloader.config.enabled
+            or (self.enable_agent_skills and self.skill_manager)
+        )
+
+        if registry is None and needs_internal_registry:
+            registry = self.register_internal_tool
+
+        if registry is None:
+            return None
+
+        if self.enable_advanced_tool_use:
+            await build_tool_registry_advance_tools_use(registry=registry)
+
+        if self.enable_workspace_memory:
+            build_tool_registry_memory_tool(
+                backend=None,
+                registry=registry,
+            )
+
+        if self.tool_offloader.config.enabled:
+            build_tool_registry_artifact_tool(
+                offloader=self.tool_offloader,
+                registry=registry,
+            )
+
+        if self.enable_agent_skills and self.skill_manager:
+            build_skill_tools(
+                skill_manager=self.skill_manager,
+                registry=registry,
+            )
+
+        return registry
+
+    async def render_prompt_registry(
+        self, mcp_tools: dict | None = None, local_tools: Any = None
+    ) -> str:
+        lines = ["Available tools:"]
+
+        try:
+            if local_tools:
+                self._append_local_tools(lines=lines, local_tools=local_tools)
+
+            if mcp_tools and not self.enable_advanced_tool_use:
+                self._append_mcp_tools(lines=lines, mcp_tools=mcp_tools)
+
+            if len(lines) == 1:
+                return "No tools available"
+        except Exception as e:
+            logger.error(f"Error building compact tool registry: {e}")
+            return "No tools available"
+
+        return "\n".join(lines)
+
+    def _append_local_tools(self, lines: list[str], local_tools: Any) -> None:
+        local_tools_list = local_tools.get_available_tools()
+        if not local_tools_list:
+            return
+
+        for tool in local_tools_list:
+            if not isinstance(tool, dict):
+                continue
+
+            name = tool.get("name", "unknown")
+            desc = tool.get("description", "").replace("\n", " ").strip()
+            lines.append(f"\n{name}: {desc}")
+            self._append_schema_params(lines=lines, input_schema=tool.get("inputSchema", {}))
+
+    def _append_mcp_tools(self, lines: list[str], mcp_tools: dict) -> None:
+        for _server_name, tools in mcp_tools.items():
+            if not tools:
+                continue
+            for tool in tools:
+                if not hasattr(tool, "name"):
+                    continue
+
+                name = str(tool.name)
+                desc = str(tool.description).replace("\n", " ").strip()
+                lines.append(f"\n{name}: {desc}")
+                if hasattr(tool, "inputSchema") and tool.inputSchema:
+                    self._append_schema_params(lines=lines, input_schema=tool.inputSchema)
+
+    def _append_schema_params(
+        self, lines: list[str], input_schema: dict[str, Any]
+    ) -> None:
+        params = input_schema.get("properties", {})
+        required = input_schema.get("required", [])
+        if not params:
+            return
+
+        for param_name, param_info in params.items():
+            param_type = self.format_param_type(param_info)
+            param_desc = self.format_param_description(param_info)
+            required_suffix = " (required)" if param_name in required else ""
+            lines.append(
+                f"  - {param_name}: {param_type}{required_suffix} — {param_desc}"
+            )
+
+    @staticmethod
+    def format_param_type(param_info: dict) -> str:
+        p_type = param_info.get("type", "any")
+
+        if p_type == "array":
+            items = param_info.get("items", {})
+            if items:
+                item_type = items.get("type", "any")
+                if item_type == "object":
+                    props = items.get("properties", {})
+                    if props:
+                        fields = ", ".join(
+                            [
+                                f'"{key}": {value.get("type", "any")}'
+                                for key, value in props.items()
+                            ]
+                        )
+                        return f"array of objects ({{{fields}}})"
+                    return "array of objects"
+                return f"array of {item_type}s"
+            return "array"
+
+        if p_type == "object":
+            props = param_info.get("properties", {})
+            if props:
+                fields = ", ".join(
+                    [
+                        f'"{key}": {value.get("type", "any")}'
+                        for key, value in props.items()
+                    ]
+                )
+                return f"object ({{{fields}}})"
+            return "object"
+
+        return p_type
+
+    @staticmethod
+    def format_param_description(param_info: dict) -> str:
+        param_desc = param_info.get("description", "").replace("\n", " ").strip()
+        param_type = param_info.get("type", "any")
+
+        if param_type == "array":
+            items = param_info.get("items", {})
+            if items.get("type") == "object":
+                props = items.get("properties", {})
+                if props:
+                    example_fields = []
+                    for key, value in props.items():
+                        value_type = value.get("type", "any")
+                        if value_type == "string":
+                            example_fields.append(f'"{key}": "..."')
+                        elif value_type == "number":
+                            example_fields.append(f'"{key}": 0')
+                        elif value_type == "boolean":
+                            example_fields.append(f'"{key}": true')
+                        else:
+                            example_fields.append(f'"{key}": ...')
+
+                    example = "{" + ", ".join(example_fields) + "}"
+                    if param_desc:
+                        param_desc += f". Example: {example}"
+                    else:
+                        param_desc = f"Example: {example}"
+
+        return param_desc if param_desc else "No description"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -220,7 +220,7 @@ async def test_run_prepares_internal_tools_once_for_prompt_and_execution(monkeyp
         return registry
 
     monkeypatch.setattr(
-        "omnicoreagent.core.agents.base.build_tool_registry_advance_tools_use",
+        "omnicoreagent.core.tools.tool_runtime_registry.build_tool_registry_advance_tools_use",
         fake_build_internal_tools,
     )
 

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -509,7 +509,9 @@ class TestOmniCoreAgentSubagents:
         )
 
         await agent.initialize()
-        runtime_tools = await agent.agent.prepare_runtime_tools(agent.local_tools)
+        runtime_tools = await agent.agent.tool_runtime_registry.prepare_tools(
+            agent.local_tools
+        )
 
         tool_names = [tool.name for tool in runtime_tools.list_tools()]
         assert "spawn_subagents" in tool_names

--- a/tests/test_tool_runtime_registry.py
+++ b/tests/test_tool_runtime_registry.py
@@ -1,0 +1,165 @@
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
+from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.tools.tool_runtime_registry import ToolRuntimeRegistry
+
+
+@pytest.fixture
+def internal_registry():
+    return ToolRegistry()
+
+
+@pytest.fixture
+def offloader(tmp_path):
+    return ToolResponseOffloader(
+        config={"enabled": False},
+        base_dir=str(tmp_path),
+    )
+
+
+def make_runtime(internal_registry, offloader, **kwargs):
+    return ToolRuntimeRegistry(
+        register_internal_tool=internal_registry,
+        tool_offloader=offloader,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_tools_returns_none_without_any_tool_sources(
+    internal_registry, offloader
+):
+    runtime = make_runtime(internal_registry, offloader)
+
+    assert await runtime.prepare_tools(local_tools=None) is None
+
+
+@pytest.mark.asyncio
+async def test_prepare_tools_uses_internal_registry_when_harness_tools_enabled(
+    monkeypatch, internal_registry, offloader
+):
+    runtime = make_runtime(
+        internal_registry,
+        offloader,
+        enable_advanced_tool_use=True,
+    )
+
+    async def fake_build_advanced_tools(registry):
+        @registry.register_tool(
+            name="internal_ping",
+            inputSchema={
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            },
+            description="Internal ping.",
+        )
+        async def internal_ping(value: str):
+            return value
+
+        return registry
+
+    monkeypatch.setattr(
+        "omnicoreagent.core.tools.tool_runtime_registry.build_tool_registry_advance_tools_use",
+        fake_build_advanced_tools,
+    )
+
+    prepared = await runtime.prepare_tools(local_tools=None)
+
+    assert prepared is internal_registry
+    assert "internal_ping" in [tool.name for tool in prepared.list_tools()]
+
+
+@pytest.mark.asyncio
+async def test_render_prompt_registry_formats_local_tool_schema(
+    internal_registry, offloader
+):
+    runtime = make_runtime(internal_registry, offloader)
+    local_tools = ToolRegistry()
+
+    @local_tools.register_tool(
+        name="search_docs",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query.",
+                },
+                "filters": {
+                    "type": "array",
+                    "description": "Filter list.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field": {"type": "string"},
+                            "active": {"type": "boolean"},
+                        },
+                    },
+                },
+            },
+            "required": ["query"],
+        },
+        description="Search documentation.\nUse for docs.",
+    )
+    async def search_docs(query: str, filters: list | None = None):
+        return {"query": query, "filters": filters or []}
+
+    rendered = await runtime.render_prompt_registry(local_tools=local_tools)
+
+    assert "search_docs: Search documentation. Use for docs." in rendered
+    assert "query: string (required) — Search query." in rendered
+    assert 'filters: array of objects ({"field": string, "active": boolean})' in rendered
+    assert 'Example: {"field": "...", "active": true}' in rendered
+
+
+@pytest.mark.asyncio
+async def test_render_prompt_registry_includes_mcp_tools_when_advanced_tools_disabled(
+    internal_registry, offloader
+):
+    runtime = make_runtime(
+        internal_registry,
+        offloader,
+        enable_advanced_tool_use=False,
+    )
+    mcp_tool = SimpleNamespace(
+        name="mcp_search",
+        description="MCP search.",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string", "description": "Query."}},
+            "required": ["query"],
+        },
+    )
+
+    rendered = await runtime.render_prompt_registry(mcp_tools={"server": [mcp_tool]})
+
+    assert "mcp_search: MCP search." in rendered
+    assert "query: string (required) — Query." in rendered
+
+
+@pytest.mark.asyncio
+async def test_render_prompt_registry_hides_mcp_tools_when_advanced_tools_enabled(
+    internal_registry, offloader
+):
+    runtime = make_runtime(
+        internal_registry,
+        offloader,
+        enable_advanced_tool_use=True,
+    )
+    mcp_tool = SimpleNamespace(
+        name="mcp_search",
+        description="MCP search.",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string", "description": "Query."}},
+            "required": ["query"],
+        },
+    )
+
+    rendered = await runtime.render_prompt_registry(mcp_tools={"server": [mcp_tool]})
+
+    assert rendered == "No tools available"


### PR DESCRIPTION
## Summary
- add ToolRuntimeRegistry for internal tool preparation and prompt registry rendering
- remove runtime tool preparation and tool schema formatting from BaseReactAgent
- add direct coverage for internal registry preparation, local tool schema rendering, MCP prompt inclusion, and advanced-tool MCP hiding behavior
- update base/subagent tests to use the new registry boundary

## Verification
- uv run ruff check src/omnicoreagent/core/agents/base.py src/omnicoreagent/core/tools/tool_runtime_registry.py tests/test_tool_runtime_registry.py tests/test_base.py tests/test_subagents.py
- uv run pytest tests/test_tool_runtime_registry.py tests/test_base.py tests/test_subagents.py -q
- uv run pytest tests/test_tool_runtime_registry.py tests/test_tool_batch_runner.py tests/test_tool_observation.py tests/test_tool_failure_handler.py tests/test_tool_response_offloader.py tests/test_tool_output_guardrail.py tests/test_mcp_response_guardrail.py -q
- uv run ruff check .
- uv run pytest -q
- uv run hatch build
- git diff --check