### PR TITLE
Lazy load advanced tool exports

### DIFF
--- a/src/omnicoreagent/core/tools/__init__.py
+++ b/src/omnicoreagent/core/tools/__init__.py
@@ -1,12 +1,30 @@
 """
-Core Tools Package
+Core Tools Package.
 
-This package provides tool management functionality:
-- ToolRegistry: Registry for local tools
-- Tool: Individual tool representation
+Exports are resolved lazily so local tool registration does not import advanced
+tool retrieval/runtime modules.
 """
 
-from .local_tools_registry import ToolRegistry, Tool
-from .advance_tools.advanced_tools_use import AdvanceToolsUse
+from importlib import import_module
+from typing import Any
 
 __all__ = ["ToolRegistry", "Tool", "AdvanceToolsUse"]
+
+_EXPORTS = {
+    "ToolRegistry": ("omnicoreagent.core.tools.local_tools_registry", "ToolRegistry"),
+    "Tool": ("omnicoreagent.core.tools.local_tools_registry", "Tool"),
+    "AdvanceToolsUse": (
+        "omnicoreagent.core.tools.advance_tools.advanced_tools_use",
+        "AdvanceToolsUse",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attr_name = _EXPORTS[name]
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -131,3 +131,31 @@ print(json.dumps({
         "export": "OmniCoreAgent",
         "loaded_runtime_modules": [],
     }
+
+
+def test_tool_registry_export_does_not_load_advanced_tools(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import sys
+
+from omnicoreagent import ToolRegistry
+
+print(json.dumps({
+    "export": ToolRegistry.__name__,
+    "advanced_tools_loaded": (
+        "omnicoreagent.core.tools.advance_tools.advanced_tools_use" in sys.modules
+    ),
+    "utils_loaded": "omnicoreagent.core.utils" in sys.modules,
+    "constants_loaded": "omnicoreagent.core.constants" in sys.modules,
+}))
+""",
+    )
+
+    assert result == {
+        "export": "ToolRegistry",
+        "advanced_tools_loaded": False,
+        "utils_loaded": False,
+        "constants_loaded": False,
+    }


### PR DESCRIPTION
## Summary
- make omnicoreagent.core.tools exports lazy
- keep ToolRegistry and Tool imports on the lightweight local-tools path
- defer AdvanceToolsUse and BM25/advanced runtime imports until advanced tools are explicitly requested
- add a startup regression test so ToolRegistry does not pull advanced tool modules, constants, or core utils

## Verification
- uv run ruff check .
- uv run pytest tests/test_import_startup.py tests/test_base.py tests/test_tool_runtime_registry.py tests/test_tool_batch_runner.py tests/test_subagents.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check
- manual probe: from omnicoreagent import ToolRegistry loads only omnicoreagent, omnicoreagent.core, omnicoreagent.core.tools, and local_tools_registry