### PR TITLE
Keep agent construction lightweight

### DIFF
--- a/src/omnicoreagent/agent.py
+++ b/src/omnicoreagent/agent.py
@@ -30,9 +30,12 @@ _RUNTIME_EXPORTS = {
     "build_subagent_tools": ("omnicoreagent.core.subagents", "build_subagent_tools"),
     "AgentConfig": ("omnicoreagent.runtime_config", "AgentConfig"),
     "logger": ("omnicoreagent.core.utils", "logger"),
-    "normalize_agent_config": ("omnicoreagent.runtime_config", "normalize_agent_config"),
-    "normalize_mcp_tools": ("omnicoreagent.runtime_config", "normalize_mcp_tools"),
-    "normalize_model_config": ("omnicoreagent.runtime_config", "normalize_model_config"),
+    "normalize_agent_config_light": (
+        "omnicoreagent.config_types",
+        "normalize_agent_config_light",
+    ),
+    "normalize_mcp_tools": ("omnicoreagent.config_types", "normalize_mcp_tools"),
+    "normalize_model_config": ("omnicoreagent.config_types", "normalize_model_config"),
 }
 
 
@@ -54,6 +57,21 @@ def _runtime(name: str) -> Any:
 
 def _logger() -> Any:
     return _runtime("logger")
+
+
+class _LazyDefaultPromptBuilder:
+    def __init__(self):
+        self._builder = None
+
+    def _load(self):
+        if self._builder is None:
+            self._builder = _runtime("OmniCoreAgentPromptBuilder")(
+                _runtime("REACT_AGENT_PROMPT")
+            )
+        return self._builder
+
+    def build(self, *, system_instruction: str) -> str:
+        return self._load().build(system_instruction=system_instruction)
 
 
 class OmniCoreAgent:
@@ -111,19 +129,19 @@ class OmniCoreAgent:
             self.local_tools = local_tools
 
         self.sub_agents = sub_agents
-        self.agent_config = _runtime("normalize_agent_config")(name, agent_config)
+        self.agent_config = _runtime("normalize_agent_config_light")(
+            name, agent_config
+        )
 
         self.debug = debug
-        self._cumulative_usage = _runtime("Usage")()
+        self._cumulative_usage = None
 
         self.memory_router = memory_router
         self.event_router = event_router
         if prompt_builder:
             self.prompt_builder = prompt_builder
         else:
-            self.prompt_builder = _runtime("OmniCoreAgentPromptBuilder")(
-                _runtime("REACT_AGENT_PROMPT")
-            )
+            self.prompt_builder = _LazyDefaultPromptBuilder()
         self.agent = None
         self.mcp_client = None
         self.llm_connection = None
@@ -375,7 +393,7 @@ class OmniCoreAgent:
         )
 
         if isinstance(response, dict) and "usage" in response:
-            self._cumulative_usage.incr(response["usage"])
+            self._usage().incr(response["usage"])
             return {
                 "response": response["answer"],
                 "session_id": session_id,
@@ -392,19 +410,25 @@ class OmniCoreAgent:
         Returns:
             Dict containing total requests, tokens, and time.
         """
+        cumulative_usage = self._usage()
         average_time = (
-            self._cumulative_usage.total_time / self._cumulative_usage.requests
-            if self._cumulative_usage.requests > 0
+            cumulative_usage.total_time / cumulative_usage.requests
+            if cumulative_usage.requests > 0
             else 0
         )
         return {
-            "total_requests": self._cumulative_usage.requests,
-            "total_request_tokens": self._cumulative_usage.request_tokens,
-            "total_response_tokens": self._cumulative_usage.response_tokens,
-            "total_tokens": self._cumulative_usage.total_tokens,
-            "total_time": self._cumulative_usage.total_time,
+            "total_requests": cumulative_usage.requests,
+            "total_request_tokens": cumulative_usage.request_tokens,
+            "total_response_tokens": cumulative_usage.response_tokens,
+            "total_tokens": cumulative_usage.total_tokens,
+            "total_time": cumulative_usage.total_time,
             "average_time": average_time,
         }
+
+    def _usage(self):
+        if self._cumulative_usage is None:
+            self._cumulative_usage = _runtime("Usage")()
+        return self._cumulative_usage
 
     async def list_all_available_tools(self):
         """List all available tools (MCP and local)"""

--- a/src/omnicoreagent/config_types.py
+++ b/src/omnicoreagent/config_types.py
@@ -1,0 +1,165 @@
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+import uuid
+
+
+SUPPORTED_MODELS_PROVIDERS = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "groq": "groq",
+    "ollama": "ollama",
+    "azure": "azure",
+    "gemini": "gemini",
+    "deepseek": "deepseek",
+    "mistral": "mistral",
+    "openrouter": "openrouter",
+    "cencori": "cencori",
+}
+
+
+class TransportType(str, Enum):
+    STDIO = "stdio"
+    SSE = "sse"
+    STREAMABLE_HTTP = "streamable_http"
+
+
+@dataclass
+class ModelConfig:
+    provider: str
+    model: str
+    temperature: float | None = 0.5
+    max_tokens: int | None = 5000
+    max_context_length: int | None = 100000
+    top_p: float | None = 0.7
+    top_k: int | str | None = "N/A"
+    api_key: str | None = None
+    azure_endpoint: str | None = None
+    azure_api_version: str | None = None
+    azure_deployment: str | None = None
+    ollama_host: str | None = None
+
+
+@dataclass
+class MCPToolConfig:
+    name: str | None = None
+    transport_type: TransportType | str = TransportType.STDIO
+    url: str | None = None
+    command: str | None = None
+    args: list[str] | None = None
+    headers: dict[str, str] | None = None
+    env: dict[str, str] | None = None
+    timeout: int | None = 60
+    sse_read_timeout: int | None = 120
+    auth: dict[str, Any] | None = None
+
+    def __post_init__(self):
+        self.transport_type = TransportType(self.transport_type)
+        if not self.name:
+            base = self.command or self.url or "mcp_tool"
+            self.name = f"{base}_{uuid.uuid4().hex[:6]}"
+
+
+def default_agent_config(name: str) -> dict[str, Any]:
+    return {
+        "agent_name": name,
+        "request_limit": 0,
+        "total_tokens_limit": 0,
+        "max_steps": 15,
+        "tool_call_timeout": 30,
+        "enable_advanced_tool_use": False,
+        "enable_subagents": False,
+        "enable_agent_skills": False,
+        "memory_config": {
+            "mode": "sliding_window",
+            "value": 10000,
+            "summary": {"enabled": False, "retention_policy": "keep"},
+        },
+        "enable_workspace_memory": False,
+        "guardrail_config": {},
+        "guardrail_mode": "full",
+        "context_management": {
+            "enabled": False,
+            "mode": "token_budget",
+            "value": 100000,
+            "threshold_percent": 75,
+            "strategy": "truncate",
+            "preserve_recent": 4,
+        },
+        "tool_offload": {
+            "enabled": False,
+            "threshold_tokens": 500,
+            "threshold_bytes": 2000,
+            "max_preview_tokens": 150,
+            "max_preview_lines": 10,
+        },
+    }
+
+
+def normalize_model_config(config: dict[str, Any] | ModelConfig) -> dict[str, Any]:
+    if isinstance(config, ModelConfig):
+        data = asdict(config)
+    elif isinstance(config, dict):
+        data = dict(config)
+    else:
+        raise ValueError("model_config must be a dict or ModelConfig")
+
+    provider = data.get("provider")
+    model = data.get("model")
+    if not provider:
+        raise ValueError("model_config.provider is required")
+    if provider not in SUPPORTED_MODELS_PROVIDERS:
+        supported = ", ".join(SUPPORTED_MODELS_PROVIDERS)
+        raise ValueError(f"Unsupported provider: {provider}. Supported: {supported}")
+    if not model:
+        raise ValueError("model_config.model is required")
+
+    data["provider"] = SUPPORTED_MODELS_PROVIDERS[provider]
+    return data
+
+
+def normalize_mcp_tool_config(config: dict[str, Any] | MCPToolConfig) -> dict[str, Any]:
+    tool = config if isinstance(config, MCPToolConfig) else MCPToolConfig(**config)
+    data = asdict(tool)
+    data["transport_type"] = tool.transport_type.value
+
+    if tool.transport_type in {TransportType.SSE, TransportType.STREAMABLE_HTTP}:
+        if not tool.url:
+            raise ValueError(f"url is required for {tool.transport_type.value} transport")
+    elif tool.transport_type == TransportType.STDIO and not tool.command:
+        raise ValueError("command is required for stdio transport")
+
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def normalize_mcp_tools(
+    tools: list[dict[str, Any] | MCPToolConfig] | None,
+) -> list[dict[str, Any]]:
+    normalized = [normalize_mcp_tool_config(tool) for tool in tools or []]
+    names = [tool["name"] for tool in normalized]
+    duplicates = {name for name in names if names.count(name) > 1}
+    if duplicates:
+        raise ValueError(f"Duplicate MCP tool names: {', '.join(sorted(duplicates))}")
+    return normalized
+
+
+def normalize_agent_config_light(name: str, config: Any = None) -> dict[str, Any]:
+    if hasattr(config, "model_copy") and hasattr(config, "model_dump"):
+        data = config.model_copy(update={"agent_name": name}).model_dump()
+    elif isinstance(config, dict):
+        data = {**default_agent_config(name), **config, "agent_name": name}
+    elif config is None:
+        data = default_agent_config(name)
+    else:
+        raise ValueError("agent_config must be a dict or AgentConfig")
+
+    if data.get("request_limit") is None:
+        data["request_limit"] = 0
+    if data.get("total_tokens_limit") is None:
+        data["total_tokens_limit"] = 0
+    if data.get("guardrail_config") is None:
+        data["guardrail_config"] = {}
+    if data.get("enable_subagents"):
+        data["enable_workspace_memory"] = True
+
+    return data

--- a/src/omnicoreagent/runtime_config.py
+++ b/src/omnicoreagent/runtime_config.py
@@ -1,53 +1,15 @@
-from dataclasses import asdict, dataclass
-from enum import Enum
 from typing import Any
-import uuid
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from omnicoreagent.core.constants import SUPPORTED_MODELS_PROVIDERS
-
-
-class TransportType(str, Enum):
-    STDIO = "stdio"
-    SSE = "sse"
-    STREAMABLE_HTTP = "streamable_http"
-
-
-@dataclass
-class ModelConfig:
-    provider: str
-    model: str
-    temperature: float | None = 0.5
-    max_tokens: int | None = 5000
-    max_context_length: int | None = 100000
-    top_p: float | None = 0.7
-    top_k: int | str | None = "N/A"
-    api_key: str | None = None
-    azure_endpoint: str | None = None
-    azure_api_version: str | None = None
-    azure_deployment: str | None = None
-    ollama_host: str | None = None
-
-
-@dataclass
-class MCPToolConfig:
-    name: str | None = None
-    transport_type: TransportType | str = TransportType.STDIO
-    url: str | None = None
-    command: str | None = None
-    args: list[str] | None = None
-    headers: dict[str, str] | None = None
-    env: dict[str, str] | None = None
-    timeout: int | None = 60
-    sse_read_timeout: int | None = 120
-    auth: dict[str, Any] | None = None
-
-    def __post_init__(self):
-        self.transport_type = TransportType(self.transport_type)
-        if not self.name:
-            base = self.command or self.url or "mcp_tool"
-            self.name = f"{base}_{uuid.uuid4().hex[:6]}"
+from omnicoreagent.config_types import (
+    MCPToolConfig as MCPToolConfig,
+    ModelConfig as ModelConfig,
+    TransportType as TransportType,
+    normalize_mcp_tool_config as normalize_mcp_tool_config,
+    normalize_mcp_tools as normalize_mcp_tools,
+    normalize_model_config as normalize_model_config,
+)
 
 
 class AgentConfig(BaseModel):
@@ -182,53 +144,6 @@ class AgentConfig(BaseModel):
         if self.enable_subagents:
             self.enable_workspace_memory = True
         return self
-
-
-def normalize_model_config(config: dict[str, Any] | ModelConfig) -> dict[str, Any]:
-    if isinstance(config, ModelConfig):
-        data = asdict(config)
-    elif isinstance(config, dict):
-        data = dict(config)
-    else:
-        raise ValueError("model_config must be a dict or ModelConfig")
-
-    provider = data.get("provider")
-    model = data.get("model")
-    if not provider:
-        raise ValueError("model_config.provider is required")
-    if provider not in SUPPORTED_MODELS_PROVIDERS:
-        supported = ", ".join(SUPPORTED_MODELS_PROVIDERS)
-        raise ValueError(f"Unsupported provider: {provider}. Supported: {supported}")
-    if not model:
-        raise ValueError("model_config.model is required")
-
-    data["provider"] = SUPPORTED_MODELS_PROVIDERS[provider]
-    return data
-
-
-def normalize_mcp_tool_config(config: dict[str, Any] | MCPToolConfig) -> dict[str, Any]:
-    tool = config if isinstance(config, MCPToolConfig) else MCPToolConfig(**config)
-    data = asdict(tool)
-    data["transport_type"] = tool.transport_type.value
-
-    if tool.transport_type in {TransportType.SSE, TransportType.STREAMABLE_HTTP}:
-        if not tool.url:
-            raise ValueError(f"url is required for {tool.transport_type.value} transport")
-    elif tool.transport_type == TransportType.STDIO and not tool.command:
-        raise ValueError("command is required for stdio transport")
-
-    return {key: value for key, value in data.items() if value is not None}
-
-
-def normalize_mcp_tools(
-    tools: list[dict[str, Any] | MCPToolConfig] | None,
-) -> list[dict[str, Any]]:
-    normalized = [normalize_mcp_tool_config(tool) for tool in tools or []]
-    names = [tool["name"] for tool in normalized]
-    duplicates = {name for name in names if names.count(name) > 1}
-    if duplicates:
-        raise ValueError(f"Duplicate MCP tool names: {', '.join(sorted(duplicates))}")
-    return normalized
 
 
 def normalize_agent_config(

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -159,3 +159,46 @@ print(json.dumps({
         "utils_loaded": False,
         "constants_loaded": False,
     }
+
+
+def test_agent_construction_does_not_load_prompt_or_runtime_modules(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import sys
+
+from omnicoreagent import OmniCoreAgent
+
+agent = OmniCoreAgent(
+    name="startup",
+    system_instruction="You are fast to create.",
+    model_config={"provider": "openai", "model": "gpt-4o", "api_key": "test"},
+    agent_config={"guardrail_mode": "off"},
+)
+
+watched_modules = [
+    "omnicoreagent.runtime_config",
+    "omnicoreagent.core.agents.react_agent",
+    "omnicoreagent.core.constants",
+    "omnicoreagent.core.events.event_router",
+    "omnicoreagent.core.guardrails",
+    "omnicoreagent.core.llm",
+    "omnicoreagent.core.memory_store.memory_router",
+    "omnicoreagent.core.system_prompts",
+    "omnicoreagent.core.token_usage",
+    "omnicoreagent.core.types",
+    "omnicoreagent.core.utils",
+]
+
+print(json.dumps({
+    "agent_name": agent.name,
+    "loaded_modules": [module for module in watched_modules if module in sys.modules],
+}))
+""",
+    )
+
+    assert result == {
+        "agent_name": "startup",
+        "loaded_modules": [],
+    }


### PR DESCRIPTION
## Summary
- add lightweight config_types for model/MCP config normalization without importing Pydantic AgentConfig
- keep runtime_config focused on Pydantic AgentConfig while re-exporting config helpers for existing imports
- defer default prompt builder creation until the first prompt build/run path
- defer cumulative Usage creation until metrics are actually recorded/read
- add startup regression coverage for plain OmniCoreAgent construction

## Where we are now
- import omnicoreagent: lightweight
- from omnicoreagent import OmniCoreAgent: loads only omnicoreagent and omnicoreagent.agent
- OmniCoreAgent(...): loads only omnicoreagent, omnicoreagent.agent, and omnicoreagent.config_types
- next deeper seam: initialize() still loads the full ReAct/tool runtime, including advanced-tool and workspace modules, even for simple agents

## Verification
- uv run ruff check .
- uv run pytest tests/test_import_startup.py tests/test_guardrail_default_mode.py tests/test_subagents.py tests/test_react_agent.py tests/test_context_manager.py tests/test_tool_response_offloader.py -q
- uv run pytest -q
- uv run hatch build
- git diff --check
- manual probe: class export and plain construction stay on lightweight module paths