### PR TITLE
Lazy load package exports and provider clients

### DIFF
--- a/src/omnicoreagent/__init__.py
+++ b/src/omnicoreagent/__init__.py
@@ -1,23 +1,13 @@
 """
-OmniCoreAgent AI Framework
+OmniCoreAgent AI Framework.
 
-A comprehensive AI agent framework with MCP client capabilities.
+Package exports are resolved lazily so importing ``omnicoreagent`` stays light.
+Provider clients, dotenv loading in user code, and optional integrations should
+only be touched when the corresponding runtime object is requested.
 """
 
-from .core.agents import ReactAgent
-from .core.memory_store import MemoryRouter
-from .core.llm import LLMConnection
-from .core.events import EventRouter
-from .core.tools import ToolRegistry, Tool
-from .core.utils import logger
-
-from .agent import OmniCoreAgent
-
-from .mcp_clients_connection import MCPClient
-
-from .workflows.parallel_agent import ParallelAgent
-from .workflows.sequential_agent import SequentialAgent
-from .workflows.router_agent import RouterAgent
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     # Core
@@ -54,6 +44,21 @@ __all__ = [
     "get_metrics",
 ]
 
+_EXPORTS = {
+    "ReactAgent": ("omnicoreagent.core.agents", "ReactAgent"),
+    "MemoryRouter": ("omnicoreagent.core.memory_store", "MemoryRouter"),
+    "LLMConnection": ("omnicoreagent.core.llm", "LLMConnection"),
+    "EventRouter": ("omnicoreagent.core.events", "EventRouter"),
+    "ToolRegistry": ("omnicoreagent.core.tools", "ToolRegistry"),
+    "Tool": ("omnicoreagent.core.tools", "Tool"),
+    "logger": ("omnicoreagent.core.utils", "logger"),
+    "OmniCoreAgent": ("omnicoreagent.agent", "OmniCoreAgent"),
+    "MCPClient": ("omnicoreagent.mcp_clients_connection", "MCPClient"),
+    "ParallelAgent": ("omnicoreagent.workflows.parallel_agent", "ParallelAgent"),
+    "SequentialAgent": ("omnicoreagent.workflows.sequential_agent", "SequentialAgent"),
+    "RouterAgent": ("omnicoreagent.workflows.router_agent", "RouterAgent"),
+}
+
 _OPTIONAL_EXPORTS = {
     "DatabaseMessageStore": ("omnicoreagent.core.memory_store", "postgres"),
     "BackgroundOmniCoreAgent": (
@@ -88,15 +93,23 @@ _OPTIONAL_EXPORTS = {
 }
 
 
-def __getattr__(name: str):
-    if name not in _OPTIONAL_EXPORTS:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+def __getattr__(name: str) -> Any:
+    if name in _EXPORTS:
+        module_name, attr_name = _EXPORTS[name]
+        value = getattr(import_module(module_name), attr_name)
+        globals()[name] = value
+        return value
 
-    from omnicoreagent._optional import load_optional
+    if name in _OPTIONAL_EXPORTS:
+        from omnicoreagent._optional import load_optional
 
-    module_name, extra = _OPTIONAL_EXPORTS[name]
-    return load_optional(
-        name,
-        extra,
-        lambda: getattr(__import__(module_name, fromlist=[name]), name),
-    )
+        module_name, extra = _OPTIONAL_EXPORTS[name]
+        value = load_optional(
+            name,
+            extra,
+            lambda: getattr(import_module(module_name), name),
+        )
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/omnicoreagent/agent.py
+++ b/src/omnicoreagent/agent.py
@@ -2,7 +2,6 @@ import uuid
 from typing import Any, Dict, List, Optional, Union
 
 from omnicoreagent.core.agents.react_agent import ReactAgent
-from omnicoreagent.mcp_clients_connection.client import MCPClient
 from omnicoreagent.core.llm import LLMConnection
 from omnicoreagent.core.memory_store.memory_router import MemoryRouter
 from omnicoreagent.runtime_config import (
@@ -139,6 +138,8 @@ class OmniCoreAgent:
     def _create_agent(self):
         """Create the appropriate agent based on configuration"""
         if self.mcp_tools:
+            from omnicoreagent.mcp_clients_connection.client import MCPClient
+
             self.mcp_client = MCPClient(
                 servers=self.mcp_tools,
                 model_config=self.model_config,

--- a/src/omnicoreagent/core/__init__.py
+++ b/src/omnicoreagent/core/__init__.py
@@ -1,22 +1,12 @@
 """
-Core AI Agent Framework Components
+Core AI Agent Framework Components.
 
-This package contains the core AI agent functionality including:
-- Agents (React, Sequential)
-- Memory Management (In-Memory, Redis, Database, MongoDB)
-- LLM Connections and Support
-- Event System
-- Database Layer
-- Tools Management
-- Utilities and Constants
+Exports are resolved lazily to keep core package import cheap and free of
+provider/runtime side effects.
 """
 
-from .agents import ReactAgent
-from .memory_store import MemoryRouter
-from .tools import ToolRegistry, Tool
-from .types import ParsedResponse, ToolCall
-from .token_usage import UsageLimits, Usage, UsageLimitExceeded
-from omnicoreagent.runtime_config import AgentConfig
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "ReactAgent",
@@ -34,20 +24,43 @@ __all__ = [
     "UsageLimitExceeded",
 ]
 
+_EXPORTS = {
+    "ReactAgent": ("omnicoreagent.core.agents", "ReactAgent"),
+    "MemoryRouter": ("omnicoreagent.core.memory_store", "MemoryRouter"),
+    "LLMConnection": ("omnicoreagent.core.llm", "LLMConnection"),
+    "EventRouter": ("omnicoreagent.core.events", "EventRouter"),
+    "ToolRegistry": ("omnicoreagent.core.tools", "ToolRegistry"),
+    "Tool": ("omnicoreagent.core.tools", "Tool"),
+    "AgentConfig": ("omnicoreagent.runtime_config", "AgentConfig"),
+    "ParsedResponse": ("omnicoreagent.core.types", "ParsedResponse"),
+    "ToolCall": ("omnicoreagent.core.types", "ToolCall"),
+    "UsageLimits": ("omnicoreagent.core.token_usage", "UsageLimits"),
+    "Usage": ("omnicoreagent.core.token_usage", "Usage"),
+    "UsageLimitExceeded": ("omnicoreagent.core.token_usage", "UsageLimitExceeded"),
+}
+
 _OPTIONAL_EXPORTS = {
     "DatabaseMessageStore": ("omnicoreagent.core.memory_store", "postgres"),
 }
 
 
-def __getattr__(name: str):
-    if name not in _OPTIONAL_EXPORTS:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+def __getattr__(name: str) -> Any:
+    if name in _EXPORTS:
+        module_name, attr_name = _EXPORTS[name]
+        value = getattr(import_module(module_name), attr_name)
+        globals()[name] = value
+        return value
 
-    from omnicoreagent._optional import load_optional
+    if name in _OPTIONAL_EXPORTS:
+        from omnicoreagent._optional import load_optional
 
-    module_name, extra = _OPTIONAL_EXPORTS[name]
-    return load_optional(
-        name,
-        extra,
-        lambda: getattr(__import__(module_name, fromlist=[name]), name),
-    )
+        module_name, extra = _OPTIONAL_EXPORTS[name]
+        value = load_optional(
+            name,
+            extra,
+            lambda: getattr(import_module(module_name), name),
+        )
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/omnicoreagent/core/llm.py
+++ b/src/omnicoreagent/core/llm.py
@@ -6,10 +6,7 @@ import time
 import warnings
 from typing import Any
 
-import litellm
-import openai
 from decouple import config as decouple_config
-from dotenv import load_dotenv
 
 from omnicoreagent.core.utils import logger
 
@@ -17,19 +14,34 @@ warnings.filterwarnings(
     "ignore", message="Pydantic serializer warnings", module="pydantic.main"
 )
 
-load_dotenv()
-
-os.environ["LITELLM_LOG"] = "CRITICAL"
-litellm.set_verbose = False
-litellm.callbacks = []
-litellm.success_callback = []
-litellm.failure_callback = []
+_LITELLM_CONFIGURED = False
 
 for logger_name in ["LiteLLM", "litellm", "litellm.proxy"]:
     _litellm_logger = logging.getLogger(logger_name)
-    _litellm_logger.disabled = True
     _litellm_logger.setLevel(logging.CRITICAL)
     _litellm_logger.propagate = False
+
+
+def _get_litellm():
+    global _LITELLM_CONFIGURED
+
+    import litellm
+
+    if not _LITELLM_CONFIGURED:
+        os.environ["LITELLM_LOG"] = "CRITICAL"
+        litellm.set_verbose = False
+        litellm.callbacks = []
+        litellm.success_callback = []
+        litellm.failure_callback = []
+        _LITELLM_CONFIGURED = True
+
+    return litellm
+
+
+def _get_openai():
+    import openai
+
+    return openai
 
 
 def retry_with_backoff(max_retries=3, base_delay=1, max_delay=60, backoff_factor=2):
@@ -220,11 +232,13 @@ class LLMConnection:
         try:
             params = self._completion_params(messages, tools)
             if self.llm_config["provider"].lower() == "cencori":
+                openai = _get_openai()
                 client = openai.AsyncOpenAI(
                     base_url="https://api.cencori.com/v1",
                     api_key=self.llm_api_key,
                 )
                 return await client.chat.completions.create(**params)
+            litellm = _get_litellm()
             litellm.drop_params = True
             return await litellm.acompletion(**params)
         except Exception as e:
@@ -243,11 +257,13 @@ class LLMConnection:
         try:
             params = self._completion_params(messages, tools)
             if self.llm_config["provider"].lower() == "cencori":
+                openai = _get_openai()
                 client = openai.OpenAI(
                     base_url="https://api.cencori.com/v1",
                     api_key=self.llm_api_key,
                 )
                 return client.chat.completions.create(**params)
+            litellm = _get_litellm()
             litellm.drop_params = True
             return litellm.completion(**params)
         except Exception as e:

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -1,0 +1,96 @@
+import json
+import os
+import subprocess
+import sys
+
+
+def _run_import_probe(tmp_path, code: str) -> dict:
+    env = os.environ.copy()
+    for key in list(env):
+        if key.startswith("OMNISERVE_"):
+            env.pop(key)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_root_import_does_not_load_dotenv_or_provider_clients(tmp_path):
+    (tmp_path / ".env").write_text("OMNISERVE_AUTH_ENABLED=false\n")
+
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import os
+import sys
+
+import omnicoreagent
+
+print(json.dumps({
+    "omniserve_auth": os.environ.get("OMNISERVE_AUTH_ENABLED"),
+    "dotenv_loaded": "dotenv" in sys.modules,
+    "litellm_loaded": "litellm" in sys.modules,
+    "openai_loaded": "openai" in sys.modules,
+    "has_omnicoreagent": hasattr(omnicoreagent, "__all__"),
+}))
+""",
+    )
+
+    assert result == {
+        "omniserve_auth": None,
+        "dotenv_loaded": False,
+        "litellm_loaded": False,
+        "openai_loaded": False,
+        "has_omnicoreagent": True,
+    }
+
+
+def test_public_exports_resolve_without_provider_client_imports(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import sys
+
+from omnicoreagent import (
+    EventRouter,
+    LLMConnection,
+    MemoryRouter,
+    OmniCoreAgent,
+    ToolRegistry,
+)
+
+print(json.dumps({
+    "exports": [
+        EventRouter.__name__,
+        LLMConnection.__name__,
+        MemoryRouter.__name__,
+        OmniCoreAgent.__name__,
+        ToolRegistry.__name__,
+    ],
+    "litellm_loaded": "litellm" in sys.modules,
+    "openai_loaded": "openai" in sys.modules,
+    "dotenv_loaded": "dotenv" in sys.modules,
+}))
+""",
+    )
+
+    assert result == {
+        "exports": [
+            "EventRouter",
+            "LLMConnection",
+            "MemoryRouter",
+            "OmniCoreAgent",
+            "ToolRegistry",
+        ],
+        "litellm_loaded": False,
+        "openai_loaded": False,
+        "dotenv_loaded": False,
+    }

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,5 +1,8 @@
-from unittest.mock import patch, AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import pytest
+
 from omnicoreagent.core.llm import LLMConnection
 
 
@@ -15,8 +18,7 @@ def make_model_config(provider="openai", model="gpt-4"):
 
 @pytest.fixture
 def mock_llm_connection():
-    with patch("omnicoreagent.core.llm.litellm"):
-        return LLMConnection(make_model_config(), api_key="test-api-key")
+    return LLMConnection(make_model_config(), api_key="test-api-key")
 
 
 class TestLLMConnection:
@@ -40,12 +42,10 @@ class TestLLMConnection:
     async def test_llm_call_with_tools_and_without(self):
         messages = [{"role": "user", "content": "What is AI?"}]
         tools = [{"name": "tool", "description": "desc"}]
+        mock_completion = AsyncMock(return_value={"mocked": "response"})
+        mock_litellm = SimpleNamespace(acompletion=mock_completion)
 
-        with patch(
-            "omnicoreagent.core.llm.litellm.acompletion", new_callable=AsyncMock
-        ) as mock_completion:
-            mock_completion.return_value = {"mocked": "response"}
-
+        with patch("omnicoreagent.core.llm._get_litellm", return_value=mock_litellm):
             conn = LLMConnection(
                 make_model_config("groq", "llama-3"),
                 api_key="test-api-key",
@@ -72,12 +72,10 @@ class TestLLMConnection:
     @pytest.mark.asyncio
     async def test_llm_call_handles_exceptions_gracefully(self):
         messages = [{"role": "user", "content": "Fail please"}]
+        mock_completion = AsyncMock(side_effect=Exception("Boom"))
+        mock_litellm = SimpleNamespace(acompletion=mock_completion)
 
-        with patch(
-            "omnicoreagent.core.llm.litellm.acompletion", new_callable=AsyncMock
-        ) as mock_completion:
-            mock_completion.side_effect = Exception("Boom")
-
+        with patch("omnicoreagent.core.llm._get_litellm", return_value=mock_litellm):
             conn = LLMConnection(
                 make_model_config("gemini", "gemini-pro"),
                 api_key="test-api-key",


### PR DESCRIPTION
## Summary
- make root and core package exports lazy so importing omnicoreagent does not eagerly import the agent/runtime stack
- stop core.llm from calling load_dotenv or importing LiteLLM/OpenAI at module import time
- defer MCP client import inside OmniCoreAgent until MCP tools are actually configured
- add startup import probes to prevent dotenv/provider/client regressions

## Verification
- uv run ruff check .
- uv run pytest tests/test_import_startup.py tests/test_llm.py tests/test_client.py tests/test_subagents.py tests/test_omniserve_full.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check
- manual probe: import omnicoreagent and from omnicoreagent import OmniCoreAgent leave dotenv, mcp, litellm, and openai unloaded