### PR TITLE
Extract message history context loader

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -60,6 +60,7 @@ from omnicoreagent.core.tool_response_offloader import (
     ToolResponseOffloader,
     OffloadConfig,
 )
+from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
 from omnicoreagent.core.tools.tool_observation import ToolObservationHandler
 from omnicoreagent.core.guardrails import PromptInjectionGuard
 from omnicoreagent.core.agents.xml_parser import (
@@ -126,6 +127,9 @@ class BaseReactAgent:
         )
         self.tool_call_resolver = ToolCallResolver(guardrail=self.guardrail)
         self.tool_failure_handler = ToolFailureHandler(agent_name=self.agent_name)
+        self.message_history_loader = AgentMessageHistoryLoader(
+            agent_name=self.agent_name
+        )
         self.tool_batch_runner = ToolBatchRunner(
             agent_name=self.agent_name,
             tool_call_timeout=self.tool_call_timeout,
@@ -189,86 +193,6 @@ class BaseReactAgent:
                 await event_router(session_id=session_id, event=event)
 
         return parse_action_or_answer(response, debug=debug)
-
-    @track("memory_processing")
-    async def update_llm_working_memory(
-        self,
-        message_history: Callable[[], Any],
-        session_id: str,
-        llm_connection: Callable,
-        debug: bool,
-    ):
-        """Update the LLM's working memory with the current message history and process memory asynchronously"""
-
-        short_term_memory_message_history = await message_history(
-            agent_name=self.agent_name, session_id=session_id
-        )
-        if not short_term_memory_message_history:
-            return
-
-        validated_messages = [
-            Message.model_validate(msg) if isinstance(msg, dict) else msg
-            for msg in short_term_memory_message_history
-        ]
-        session_state = self._get_session_state(session_id=session_id, debug=debug)
-        for message in validated_messages:
-            role = message.role
-            metadata = message.metadata
-
-            if role == "user":
-                if not message.content.strip().startswith("<observations>"):
-                    self._try_flush_pending(session_id=session_id, debug=debug)
-                    session_state.messages.append(
-                        Message(role="user", content=message.content)
-                    )
-
-            elif role == "assistant":
-                if metadata.has_tool_calls:
-                    self._try_flush_pending(session_id=session_id, debug=debug)
-                    session_state.assistant_with_tool_calls = {
-                        "role": "assistant",
-                        "content": message.content,
-                        "tool_calls": (
-                            [tc.model_dump() for tc in metadata.tool_calls]
-                            if metadata.tool_calls
-                            else []
-                        ),
-                    }
-                    session_state.pending_tool_responses = []
-                else:
-                    self._try_flush_pending(session_id=session_id, debug=debug)
-                    session_state.messages.append(
-                        Message(role="assistant", content=message.content)
-                    )
-
-            elif role == "tool":
-                session_state.pending_tool_responses.append(
-                    {
-                        "role": "tool",
-                        "content": message.content,
-                        "tool_call_id": metadata.tool_call_id,
-                    }
-                )
-                self._try_flush_pending(session_id=session_id, debug=debug)
-
-            else:
-                logger.warning(f"Unknown message role encountered: {role}")
-
-    def _try_flush_pending(self, session_id: str, debug: bool):
-        session_state = self._get_session_state(session_id=session_id, debug=debug)
-        if session_state.assistant_with_tool_calls:
-            expected = {
-                tc["id"]
-                for tc in session_state.assistant_with_tool_calls.get("tool_calls", [])
-            }
-            actual = {
-                resp["tool_call_id"] for resp in session_state.pending_tool_responses
-            }
-            if not (expected - actual):
-                session_state.messages.append(session_state.assistant_with_tool_calls)
-                session_state.messages.extend(session_state.pending_tool_responses)
-                session_state.assistant_with_tool_calls = None
-                session_state.pending_tool_responses = []
 
     async def resolve_tool_call_request(
         self,
@@ -411,7 +335,6 @@ class BaseReactAgent:
         session_state,
         system_prompt: str,
         session_id: str,
-        llm_connection: Callable,
         message_history: Callable[[], Any],
         mcp_tools: dict = None,
         local_tools: Any = None,
@@ -430,11 +353,10 @@ class BaseReactAgent:
             mcp_tools=mcp_tools, local_tools=local_tools
         )
 
-        tasks["history"] = self.update_llm_working_memory(
+        tasks["history"] = self.message_history_loader.load(
             message_history=message_history,
             session_id=session_id,
-            llm_connection=llm_connection,
-            debug=debug,
+            session_state=session_state,
         )
 
         try:
@@ -697,7 +619,6 @@ class BaseReactAgent:
         await self.prepare_initial_messages(
             system_prompt=system_prompt,
             session_state=session_state,
-            llm_connection=llm_connection,
             message_history=message_history,
             mcp_tools=mcp_tools,
             local_tools=runtime_local_tools,

--- a/src/omnicoreagent/core/agents/message_history.py
+++ b/src/omnicoreagent/core/agents/message_history.py
@@ -1,0 +1,140 @@
+from collections.abc import Callable
+from typing import Any
+
+from omnicoreagent.core.types import Message, SessionState
+from omnicoreagent.core.utils import logger, track
+
+
+class AgentMessageHistoryLoader:
+    """Rebuild clean LLM context from persisted conversation history.
+
+    Observation blocks are transient tool feedback for the previous run, so they
+    are intentionally not replayed into a new request. Assistant tool-call
+    messages are restored only with their matching tool responses, preserving
+    provider protocol integrity while keeping the next context window clean.
+    """
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    @track("memory_processing")
+    async def load(
+        self,
+        *,
+        message_history: Callable[..., Any],
+        session_id: str,
+        session_state: SessionState,
+    ) -> None:
+        stored_messages = await message_history(
+            agent_name=self.agent_name, session_id=session_id
+        )
+        if not stored_messages:
+            return
+
+        for message in self._validated_messages(stored_messages):
+            self._apply_message(message=message, session_state=session_state)
+
+    def _validated_messages(self, stored_messages: list[Any]) -> list[Message]:
+        return [
+            Message.model_validate(message) if isinstance(message, dict) else message
+            for message in stored_messages
+        ]
+
+    def _apply_message(self, message: Message, session_state: SessionState) -> None:
+        if message.role == "user":
+            self._apply_user_message(message=message, session_state=session_state)
+            return
+        if message.role == "assistant":
+            self._apply_assistant_message(message=message, session_state=session_state)
+            return
+        if message.role == "tool":
+            self._apply_tool_message(message=message, session_state=session_state)
+            return
+        logger.warning(f"Unknown message role encountered: {message.role}")
+
+    def _apply_user_message(
+        self, message: Message, session_state: SessionState
+    ) -> None:
+        if message.content.strip().startswith("<observations>"):
+            return
+
+        self._clear_or_flush_pending(session_state=session_state)
+        session_state.messages.append(Message(role="user", content=message.content))
+
+    def _apply_assistant_message(
+        self, message: Message, session_state: SessionState
+    ) -> None:
+        metadata = message.metadata
+        if metadata and metadata.has_tool_calls:
+            self._clear_or_flush_pending(session_state=session_state)
+            session_state.assistant_with_tool_calls = {
+                "role": "assistant",
+                "content": message.content,
+                "tool_calls": (
+                    [tool_call.model_dump() for tool_call in metadata.tool_calls]
+                    if metadata.tool_calls
+                    else []
+                ),
+            }
+            session_state.pending_tool_responses = []
+            return
+
+        self._clear_or_flush_pending(session_state=session_state)
+        session_state.messages.append(Message(role="assistant", content=message.content))
+
+    def _apply_tool_message(
+        self, message: Message, session_state: SessionState
+    ) -> None:
+        metadata = message.metadata
+        tool_call_id = metadata.tool_call_id if metadata else message.tool_call_id
+        if not tool_call_id:
+            logger.warning("Skipping tool message without tool_call_id.")
+            return
+
+        session_state.pending_tool_responses.append(
+            {
+                "role": "tool",
+                "content": message.content,
+                "tool_call_id": str(tool_call_id),
+            }
+        )
+        self.flush_pending(session_state=session_state)
+
+    def _clear_or_flush_pending(self, session_state: SessionState) -> None:
+        if self.flush_pending(session_state=session_state):
+            return
+        self.discard_pending(session_state=session_state)
+
+    def flush_pending(self, session_state: SessionState) -> bool:
+        if not session_state.assistant_with_tool_calls:
+            return True
+
+        expected = {
+            str(tool_call["id"])
+            for tool_call in session_state.assistant_with_tool_calls.get(
+                "tool_calls", []
+            )
+        }
+        actual = {
+            str(response["tool_call_id"])
+            for response in session_state.pending_tool_responses
+        }
+        if expected - actual:
+            return False
+
+        session_state.messages.append(session_state.assistant_with_tool_calls)
+        session_state.messages.extend(session_state.pending_tool_responses)
+        session_state.assistant_with_tool_calls = None
+        session_state.pending_tool_responses = []
+        return True
+
+    def discard_pending(self, session_state: SessionState) -> None:
+        if not (
+            session_state.assistant_with_tool_calls
+            or session_state.pending_tool_responses
+        ):
+            return
+
+        logger.warning("Discarding incomplete tool-call history before new turn.")
+        session_state.assistant_with_tool_calls = None
+        session_state.pending_tool_responses = []

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -52,19 +52,6 @@ async def test_extract_action_or_answer_fallback_error(agent):
 
 
 @pytest.mark.asyncio
-async def test_update_llm_working_memory_empty(agent):
-    message_history = AsyncMock(return_value=[])
-    await agent.update_llm_working_memory(
-        message_history=message_history,
-        session_id="chat456",
-        llm_connection=AsyncMock(),
-        debug=False,
-    )
-    session_state = agent._get_session_state("chat456", debug=False)
-    assert len(session_state.messages) == 0
-
-
-@pytest.mark.asyncio
 async def test_act_executes_tool_name_with_and_as_literal(agent):
     registry = ToolRegistry()
     history = []

--- a/tests/test_message_history.py
+++ b/tests/test_message_history.py
@@ -1,0 +1,228 @@
+import pytest
+
+from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
+from omnicoreagent.core.types import (
+    AgentState,
+    Message,
+    SessionState,
+    ToolCall,
+    ToolCallMetadata,
+    ToolFunction,
+)
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+TOOL_ALPHA_ID = "11111111-1111-1111-1111-111111111111"
+TOOL_BETA_ID = "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.fixture
+def session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+@pytest.fixture
+def loader():
+    return AgentMessageHistoryLoader(agent_name="test_agent")
+
+
+@pytest.mark.asyncio
+async def test_load_empty_history_leaves_messages_empty(loader, session_state):
+    async def message_history(agent_name, session_id):
+        return []
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-1",
+        session_state=session_state,
+    )
+
+    assert session_state.messages == []
+
+
+@pytest.mark.asyncio
+async def test_load_skips_observation_user_messages(loader, session_state):
+    async def message_history(agent_name, session_id):
+        return [
+            Message(role="user", content="start"),
+            Message(role="user", content="<observations><tool>old</tool></observations>"),
+            Message(role="assistant", content="answer"),
+        ]
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-2",
+        session_state=session_state,
+    )
+
+    assert [message.content for message in session_state.messages] == [
+        "start",
+        "answer",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_accepts_dict_messages(loader, session_state):
+    async def message_history(agent_name, session_id):
+        return [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-3",
+        session_state=session_state,
+    )
+
+    assert [message.role for message in session_state.messages] == [
+        "user",
+        "assistant",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_pairs_assistant_tool_call_with_tool_responses(
+    loader, session_state
+):
+    tool_metadata = ToolCallMetadata(
+        has_tool_calls=True,
+        tool_call_id=TOOL_ALPHA_ID,
+        tool_calls=[
+            ToolCall(
+                id=TOOL_ALPHA_ID,
+                function=ToolFunction(name="alpha", arguments='{"value": "one"}'),
+            ),
+            ToolCall(
+                id=TOOL_BETA_ID,
+                function=ToolFunction(name="beta", arguments='{"value": "two"}'),
+            ),
+        ],
+    )
+
+    async def message_history(agent_name, session_id):
+        return [
+            Message(role="assistant", content="<tool_calls />", metadata=tool_metadata),
+            Message(
+                role="tool",
+                content="alpha result",
+                metadata=ToolCallMetadata(tool_call_id=TOOL_ALPHA_ID),
+            ),
+            Message(
+                role="tool",
+                content="beta result",
+                metadata=ToolCallMetadata(tool_call_id=TOOL_BETA_ID),
+            ),
+        ]
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-4",
+        session_state=session_state,
+    )
+
+    assert len(session_state.messages) == 3
+    assert session_state.messages[0]["role"] == "assistant"
+    assert session_state.messages[1]["tool_call_id"] == TOOL_ALPHA_ID
+    assert session_state.messages[2]["tool_call_id"] == TOOL_BETA_ID
+    assert session_state.assistant_with_tool_calls is None
+    assert session_state.pending_tool_responses == []
+
+
+@pytest.mark.asyncio
+async def test_load_keeps_incomplete_tool_batch_pending(loader, session_state):
+    tool_metadata = ToolCallMetadata(
+        has_tool_calls=True,
+        tool_call_id=TOOL_ALPHA_ID,
+        tool_calls=[
+            ToolCall(
+                id=TOOL_ALPHA_ID,
+                function=ToolFunction(name="alpha", arguments="{}"),
+            ),
+            ToolCall(
+                id=TOOL_BETA_ID,
+                function=ToolFunction(name="beta", arguments="{}"),
+            ),
+        ],
+    )
+
+    async def message_history(agent_name, session_id):
+        return [
+            Message(role="assistant", content="<tool_calls />", metadata=tool_metadata),
+            Message(
+                role="tool",
+                content="alpha result",
+                metadata=ToolCallMetadata(tool_call_id=TOOL_ALPHA_ID),
+            ),
+        ]
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-5",
+        session_state=session_state,
+    )
+
+    assert session_state.messages == []
+    assert session_state.assistant_with_tool_calls is not None
+    assert len(session_state.pending_tool_responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_load_drops_incomplete_tool_batch_before_next_user_turn(
+    loader, session_state
+):
+    tool_metadata = ToolCallMetadata(
+        has_tool_calls=True,
+        tool_calls=[
+            ToolCall(
+                id=TOOL_ALPHA_ID,
+                function=ToolFunction(name="alpha", arguments="{}"),
+            ),
+            ToolCall(
+                id=TOOL_BETA_ID,
+                function=ToolFunction(name="beta", arguments="{}"),
+            ),
+        ],
+    )
+
+    async def message_history(agent_name, session_id):
+        return [
+            Message(role="assistant", content="<tool_calls />", metadata=tool_metadata),
+            Message(
+                role="tool",
+                content="alpha result",
+                metadata=ToolCallMetadata(tool_call_id=TOOL_ALPHA_ID),
+            ),
+            Message(role="user", content="next request"),
+        ]
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-6",
+        session_state=session_state,
+    )
+
+    assert [message.content for message in session_state.messages] == ["next request"]
+    assert session_state.assistant_with_tool_calls is None
+    assert session_state.pending_tool_responses == []
+
+
+@pytest.mark.asyncio
+async def test_load_skips_tool_message_without_tool_call_id(loader, session_state):
+    async def message_history(agent_name, session_id):
+        return [Message(role="tool", content="orphan tool")]
+
+    await loader.load(
+        message_history=message_history,
+        session_id="chat-7",
+        session_state=session_state,
+    )
+
+    assert session_state.messages == []
+    assert session_state.pending_tool_responses == []

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -7,6 +7,15 @@ from fastapi.testclient import TestClient
 from omnicoreagent import OmniCoreAgent, OmniServe, OmniServeConfig
 from omnicoreagent.serve.resilience import CircuitBreaker, CircuitBreakerConfig, CircuitBreakerOpenError
 
+
+@pytest.fixture(autouse=True)
+def isolate_omniserve_env(monkeypatch):
+    """Keep local dotenv values from changing explicit test config."""
+    for key in list(os.environ):
+        if key.startswith("OMNISERVE_"):
+            monkeypatch.delenv(key, raising=False)
+
+
 # =============================================================================
 # Test Configuration
 # =============================================================================


### PR DESCRIPTION
## Summary
- move persisted message history reconstruction out of BaseReactAgent into AgentMessageHistoryLoader
- preserve harness context hygiene by skipping old observation blocks and restoring assistant/tool protocol pairs only when complete
- drop stale incomplete tool-call fragments before a later conversational turn pollutes the next request context
- isolate OmniServe tests from local OMNISERVE_* dotenv values so explicit test config stays deterministic

## Verification
- uv run ruff check .
- uv run pytest tests/test_message_history.py tests/test_base.py -q
- uv run pytest tests/test_prompt_context.py tests/test_tool_runtime_registry.py tests/test_tool_batch_runner.py tests/test_tool_observation.py tests/test_tool_failure_handler.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check