### PR TITLE
Keep lightweight agent initialization lazy

### DIFF
--- a/src/omnicoreagent/core/tool_response_offloader.py
+++ b/src/omnicoreagent/core/tool_response_offloader.py
@@ -10,18 +10,19 @@ Inspired by:
 - Anthropic's "Context efficient tool results" pattern
 """
 
+from __future__ import annotations
+
 import json
 import hashlib
 from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import TYPE_CHECKING, Optional, Dict, Any
 from datetime import datetime, timedelta
 
 from omnicoreagent.core.summarizer.tokenizer import count_tokens
 from omnicoreagent.core.utils import logger
-from omnicoreagent.core.workspace_storage import (
-    WorkspaceStorage,
-    create_workspace_storage,
-)
+
+if TYPE_CHECKING:
+    from omnicoreagent.core.workspace_storage import WorkspaceStorage
 
 
 @dataclass
@@ -105,11 +106,8 @@ class ToolResponseOffloader:
         if isinstance(config, dict):
             config = OffloadConfig.from_dict(config)
         self.config = config or OffloadConfig()
-
-        self.storage = storage or create_workspace_storage(
-            namespace="artifacts",
-            workspace_dir=base_dir,
-        )
+        self._base_dir = base_dir
+        self._storage = storage
 
         if self.config.enabled:
             self._ensure_storage_dir()
@@ -118,6 +116,18 @@ class ToolResponseOffloader:
 
         self._offload_count = 0
         self._tokens_saved = 0
+
+    @property
+    def storage(self) -> WorkspaceStorage:
+        """Storage backend for persisted tool response artifacts."""
+        if self._storage is None:
+            from omnicoreagent.core.workspace_storage import create_workspace_storage
+
+            self._storage = create_workspace_storage(
+                namespace="artifacts",
+                workspace_dir=self._base_dir,
+            )
+        return self._storage
 
     def _ensure_storage_dir(self):
         """Create storage directory if it doesn't exist."""

--- a/src/omnicoreagent/core/tools/tool_runtime_registry.py
+++ b/src/omnicoreagent/core/tools/tool_runtime_registry.py
@@ -1,16 +1,40 @@
 from typing import Any
 
-from omnicoreagent.core.skills.tools import build_skill_tools
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
-from omnicoreagent.core.tools.advance_tools_use import (
-    build_tool_registry_advance_tools_use,
-)
-from omnicoreagent.core.tools.artifact_tool import build_tool_registry_artifact_tool
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
-from omnicoreagent.core.tools.memory_tool.memory_tool import (
-    build_tool_registry_memory_tool,
-)
 from omnicoreagent.core.utils import logger
+
+
+async def build_tool_registry_advance_tools_use(registry: ToolRegistry):
+    from omnicoreagent.core.tools.advance_tools_use import (
+        build_tool_registry_advance_tools_use as build_advanced_tools,
+    )
+
+    return await build_advanced_tools(registry=registry)
+
+
+def build_tool_registry_memory_tool(*, backend: Any, registry: ToolRegistry):
+    from omnicoreagent.core.tools.memory_tool.memory_tool import (
+        build_tool_registry_memory_tool as build_memory_tools,
+    )
+
+    return build_memory_tools(backend=backend, registry=registry)
+
+
+def build_tool_registry_artifact_tool(
+    *, offloader: ToolResponseOffloader, registry: ToolRegistry
+):
+    from omnicoreagent.core.tools.artifact_tool import (
+        build_tool_registry_artifact_tool as build_artifact_tools,
+    )
+
+    return build_artifact_tools(offloader=offloader, registry=registry)
+
+
+def build_skill_tools(*, skill_manager: Any, registry: ToolRegistry):
+    from omnicoreagent.core.skills.tools import build_skill_tools as build_tools
+
+    return build_tools(skill_manager=skill_manager, registry=registry)
 
 
 class ToolRuntimeRegistry:

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -202,3 +202,76 @@ print(json.dumps({
         "agent_name": "startup",
         "loaded_modules": [],
     }
+
+
+def test_disabled_tool_offloader_does_not_load_workspace_storage(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import sys
+
+from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
+
+offloader = ToolResponseOffloader(config={"enabled": False})
+
+print(json.dumps({
+    "offload_enabled": offloader.config.enabled,
+    "workspace_loaded": "omnicoreagent.core.workspace" in sys.modules,
+    "workspace_storage_loaded": "omnicoreagent.core.workspace_storage" in sys.modules,
+}))
+""",
+    )
+
+    assert result == {
+        "offload_enabled": False,
+        "workspace_loaded": False,
+        "workspace_storage_loaded": False,
+    }
+
+
+def test_agent_initialize_without_optional_tools_stays_lightweight(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import asyncio
+import json
+import logging
+import sys
+
+from omnicoreagent import OmniCoreAgent
+
+logging.getLogger("omnicoreagent").disabled = True
+
+watched_modules = [
+    "omnicoreagent.core.tools.advance_tools.advanced_tools_use",
+    "omnicoreagent.core.tools.advance_tools_use",
+    "omnicoreagent.core.tools.artifact_tool",
+    "omnicoreagent.core.tools.memory_tool.memory_tool",
+    "omnicoreagent.core.skills.tools",
+    "omnicoreagent.core.workspace",
+    "omnicoreagent.core.workspace_storage",
+]
+
+async def main():
+    agent = OmniCoreAgent(
+        name="startup",
+        system_instruction="You are fast to initialize.",
+        model_config={"provider": "openai", "model": "gpt-4o", "api_key": "test"},
+        agent_config={"guardrail_mode": "off"},
+    )
+    await agent.initialize()
+
+    print(json.dumps({
+        "agent_name": agent.name,
+        "loaded_modules": [module for module in watched_modules if module in sys.modules],
+    }))
+
+asyncio.run(main())
+""",
+    )
+
+    assert result == {
+        "agent_name": "startup",
+        "loaded_modules": [],
+    }


### PR DESCRIPTION
## Summary
- lazy-load optional advanced, artifact, memory-tool, and skill tool builders from the runtime registry
- avoid constructing workspace storage when tool response offloading is disabled
- add startup regression tests for disabled offloading and simple agent initialization

## Tests
- uv run ruff check .
- uv run pytest -q
- git diff --check
- uv run hatch build