### PR TITLE
Clean runtime initialization imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,6 @@ OMNICOREAGENT_WORKSPACE_BACKEND=local  # local, s3, or r2
 OMNICOREAGENT_WORKSPACE_DIR=.omnicoreagent/workspace
 AWS_S3_BUCKET=your-s3-bucket           # when backend=s3
 R2_BUCKET_NAME=your-r2-bucket          # when backend=r2
-
-# Optional: Observability
-OPIK_API_KEY=your_opik_key
-OPIK_WORKSPACE=your_workspace
 ```
 
 ### Agent Configuration
@@ -298,7 +294,7 @@ MIT License — see [LICENSE](LICENSE)
 
 ### 🙏 Acknowledgments
 
-Built on: [LiteLLM](https://github.com/BerriAI/litellm), [FastAPI](https://fastapi.tiangolo.com/), [Redis](https://redis.io/), [Opik](https://opik.ai/), [Pydantic](https://pydantic-docs.helpmanual.io/), [APScheduler](https://apscheduler.readthedocs.io/)
+Built on: [LiteLLM](https://github.com/BerriAI/litellm), [FastAPI](https://fastapi.tiangolo.com/), [Redis](https://redis.io/), [Pydantic](https://pydantic-docs.helpmanual.io/), [APScheduler](https://apscheduler.readthedocs.io/)
 
 ---
 

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -29,14 +29,6 @@ Environment variables are the best way to manage sensitive data like API keys an
 | **SQL Database** | `DATABASE_URL` | `postgresql://user:pass@localhost:5432/db` |
 | **MongoDB** | `MONGODB_URI` | `mongodb://localhost:27017` |
 
-### Observability
-| Service | Variable |
-|---------|----------|
-| **Opik** | `OPIK_API_KEY` |
-| **Opik Project** | `OPIK_PROJECT_NAME` |
-
----
-
 ## 2. Agent Configuration
 
 The `AgentConfig` handles the runtime behavior of the agent, such as reasoning steps and resource limits.

--- a/docs/how-to-guides/observability.mdx
+++ b/docs/how-to-guides/observability.mdx
@@ -1,6 +1,6 @@
 ---
 title: Observability
-description: 'Production metrics, Opik tracing, and per-request performance monitoring'
+description: 'Production metrics and per-request performance monitoring'
 icon: 'chart-line'
 ---
 
@@ -26,37 +26,19 @@ print(f"Avg Response Time: {stats['average_time']:.2f}s")
 
 ---
 
-## Opik Tracing
+## Runtime Metrics
 
-Monitor and optimize your agents with deep traces using [Opik](https://opik.ai/).
+OmniCoreAgent exposes lightweight runtime metrics without requiring an external
+tracing service.
 
-### Setup
+### What's Available
 
-```bash
-# Add to .env
-OPIK_API_KEY=your_opik_api_key
-OPIK_WORKSPACE=your_workspace
-```
-
-### What's Tracked
-
-- LLM call performance
-- Tool execution traces
-- Memory operations
-- Agent workflow
-- Bottleneck identification
-
-### Example Trace
-
-```
-Agent Execution Trace:
-├── agent_execution: 4.6s
-    ├── tools_registry_retrieval: 0.02s ✅
-    ├── memory_retrieval_step: 0.08s ✅
-    ├── llm_call: 4.5s ⚠️ (bottleneck!)
-    └── action_execution: 0.03s ✅
-```
+- Request count
+- Request, response, and total tokens
+- Total runtime
+- Average response time
 
 <Tip>
-Essential for production. Use Metrics for cost/performance monitoring, and Opik for identifying bottlenecks and debugging complex agent logic.
+Use metrics for cost and performance monitoring. Deeper agent tracing and
+observability will be handled by OmniCoreAgent's internal observability layer.
 </Tip>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "httpx-sse>=0.4.0",
     "pydantic[email]>=2.6.0",
     "anyio>=4.2.0",
-    "python-decouple>=3.8",
     "mcp[cli]>=1.9.1",
     "litellm>=1.75.2",
     "click>=8.1.7",
@@ -53,7 +52,6 @@ mongodb = ["motor>=3.7.1", "pymongo>=4.15.1"]
 s3 = ["boto3>=1.42.37"]
 serve = ["fastapi>=0.115.12", "uvicorn>=0.34.1", "python-multipart>=0.0.20"]
 background = ["apscheduler>=3.11.0", "tzlocal>=5.2"]
-observability = ["opik>=1.8.19"]
 tokenizer = ["tiktoken>=0.8.0"]
 all = [
     "redis>=5.2.1",
@@ -67,7 +65,6 @@ all = [
     "python-multipart>=0.0.20",
     "apscheduler>=3.11.0",
     "tzlocal>=5.2",
-    "opik>=1.8.19",
     "tiktoken>=0.8.0",
 ]
 
@@ -115,7 +112,6 @@ dev = [
     "fastapi>=0.115.12",
     "pre-commit>=4.2.0",
     "motor>=3.7.1",
-    "opik>=1.8.19",
     "psycopg2-binary>=2.9.10",
     "pytest>=8.3.5",
     "pytest-asyncio>=0.26.0",

--- a/src/omnicoreagent/core/events/base.py
+++ b/src/omnicoreagent/core/events/base.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, Any, Dict, List, Optional, Union
+from collections.abc import AsyncIterator
+from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import datetime, timezone
 from enum import Enum
-from datetime import datetime
+import json
+from typing import Any, Type
 from uuid import uuid4
-from typing import Type
-from pydantic import BaseModel, Field
 
 
 class EventType(str, Enum):
@@ -24,49 +27,69 @@ class EventType(str, Enum):
     BACKGROUND_AGENT_STATUS = "background_agent_status"
 
 
-class UserMessagePayload(BaseModel):
+class SerializableRecord:
+    def model_dump(self) -> dict[str, Any]:
+        return _to_plain(self)
+
+    def dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+    def json(self) -> str:
+        return json.dumps(self.model_dump())
+
+
+@dataclass
+class UserMessagePayload(SerializableRecord):
     message: str
 
 
-class AgentMessagePayload(BaseModel):
+@dataclass
+class AgentMessagePayload(SerializableRecord):
     message: str
 
 
-class ToolCallStartedPayload(BaseModel):
+@dataclass
+class ToolCallStartedPayload(SerializableRecord):
     tool_name: str
-    tool_args: str | Dict[str, Any]
-    tool_call_id: Optional[str] = None
+    tool_args: str | dict[str, Any]
+    tool_call_id: str | None = None
 
 
-class ToolCallResultPayload(BaseModel):
+@dataclass
+class ToolCallResultPayload(SerializableRecord):
     tool_name: str
-    tool_args: str | Dict[str, Any]
-    tool_call_id: Optional[str] = None
+    tool_args: str | dict[str, Any]
     result: str
+    tool_call_id: str | None = None
 
 
-class ToolCallErrorPayload(BaseModel):
+@dataclass
+class ToolCallErrorPayload(SerializableRecord):
     tool_name: str
     error_message: str
 
 
-class FinalAnswerPayload(BaseModel):
+@dataclass
+class FinalAnswerPayload(SerializableRecord):
     message: str
 
 
-class AgentThoughtPayload(BaseModel):
+@dataclass
+class AgentThoughtPayload(SerializableRecord):
     message: str
 
 
-class SubAgentCallStartedPayload(BaseModel):
+@dataclass
+class SubAgentCallStartedPayload(SerializableRecord):
     agent_name: str
     session_id: str
     timestamp: str
     run_count: int
-    kwargs: Dict[str, Any]
+    kwargs: dict[str, Any]
 
 
-class SubAgentCallResultPayload(BaseModel):
+@dataclass
+class SubAgentCallResultPayload(SerializableRecord):
     agent_name: str
     session_id: str
     timestamp: str
@@ -74,7 +97,8 @@ class SubAgentCallResultPayload(BaseModel):
     result: Any
 
 
-class SubAgentCallErrorPayload(BaseModel):
+@dataclass
+class SubAgentCallErrorPayload(SerializableRecord):
     agent_name: str
     session_id: str
     timestamp: str
@@ -82,15 +106,17 @@ class SubAgentCallErrorPayload(BaseModel):
     error_count: int
 
 
-class BackgroundTaskStartedPayload(BaseModel):
+@dataclass
+class BackgroundTaskStartedPayload(SerializableRecord):
     agent_id: str
     session_id: str
     timestamp: str
     run_count: int
-    kwargs: Dict[str, Any]
+    kwargs: dict[str, Any]
 
 
-class BackgroundTaskCompletedPayload(BaseModel):
+@dataclass
+class BackgroundTaskCompletedPayload(SerializableRecord):
     agent_id: str
     session_id: str
     timestamp: str
@@ -98,7 +124,8 @@ class BackgroundTaskCompletedPayload(BaseModel):
     result: Any
 
 
-class BackgroundTaskErrorPayload(BaseModel):
+@dataclass
+class BackgroundTaskErrorPayload(SerializableRecord):
     agent_id: str
     session_id: str
     timestamp: str
@@ -106,44 +133,37 @@ class BackgroundTaskErrorPayload(BaseModel):
     error_count: int
 
 
-class BackgroundAgentStatusPayload(BaseModel):
+@dataclass
+class BackgroundAgentStatusPayload(SerializableRecord):
     agent_id: str
     status: str
     timestamp: str
-    session_id: Optional[str] = None
-    last_run: Optional[str] = None
-    run_count: Optional[int] = None
-    error_count: Optional[int] = None
-    error: Optional[str] = None
+    session_id: str | None = None
+    last_run: str | None = None
+    run_count: int | None = None
+    error_count: int | None = None
+    error: str | None = None
 
 
-EventPayload = Union[
-    UserMessagePayload,
-    AgentMessagePayload,
-    ToolCallStartedPayload,
-    ToolCallResultPayload,
-    ToolCallErrorPayload,
-    FinalAnswerPayload,
-    AgentThoughtPayload,
-    SubAgentCallStartedPayload,
-    SubAgentCallResultPayload,
-    SubAgentCallErrorPayload,
-    BackgroundTaskStartedPayload,
-    BackgroundTaskCompletedPayload,
-    BackgroundTaskErrorPayload,
-    BackgroundAgentStatusPayload,
-]
+EventPayload = (
+    UserMessagePayload
+    | AgentMessagePayload
+    | ToolCallStartedPayload
+    | ToolCallResultPayload
+    | ToolCallErrorPayload
+    | FinalAnswerPayload
+    | AgentThoughtPayload
+    | SubAgentCallStartedPayload
+    | SubAgentCallResultPayload
+    | SubAgentCallErrorPayload
+    | BackgroundTaskStartedPayload
+    | BackgroundTaskCompletedPayload
+    | BackgroundTaskErrorPayload
+    | BackgroundAgentStatusPayload
+)
 
 
-class Event(BaseModel):
-    type: EventType
-    payload: EventPayload
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
-    agent_name: str
-    event_id: str = Field(default_factory=lambda: str(uuid4()))
-
-
-EVENT_PAYLOAD_MAP: dict[EventType, Type[BaseModel]] = {
+EVENT_PAYLOAD_MAP: dict[EventType, Type[Any]] = {
     EventType.USER_MESSAGE: UserMessagePayload,
     EventType.AGENT_MESSAGE: AgentMessagePayload,
     EventType.TOOL_CALL_STARTED: ToolCallStartedPayload,
@@ -161,11 +181,67 @@ EVENT_PAYLOAD_MAP: dict[EventType, Type[BaseModel]] = {
 }
 
 
+def _to_plain(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if is_dataclass(value):
+        return {key: _to_plain(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {key: _to_plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_plain(item) for item in value]
+    if isinstance(value, tuple):
+        return [_to_plain(item) for item in value]
+    return value
+
+
+@dataclass
+class Event:
+    type: EventType | str
+    payload: EventPayload | dict[str, Any]
+    agent_name: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    event_id: str = field(default_factory=lambda: str(uuid4()))
+
+    def __post_init__(self):
+        self.type = EventType(self.type)
+        payload_type = EVENT_PAYLOAD_MAP[self.type]
+        if isinstance(self.payload, dict):
+            self.payload = payload_type(**self.payload)
+        validate_event(self)
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "type": _to_plain(self.type),
+            "payload": _to_plain(self.payload),
+            "timestamp": _to_plain(self.timestamp),
+            "agent_name": self.agent_name,
+            "event_id": self.event_id,
+        }
+
+    def dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+    def json(self) -> str:
+        return json.dumps(self.model_dump())
+
+    @classmethod
+    def parse_raw(cls, raw: str) -> Event:
+        data = json.loads(raw)
+        timestamp = data.get("timestamp")
+        if isinstance(timestamp, str):
+            data["timestamp"] = datetime.fromisoformat(timestamp)
+        return cls(**data)
+
+
 def validate_event(event: Event):
     expected_type = EVENT_PAYLOAD_MAP[event.type]
     if not isinstance(event.payload, expected_type):
         raise TypeError(
-            f"Payload mismatch: Expected {expected_type} for {event.type}, got {type(event.payload)}"
+            f"Payload mismatch: Expected {expected_type} for "
+            f"{event.type}, got {type(event.payload)}"
         )
 
 
@@ -176,7 +252,7 @@ class BaseEventStore(ABC):
         raise NotImplementedError("Subclasses must implement this method")
 
     @abstractmethod
-    async def get_events(self, session_id: str) -> List[Event]:
+    async def get_events(self, session_id: str) -> list[Event]:
         raise NotImplementedError("Subclasses must implement this method")
 
     @abstractmethod

--- a/src/omnicoreagent/core/events/redis_stream.py
+++ b/src/omnicoreagent/core/events/redis_stream.py
@@ -1,9 +1,10 @@
+import os
+
 import redis.asyncio as redis
 from typing import AsyncIterator, List
-from decouple import config
 from omnicoreagent.core.events.base import BaseEventStore, Event
 
-REDIS_URL = config("REDIS_URL", default="redis://localhost:6379/0")
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 
 
 class RedisStreamEventStore(BaseEventStore):
@@ -45,4 +46,3 @@ class RedisStreamEventStore(BaseEventStore):
                 for entry_id, data in entries:
                     last_id = entry_id
                     yield Event.parse_raw(data["event"])
-

--- a/src/omnicoreagent/core/llm.py
+++ b/src/omnicoreagent/core/llm.py
@@ -6,8 +6,6 @@ import time
 import warnings
 from typing import Any
 
-from decouple import config as decouple_config
-
 from omnicoreagent.core.utils import logger
 
 warnings.filterwarnings(
@@ -61,7 +59,9 @@ def retry_with_backoff(max_retries=3, base_delay=1, max_delay=60, backoff_factor
                             f"Max retries ({max_retries}) exceeded. Last error: {e}"
                         )
                         break
-                    _sleep_before_retry(e, attempt, max_retries, base_delay, max_delay, backoff_factor)
+                    _sleep_before_retry(
+                        e, attempt, max_retries, base_delay, max_delay, backoff_factor
+                    )
             raise last_exception
 
         def sync_wrapper(*args, **kwargs):
@@ -79,7 +79,9 @@ def retry_with_backoff(max_retries=3, base_delay=1, max_delay=60, backoff_factor
                             f"Max retries ({max_retries}) exceeded. Last error: {e}"
                         )
                         break
-                    _sleep_before_retry(e, attempt, max_retries, base_delay, max_delay, backoff_factor)
+                    _sleep_before_retry(
+                        e, attempt, max_retries, base_delay, max_delay, backoff_factor
+                    )
             raise last_exception
 
         return async_wrapper if inspect.iscoroutinefunction(func) else sync_wrapper
@@ -147,7 +149,7 @@ class LLMConnection:
         if not provider or not model:
             raise ValueError("model_config requires provider and model")
 
-        self.llm_api_key = self.llm_api_key or decouple_config("LLM_API_KEY", default=None)
+        self.llm_api_key = self.llm_api_key or os.environ.get("LLM_API_KEY")
         if not self.llm_api_key and provider.lower() != "ollama":
             raise ValueError("LLM_API_KEY not found in environment variables")
 
@@ -209,7 +211,10 @@ class LLMConnection:
             os.environ[env_name] = self.llm_api_key
 
     def is_llm_available(self) -> bool:
-        return self.llm_api_key is not None or self.llm_config["provider"].lower() == "ollama"
+        return (
+            self.llm_api_key is not None
+            or self.llm_config["provider"].lower() == "ollama"
+        )
 
     def to_dict(self, msg):
         if hasattr(msg, "model_dump"):

--- a/src/omnicoreagent/core/memory_store/memory_router.py
+++ b/src/omnicoreagent/core/memory_store/memory_router.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional, Callable
-from decouple import config as decouple_config
+import os
+
 from omnicoreagent.core.memory_store.in_memory import InMemoryStore
 from omnicoreagent._optional import load_optional
 from omnicoreagent.core.utils import logger
@@ -35,7 +36,7 @@ class MemoryRouter:
         if self.memory_store_type == "in_memory":
             self.memory_store = InMemoryStore()
         elif self.memory_store_type == "database":
-            db_url = decouple_config("DATABASE_URL", default=None)
+            db_url = os.environ.get("DATABASE_URL")
             if db_url is None:
                 logger.info("Database not configured, using in_memory")
                 self.memory_store = InMemoryStore()
@@ -50,7 +51,7 @@ class MemoryRouter:
                 )
                 self.memory_store = DatabaseMessageStore(db_url=db_url)
         elif self.memory_store_type == "redis":
-            redis_url = decouple_config("REDIS_URL", default=None)
+            redis_url = os.environ.get("REDIS_URL")
             if redis_url is None:
                 logger.info("Redis not configured, using in_memory")
                 self.memory_store = InMemoryStore()
@@ -65,13 +66,13 @@ class MemoryRouter:
                 )
                 self.memory_store = RedisMemoryStore(redis_url=redis_url)
         elif self.memory_store_type == "mongodb":
-            uri = decouple_config("MONGODB_URI", default=None)
+            uri = os.environ.get("MONGODB_URI")
             if uri is None:
                 logger.info("MongoDB not configured, using in_memory")
                 self.memory_store = InMemoryStore()
             else:
-                db_name = decouple_config("MONGODB_DB_NAME", default="omnicoreagent")
-                collection = decouple_config("MONGODB_COLLECTION", default="messages")
+                db_name = os.environ.get("MONGODB_DB_NAME", "omnicoreagent")
+                collection = os.environ.get("MONGODB_COLLECTION", "messages")
                 MongoDb = load_optional(
                     "MongoDB memory",
                     "mongodb",

--- a/src/omnicoreagent/core/memory_store/redis_memory.py
+++ b/src/omnicoreagent/core/memory_store/redis_memory.py
@@ -1,8 +1,8 @@
 import json
+import os
 import uuid
 from typing import Any, List, Callable
 import redis.asyncio as redis
-from decouple import config
 import threading
 import asyncio
 
@@ -14,7 +14,7 @@ from omnicoreagent.core.summarizer.summarizer_engine import (
 from omnicoreagent.core.summarizer.summarizer_types import SummaryConfig
 from datetime import datetime, timezone
 
-REDIS_URL = config("REDIS_URL", default=None)
+REDIS_URL = os.environ.get("REDIS_URL")
 
 
 class RedisConnectionManager:

--- a/src/omnicoreagent/core/summarizer/summarizer_types.py
+++ b/src/omnicoreagent/core/summarizer/summarizer_types.py
@@ -2,8 +2,8 @@
 Types for the summarizer engine and message lifecycle management.
 """
 
+from dataclasses import dataclass
 from enum import Enum
-from pydantic import BaseModel, Field
 
 
 class MessageStatus(str, Enum):
@@ -28,7 +28,8 @@ class SummaryRetentionPolicy(str, Enum):
     DELETE = "delete"
 
 
-class SummaryConfig(BaseModel):
+@dataclass
+class SummaryConfig:
     """
     User-facing configuration for summarization.
 
@@ -39,16 +40,11 @@ class SummaryConfig(BaseModel):
     Internal settings like summary_ratio and model are handled automatically.
     """
 
-    enabled: bool = Field(
-        default=False, description="Enable summarization when history exceeds limits"
-    )
-    retention_policy: SummaryRetentionPolicy = Field(
-        default=SummaryRetentionPolicy.KEEP,
-        description="What to do with messages after summarization: 'keep' or 'delete'",
-    )
+    enabled: bool = False
+    retention_policy: SummaryRetentionPolicy | str = SummaryRetentionPolicy.KEEP
 
-    class Config:
-        use_enum_values = True
+    def __post_init__(self):
+        self.retention_policy = SummaryRetentionPolicy(self.retention_policy)
 
 
 SUMMARY_TAG = "[CONVERSATION SUMMARY]"

--- a/src/omnicoreagent/core/tools/memory_tool/factory.py
+++ b/src/omnicoreagent/core/tools/memory_tool/factory.py
@@ -1,8 +1,9 @@
-from omnicoreagent.core.tools.memory_tool.base import AbstractMemoryBackend
-from omnicoreagent.core.tools.memory_tool.storage import WorkspaceMemoryBackend
+import os
 from threading import Lock
 
-from decouple import config
+from omnicoreagent.core.tools.memory_tool.base import AbstractMemoryBackend
+from omnicoreagent.core.tools.memory_tool.storage import WorkspaceMemoryBackend
+
 from omnicoreagent.core.utils import logger
 from omnicoreagent.core.workspace_storage import create_workspace_storage
 
@@ -45,9 +46,9 @@ def create_memory_backend(
 
 
 def _backend_cache_key() -> tuple:
-    workspace_backend = config("OMNICOREAGENT_WORKSPACE_BACKEND", default="local")
+    workspace_backend = os.environ.get("OMNICOREAGENT_WORKSPACE_BACKEND", "local")
     workspace_backend = workspace_backend.lower().strip()
-    prefix = config("OMNICOREAGENT_WORKSPACE_PREFIX", default="workspace").strip("/")
+    prefix = os.environ.get("OMNICOREAGENT_WORKSPACE_PREFIX", "workspace").strip("/")
 
     if workspace_backend == "local":
         from omnicoreagent.core.workspace import get_memories_dir
@@ -57,17 +58,17 @@ def _backend_cache_key() -> tuple:
     if workspace_backend == "s3":
         return (
             workspace_backend,
-            config("AWS_S3_BUCKET", default=None),
-            config("AWS_REGION", default=None),
-            config("AWS_ENDPOINT_URL", default=None),
+            os.environ.get("AWS_S3_BUCKET"),
+            os.environ.get("AWS_REGION"),
+            os.environ.get("AWS_ENDPOINT_URL"),
             prefix,
         )
 
     if workspace_backend == "r2":
         return (
             workspace_backend,
-            config("R2_BUCKET_NAME", default=None),
-            config("R2_ACCOUNT_ID", default=None),
+            os.environ.get("R2_BUCKET_NAME"),
+            os.environ.get("R2_ACCOUNT_ID"),
             prefix,
         )
 

--- a/src/omnicoreagent/core/utils.py
+++ b/src/omnicoreagent/core/utils.py
@@ -1,62 +1,23 @@
 import hashlib
 import json
 import logging
-import platform
 import re
-import subprocess
-import sys
 import traceback
 import uuid
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 from typing import Any, Callable, Coroutine, Optional
 from dataclasses import dataclass
 from types import SimpleNamespace
-from rich.console import Console, Group
-from rich.panel import Panel
-from rich.pretty import Pretty
-from rich.text import Text
 from datetime import datetime, timezone
-from decouple import config as decouple_config
 import asyncio
 from html import escape
 import ast
 import inspect
 
-console = Console()
 logger = logging.getLogger("omnicoreagent")
-logger.setLevel(logging.INFO)
-
-
-for handler in logger.handlers[:]:
-    logger.removeHandler(handler)
-
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setLevel(logging.INFO)
-
-log_file = Path("omnicoreagent.log")
-file_handler = logging.FileHandler(log_file, mode="a")
-file_handler.setLevel(logging.INFO)
-
-console_formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-
-file_formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-
-console_handler.setFormatter(console_formatter)
-file_handler.setFormatter(file_formatter)
-
-logger.addHandler(console_handler)
-logger.addHandler(file_handler)
-
-console_handler.flush = sys.stdout.flush
-file_handler.flush = lambda: file_handler.stream.flush()
+if not logger.handlers:
+    logger.addHandler(logging.NullHandler())
 
 
 class BackgroundTaskManager:
@@ -640,6 +601,11 @@ def strip_json_comments(text: str) -> str:
 
 
 def show_tool_response(agent_name, tool_name, tool_args, observation):
+    from rich.console import Console, Group
+    from rich.panel import Panel
+    from rich.pretty import Pretty
+    from rich.text import Text
+
     content = Group(
         Text(agent_name.upper(), style="bold magenta"),
         Text(f"→ Calling tool: {tool_name}", style="bold blue"),
@@ -650,10 +616,15 @@ def show_tool_response(agent_name, tool_name, tool_args, observation):
     )
 
     panel = Panel.fit(content, title="🔧 TOOL CALL LOG", border_style="bright_black")
-    console.print(panel)
+    Console().print(panel)
 
 
 def show_sub_agent_call_result(agent_call_result):
+    from rich.console import Console, Group
+    from rich.panel import Panel
+    from rich.pretty import Pretty
+    from rich.text import Text
+
     blocks = []
 
     parent_agent = agent_call_result.get("agent_name", "unknown_agent")
@@ -693,7 +664,7 @@ def show_sub_agent_call_result(agent_call_result):
         border_style="bright_black",
     )
 
-    console.print(panel)
+    Console().print(panel)
 
 
 def normalize_tool_args(value: Any) -> Any:
@@ -757,48 +728,6 @@ def normalize_tool_args(value: Any) -> Any:
     return _normalize(value)
 
 
-def get_mac_address() -> str:
-    """Get the MAC address of the client machine.
-
-    Returns:
-        str: The MAC address as a string, or a fallback UUID if MAC address cannot be determined.
-    """
-    try:
-        if platform.system() == "Linux":
-            for interface in ["eth0", "wlan0", "en0"]:
-                try:
-                    with open(f"/sys/class/net/{interface}/address") as f:
-                        mac = f.read().strip()
-                        if mac:
-                            return mac
-                except FileNotFoundError:
-                    continue
-
-            result = subprocess.run(
-                ["ip", "link", "show"], capture_output=True, text=True
-            )
-            for line in result.stdout.split("\n"):
-                if "link/ether" in line:
-                    return line.split("link/ether")[1].split()[0]
-
-        elif platform.system() == "Darwin":
-            result = subprocess.run(["ifconfig"], capture_output=True, text=True)
-            for line in result.stdout.split("\n"):
-                if "ether" in line:
-                    return line.split("ether")[1].split()[0]
-
-        elif platform.system() == "Windows":
-            result = subprocess.run(["getmac"], capture_output=True, text=True)
-            for line in result.stdout.split("\n"):
-                if ":" in line and "-" in line:
-                    return line.split()[0]
-
-    except Exception as e:
-        logger.warning(f"Could not get MAC address: {e}")
-
-    return str(uuid.uuid4())
-
-
 def build_xml_observations_block(tools_results):
     if not tools_results:
         return "<observations></observations>"
@@ -826,50 +755,15 @@ def build_xml_observations_block(tools_results):
     return "\n".join(lines)
 
 
-CLIENT_MAC_ADDRESS = get_mac_address()
+def track(name_or_func=None):
+    """No-op trace decorator placeholder for internal observability hooks."""
+    if callable(name_or_func):
+        return name_or_func
 
-OPIK_AVAILABLE = False
-track = None
+    def decorator(func):
+        return func
 
-try:
-    api_key = decouple_config("OPIK_API_KEY", default=None)
-    workspace = decouple_config("OPIK_WORKSPACE", default=None)
-
-    if api_key and workspace:
-        from opik import track as opik_track
-
-        OPIK_AVAILABLE = True
-        track = opik_track
-        logger.debug("Opik imported successfully with valid credentials")
-    else:
-        logger.debug("Opik available but no valid credentials - using fake decorator")
-
-        def track(name_or_func=None):
-            if callable(name_or_func):
-                return name_or_func
-            else:
-
-                def decorator(func):
-                    return func
-
-                return decorator
-
-            return decorator
-
-            return decorator
-except ImportError:
-
-    def track(name_or_func=None):
-        if callable(name_or_func):
-            return name_or_func
-        else:
-
-            def decorator(func):
-                return func
-
-            return decorator
-
-    logger.debug("Opik not available, using no-op decorator")
+    return decorator
 
 
 def get_json_schema(f) -> dict:

--- a/src/omnicoreagent/core/workspace_storage.py
+++ b/src/omnicoreagent/core/workspace_storage.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import urllib.parse
 from dataclasses import dataclass
@@ -5,7 +6,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Protocol
 
-from decouple import config
 from filelock import FileLock
 
 from omnicoreagent._optional import load_optional
@@ -452,7 +452,7 @@ def create_workspace_storage(
     namespace: str | None = None,
     workspace_dir: str | Path | None = None,
 ) -> WorkspaceStorage:
-    backend = (backend or config("OMNICOREAGENT_WORKSPACE_BACKEND", default="local"))
+    backend = backend or os.environ.get("OMNICOREAGENT_WORKSPACE_BACKEND", "local")
     backend = backend.lower().strip()
     namespace = (namespace or "").strip("/")
 
@@ -464,19 +464,21 @@ def create_workspace_storage(
         return LocalWorkspaceStorage(root)
 
     if backend == "s3":
-        bucket_name = config("AWS_S3_BUCKET", default=None)
+        bucket_name = os.environ.get("AWS_S3_BUCKET")
         if not bucket_name:
             raise ValueError("S3 workspace backend requires AWS_S3_BUCKET")
-        prefix = config("OMNICOREAGENT_WORKSPACE_PREFIX", default="workspace").strip("/")
+        prefix = os.environ.get("OMNICOREAGENT_WORKSPACE_PREFIX", "workspace").strip(
+            "/"
+        )
         if namespace:
             prefix = f"{prefix}/{namespace}"
         return S3WorkspaceStorage(
             bucket_name=bucket_name,
             prefix=prefix,
-            region=config("AWS_REGION", default=None),
-            aws_access_key_id=config("AWS_ACCESS_KEY_ID", default=None),
-            aws_secret_access_key=config("AWS_SECRET_ACCESS_KEY", default=None),
-            endpoint_url=config("AWS_ENDPOINT_URL", default=None),
+            region=os.environ.get("AWS_REGION"),
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+            endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
         )
 
     if backend == "r2":
@@ -488,20 +490,22 @@ def create_workspace_storage(
                 "R2_ACCESS_KEY_ID",
                 "R2_SECRET_ACCESS_KEY",
             )
-            if not config(name, default=None)
+            if not os.environ.get(name)
         ]
         if missing:
             raise ValueError(
                 f"R2 workspace backend requires environment variables: {', '.join(missing)}"
             )
-        prefix = config("OMNICOREAGENT_WORKSPACE_PREFIX", default="workspace").strip("/")
+        prefix = os.environ.get("OMNICOREAGENT_WORKSPACE_PREFIX", "workspace").strip(
+            "/"
+        )
         if namespace:
             prefix = f"{prefix}/{namespace}"
         return R2WorkspaceStorage(
-            bucket_name=config("R2_BUCKET_NAME"),
-            account_id=config("R2_ACCOUNT_ID"),
-            access_key_id=config("R2_ACCESS_KEY_ID"),
-            secret_access_key=config("R2_SECRET_ACCESS_KEY"),
+            bucket_name=os.environ["R2_BUCKET_NAME"],
+            account_id=os.environ["R2_ACCOUNT_ID"],
+            access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+            secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
             prefix=prefix,
         )
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,34 @@
+from omnicoreagent.core.events.base import (
+    Event,
+    EventType,
+    ToolCallStartedPayload,
+    UserMessagePayload,
+)
+
+
+def test_event_payloads_keep_model_dump_compatibility():
+    payload = UserMessagePayload(message="hello")
+
+    assert payload.model_dump() == {"message": "hello"}
+    assert payload.dict() == {"message": "hello"}
+    assert payload.json() == '{"message": "hello"}'
+
+
+def test_event_serializes_and_parses_without_pydantic():
+    event = Event(
+        type=EventType.TOOL_CALL_STARTED,
+        payload=ToolCallStartedPayload(tool_name="search", tool_args={"q": "test"}),
+        agent_name="agent",
+    )
+
+    parsed = Event.parse_raw(event.json())
+
+    assert parsed.type == EventType.TOOL_CALL_STARTED
+    assert parsed.agent_name == "agent"
+    assert parsed.payload.tool_name == "search"
+    assert parsed.payload.tool_args == {"q": "test"}
+    assert parsed.model_dump()["payload"] == {
+        "tool_name": "search",
+        "tool_args": {"q": "test"},
+        "tool_call_id": None,
+    }

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -236,14 +236,17 @@ def test_agent_initialize_without_optional_tools_stays_lightweight(tmp_path):
         """
 import asyncio
 import json
-import logging
 import sys
 
 from omnicoreagent import OmniCoreAgent
 
-logging.getLogger("omnicoreagent").disabled = True
-
 watched_modules = [
+    "decouple",
+    "opik",
+    "rich",
+    "rich.console",
+    "litellm",
+    "openai",
     "omnicoreagent.core.tools.advance_tools.advanced_tools_use",
     "omnicoreagent.core.tools.advance_tools_use",
     "omnicoreagent.core.tools.artifact_tool",
@@ -274,4 +277,33 @@ asyncio.run(main())
     assert result == {
         "agent_name": "startup",
         "loaded_modules": [],
+    }
+
+
+def test_core_utils_import_has_no_runtime_side_effects(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import sys
+from pathlib import Path
+
+from omnicoreagent.core import utils
+
+print(json.dumps({
+    "has_mac_probe": hasattr(utils, "get_mac_address"),
+    "log_file_created": Path("omnicoreagent.log").exists(),
+    "decouple_loaded": "decouple" in sys.modules,
+    "rich_loaded": any(module == "rich" or module.startswith("rich.") for module in sys.modules),
+    "opik_loaded": "opik" in sys.modules,
+}))
+""",
+    )
+
+    assert result == {
+        "has_mac_probe": False,
+        "log_file_created": False,
+        "decouple_loaded": False,
+        "rich_loaded": False,
+        "opik_loaded": False,
     }

--- a/uv.lock
+++ b/uv.lock
@@ -226,25 +226,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3-stubs"
-version = "1.40.37"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/80/3e31f2114867b8f8cf100a8dafda57c2cfab3b5f6e49d51a022574f07085/boto3_stubs-1.40.37.tar.gz", hash = "sha256:f9f8f1aaf8ac0cf33fe7d4611b7699f179badfe2b0066d59ae928fbf84b0b2b1", size = 100848, upload-time = "2025-09-23T19:42:45.257Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/55/1bf20a9e9538d17a9bc6099c31cd68675a5f9f0409465fdb5681ef734eb2/boto3_stubs-1.40.37-py3-none-any.whl", hash = "sha256:b4a2760e77fae7ddeb664f7deec5c6b9c03919f33f1cf20c42a3d2ab9f91f98c", size = 69688, upload-time = "2025-09-23T19:42:39.616Z" },
-]
-
-[package.optional-dependencies]
-bedrock-runtime = [
-    { name = "mypy-boto3-bedrock-runtime" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.42.37"
 source = { registry = "https://pypi.org/simple" }
@@ -256,18 +237,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/94292e7686e64d2ede8dae7102bbb11a1474e407c830de4192f2518e6cff/botocore-1.42.37.tar.gz", hash = "sha256:3ec58eb98b0857f67a2ae6aa3ded51597e7335f7640be654e0e86da4f173b5b2", size = 14914621, upload-time = "2026-01-28T20:38:34.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/30/54042dd3ad8161964f8f47aa418785079bd8d2f17053c40d65bafb9f6eed/botocore-1.42.37-py3-none-any.whl", hash = "sha256:f13bb8b560a10714d96fb7b0c7f17828dfa6e6606a1ead8c01c6ebb8765acbd8", size = 14589390, upload-time = "2026-01-28T20:38:31.306Z" },
-]
-
-[[package]]
-name = "botocore-stubs"
-version = "1.40.33"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-awscrt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/94/16f8e1f41feaa38f1350aa5a4c60c5724b6c8524ca0e6c28523bf5070e74/botocore_stubs-1.40.33.tar.gz", hash = "sha256:89c51ae0b28d9d79fde8c497cf908ddf872ce027d2737d4d4ba473fde9cdaa82", size = 42742, upload-time = "2025-09-17T20:25:56.388Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/7b/6d8fe12a955b16094460e89ea7c4e063f131f4b3bd461b96bcd625d0c79e/botocore_stubs-1.40.33-py3-none-any.whl", hash = "sha256:ad21fee32cbdc7ad4730f29baf88424c7086bf88a745f8e43660ca3e9a7e5f89", size = 66843, upload-time = "2025-09-17T20:25:54.052Z" },
 ]
 
 [[package]]
@@ -1568,18 +1537,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-boto3-bedrock-runtime"
-version = "1.40.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/ff/074a1e1425d04e7294c962803655e85e20e158734534ce8d302efaa8230a/mypy_boto3_bedrock_runtime-1.40.21.tar.gz", hash = "sha256:fa9401e86d42484a53803b1dba0782d023ab35c817256e707fbe4fff88aeb881", size = 28326, upload-time = "2025-08-29T19:25:09.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/02/9d3b881bee5552600c6f456e446069d5beffd2b7862b99e1e945d60d6a9b/mypy_boto3_bedrock_runtime-1.40.21-py3-none-any.whl", hash = "sha256:4c9ea181ef00cb3d15f9b051a50e3b78272122d24cd24ac34938efe6ddfecc62", size = 34149, upload-time = "2025-08-29T19:25:03.941Z" },
-]
-
-[[package]]
 name = "nh3"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1635,7 +1592,6 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "packaging" },
     { name = "pydantic", extra = ["email"] },
-    { name = "python-decouple" },
     { name = "python-dotenv" },
     { name = "rich" },
 ]
@@ -1646,7 +1602,6 @@ all = [
     { name = "boto3" },
     { name = "fastapi" },
     { name = "motor" },
-    { name = "opik" },
     { name = "psycopg2-binary" },
     { name = "pymongo" },
     { name = "python-multipart" },
@@ -1663,9 +1618,6 @@ background = [
 mongodb = [
     { name = "motor" },
     { name = "pymongo" },
-]
-observability = [
-    { name = "opik" },
 ]
 postgres = [
     { name = "psycopg2-binary" },
@@ -1693,7 +1645,6 @@ dev = [
     { name = "fastapi" },
     { name = "hatch" },
     { name = "motor" },
-    { name = "opik" },
     { name = "pre-commit" },
     { name = "psycopg2-binary" },
     { name = "pymongo" },
@@ -1734,15 +1685,12 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.1" },
     { name = "motor", marker = "extra == 'all'", specifier = ">=3.7.1" },
     { name = "motor", marker = "extra == 'mongodb'", specifier = ">=3.7.1" },
-    { name = "opik", marker = "extra == 'all'", specifier = ">=1.8.19" },
-    { name = "opik", marker = "extra == 'observability'", specifier = ">=1.8.19" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "psycopg2-binary", marker = "extra == 'all'", specifier = ">=2.9.10" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.10" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.6.0" },
     { name = "pymongo", marker = "extra == 'all'", specifier = ">=4.15.1" },
     { name = "pymongo", marker = "extra == 'mongodb'", specifier = ">=4.15.1" },
-    { name = "python-decouple", specifier = ">=3.8" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", marker = "extra == 'all'", specifier = ">=0.0.20" },
     { name = "python-multipart", marker = "extra == 'serve'", specifier = ">=0.0.20" },
@@ -1758,7 +1706,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.34.1" },
     { name = "uvicorn", marker = "extra == 'serve'", specifier = ">=0.34.1" },
 ]
-provides-extras = ["all", "background", "mongodb", "observability", "postgres", "redis", "s3", "serve", "tokenizer"]
+provides-extras = ["all", "background", "mongodb", "postgres", "redis", "s3", "serve", "tokenizer"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1767,7 +1715,6 @@ dev = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "hatch", specifier = ">=1.14.1" },
     { name = "motor", specifier = ">=3.7.1" },
-    { name = "opik", specifier = ">=1.8.19" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pymongo", specifier = ">=4.15.1" },
@@ -1807,32 +1754,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/9f/d11cc7fb2d60af14a97dbef4e3c7b23917387995c257951fdc321d8efd0a/openai-1.109.0.tar.gz", hash = "sha256:701e26d13e3953524ba99f44cf5fbbda40eafd41ba15a8d85b76229a2693cfe5", size = 563971, upload-time = "2025-09-23T16:59:41.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/d3/d65e318e8d3b5845afaa5960d8da779988b4cb9f4e1ca82e588fed9c6a9d/openai-1.109.0-py3-none-any.whl", hash = "sha256:8c0910bdd4ee1274d5ff0354786bdd0bc79e68c158d5d2c19e24208b412e5792", size = 948421, upload-time = "2025-09-23T16:59:39.516Z" },
-]
-
-[[package]]
-name = "opik"
-version = "1.8.54"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boto3-stubs", extra = ["bedrock-runtime"] },
-    { name = "click" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "litellm" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pytest" },
-    { name = "rapidfuzz" },
-    { name = "rich" },
-    { name = "sentry-sdk" },
-    { name = "tenacity" },
-    { name = "tqdm" },
-    { name = "uuid6" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/1a/0ae96ade771c39db5aa297f7c43ed8c85b8ab64f25143c061885e94cfadf/opik-1.8.54.tar.gz", hash = "sha256:ec86d803f3513a95fad70cc8fe573503d76138afd9c645171e2386cb1ea80c7c", size = 386545, upload-time = "2025-09-23T14:51:39.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/2e/bccdd832deed802c0d3cf28712fcb1cb2fd360d52a5f560c0207add53c33/opik-1.8.54-py3-none-any.whl", hash = "sha256:00721697bb0b0b7f58aa0c2b1ad43837b2bfc090425b3d59059e70f29e75aab7", size = 718276, upload-time = "2025-09-23T14:51:37.418Z" },
 ]
 
 [[package]]
@@ -2331,15 +2252,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-decouple"
-version = "3.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/97/373dcd5844ec0ea5893e13c39a2c67e7537987ad8de3842fe078db4582fa/python-decouple-3.8.tar.gz", hash = "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f", size = 9612, upload-time = "2023-03-01T19:38:38.143Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/d4/9193206c4563ec771faf2ccf54815ca7918529fe81f6adb22ee6d0e06622/python_decouple-3.8-py3-none-any.whl", hash = "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66", size = 9947, upload-time = "2023-03-01T19:38:36.015Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2451,105 +2363,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
-]
-
-[[package]]
-name = "rapidfuzz"
-version = "3.14.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/fc/a98b616db9a42dcdda7c78c76bdfdf6fe290ac4c5ffbb186f73ec981ad5b/rapidfuzz-3.14.1.tar.gz", hash = "sha256:b02850e7f7152bd1edff27e9d584505b84968cacedee7a734ec4050c655a803c", size = 57869570, upload-time = "2025-09-08T21:08:15.922Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/b9/4e35178f405a1a95abd37cce4dc09d4a5bbc5e098687680b5ba796d3115b/rapidfuzz-3.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:489440e4b5eea0d150a31076eb183bed0ec84f934df206c72ae4fc3424501758", size = 1939645, upload-time = "2025-09-08T21:05:16.569Z" },
-    { url = "https://files.pythonhosted.org/packages/51/af/fd7b8662a3b6952559af322dcf1c9d4eb5ec6be2697c30ae8ed3c44876ca/rapidfuzz-3.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eff22cc938c3f74d194df03790a6c3325d213b28cf65cdefd6fdeae759b745d5", size = 1393620, upload-time = "2025-09-08T21:05:18.598Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/5b/5715445e29c1c6ba364b3d27278da3fdffb18d9147982e977c6638dcecbf/rapidfuzz-3.14.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0307f018b16feaa36074bcec2496f6f120af151a098910296e72e233232a62f", size = 1387721, upload-time = "2025-09-08T21:05:20.408Z" },
-    { url = "https://files.pythonhosted.org/packages/19/49/83a14a6a90982b090257c4b2e96b9b9c423a89012b8504d5a14d92a4f8c2/rapidfuzz-3.14.1-cp310-cp310-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bc133652da143aca1ab72de235446432888b2b7f44ee332d006f8207967ecb8a", size = 1694545, upload-time = "2025-09-08T21:05:22.137Z" },
-    { url = "https://files.pythonhosted.org/packages/99/f7/94618fcaaac8c04abf364f405c6811a02bc9edef209f276dc513a9a50f7c/rapidfuzz-3.14.1-cp310-cp310-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e9e71b3fe7e4a1590843389a90fe2a8684649fc74b9b7446e17ee504ddddb7de", size = 2237075, upload-time = "2025-09-08T21:05:23.637Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f6/a5ee2db25f36b0e5e06502fb77449b7718cd9f92ad36d598e669ba91db7b/rapidfuzz-3.14.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c51519eb2f20b52eba6fc7d857ae94acc6c2a1f5d0f2d794b9d4977cdc29dd7", size = 3168778, upload-time = "2025-09-08T21:05:25.508Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e8/c9620e358805c099e6755b7d2827b1e711b5e61914d6112ce2faa2c2af79/rapidfuzz-3.14.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:fe87d94602624f8f25fff9a0a7b47f33756c4d9fc32b6d3308bb142aa483b8a4", size = 1223827, upload-time = "2025-09-08T21:05:27.299Z" },
-    { url = "https://files.pythonhosted.org/packages/84/08/24916c3c3d55d6236474c9da0a595641d0013d3604de0625e8a8974371c3/rapidfuzz-3.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2d665380503a575dda52eb712ea521f789e8f8fd629c7a8e6c0f8ff480febc78", size = 2408366, upload-time = "2025-09-08T21:05:28.808Z" },
-    { url = "https://files.pythonhosted.org/packages/40/d4/4152e8821b5c548443a6c46568fccef13de5818a5ab370d553ea3d5955b3/rapidfuzz-3.14.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:c0f0dd022b8a7cbf3c891f6de96a80ab6a426f1069a085327816cea749e096c2", size = 2530148, upload-time = "2025-09-08T21:05:30.782Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/af/6587c6d590abe232c530ad43fbfbcaec899bff7204e237f1fd21e2e44b81/rapidfuzz-3.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:bf1ba22d36858b265c95cd774ba7fe8991e80a99cd86fe4f388605b01aee81a3", size = 2810628, upload-time = "2025-09-08T21:05:32.844Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/90/a99e6cfd90feb9d770654f1f39321099bbbf7f85d2832f2ef48d3f4ebc5f/rapidfuzz-3.14.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:ca1c1494ac9f9386d37f0e50cbaf4d07d184903aed7691549df1b37e9616edc9", size = 3314406, upload-time = "2025-09-08T21:05:34.585Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b3/eba5a6c217200fd1d3615997930a9e5db6a74e3002b7867b54545f9b5cbb/rapidfuzz-3.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9e4b12e921b0fa90d7c2248742a536f21eae5562174090b83edd0b4ab8b557d7", size = 4280030, upload-time = "2025-09-08T21:05:36.646Z" },
-    { url = "https://files.pythonhosted.org/packages/04/6f/d2e060a2094cfb7f3cd487c376e098abb22601e0eea178e51a59ce0a3158/rapidfuzz-3.14.1-cp310-cp310-win32.whl", hash = "sha256:5e1c1f2292baa4049535b07e9e81feb29e3650d2ba35ee491e64aca7ae4cb15e", size = 1727070, upload-time = "2025-09-08T21:05:38.57Z" },
-    { url = "https://files.pythonhosted.org/packages/73/0a/ca231464ec689f2aabf9547a52cbc76a10affe960bddde8660699ba3de33/rapidfuzz-3.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:59a8694beb9a13c4090ab3d1712cabbd896c6949706d1364e2a2e1713c413760", size = 1545335, upload-time = "2025-09-08T21:05:40.22Z" },
-    { url = "https://files.pythonhosted.org/packages/59/c5/1e0b17f20fd3d701470548a6db8f36d589fb1a8a65d3828968547d987486/rapidfuzz-3.14.1-cp310-cp310-win_arm64.whl", hash = "sha256:e94cee93faa792572c574a615abe12912124b4ffcf55876b72312914ab663345", size = 816960, upload-time = "2025-09-08T21:05:42.225Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c7/c3c860d512606225c11c8ee455b4dc0b0214dbcfac90a2c22dddf55320f3/rapidfuzz-3.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4d976701060886a791c8a9260b1d4139d14c1f1e9a6ab6116b45a1acf3baff67", size = 1938398, upload-time = "2025-09-08T21:05:44.031Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/f3/67f5c5cd4d728993c48c1dcb5da54338d77c03c34b4903cc7839a3b89faf/rapidfuzz-3.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5e6ba7e6eb2ab03870dcab441d707513db0b4264c12fba7b703e90e8b4296df2", size = 1392819, upload-time = "2025-09-08T21:05:45.549Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/06/400d44842f4603ce1bebeaeabe776f510e329e7dbf6c71b6f2805e377889/rapidfuzz-3.14.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e532bf46de5fd3a1efde73a16a4d231d011bce401c72abe3c6ecf9de681003f", size = 1391798, upload-time = "2025-09-08T21:05:47.044Z" },
-    { url = "https://files.pythonhosted.org/packages/90/97/a6944955713b47d88e8ca4305ca7484940d808c4e6c4e28b6fa0fcbff97e/rapidfuzz-3.14.1-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f9b6a6fb8ed9b951e5f3b82c1ce6b1665308ec1a0da87f799b16e24fc59e4662", size = 1699136, upload-time = "2025-09-08T21:05:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/1e/f311a5c95ddf922db6dd8666efeceb9ac69e1319ed098ac80068a4041732/rapidfuzz-3.14.1-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b6ac3f9810949caef0e63380b11a3c32a92f26bacb9ced5e32c33560fcdf8d1", size = 2236238, upload-time = "2025-09-08T21:05:50.844Z" },
-    { url = "https://files.pythonhosted.org/packages/85/27/e14e9830255db8a99200f7111b158ddef04372cf6332a415d053fe57cc9c/rapidfuzz-3.14.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52e4c34fd567f77513e886b66029c1ae02f094380d10eba18ba1c68a46d8b90", size = 3183685, upload-time = "2025-09-08T21:05:52.362Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b2/42850c9616ddd2887904e5dd5377912cbabe2776fdc9fd4b25e6e12fba32/rapidfuzz-3.14.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:2ef72e41b1a110149f25b14637f1cedea6df192462120bea3433980fe9d8ac05", size = 1231523, upload-time = "2025-09-08T21:05:53.927Z" },
-    { url = "https://files.pythonhosted.org/packages/de/b5/6b90ed7127a1732efef39db46dd0afc911f979f215b371c325a2eca9cb15/rapidfuzz-3.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fb654a35b373d712a6b0aa2a496b2b5cdd9d32410cfbaecc402d7424a90ba72a", size = 2415209, upload-time = "2025-09-08T21:05:55.422Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/af51c50d238c82f2179edc4b9f799cc5a50c2c0ebebdcfaa97ded7d02978/rapidfuzz-3.14.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:2b2c12e5b9eb8fe9a51b92fe69e9ca362c0970e960268188a6d295e1dec91e6d", size = 2532957, upload-time = "2025-09-08T21:05:57.048Z" },
-    { url = "https://files.pythonhosted.org/packages/50/92/29811d2ba7c984251a342c4f9ccc7cc4aa09d43d800af71510cd51c36453/rapidfuzz-3.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4f069dec5c450bd987481e752f0a9979e8fdf8e21e5307f5058f5c4bb162fa56", size = 2815720, upload-time = "2025-09-08T21:05:58.618Z" },
-    { url = "https://files.pythonhosted.org/packages/78/69/cedcdee16a49e49d4985eab73b59447f211736c5953a58f1b91b6c53a73f/rapidfuzz-3.14.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:4d0d9163725b7ad37a8c46988cae9ebab255984db95ad01bf1987ceb9e3058dd", size = 3323704, upload-time = "2025-09-08T21:06:00.576Z" },
-    { url = "https://files.pythonhosted.org/packages/76/3e/5a3f9a5540f18e0126e36f86ecf600145344acb202d94b63ee45211a18b8/rapidfuzz-3.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db656884b20b213d846f6bc990c053d1f4a60e6d4357f7211775b02092784ca1", size = 4287341, upload-time = "2025-09-08T21:06:02.301Z" },
-    { url = "https://files.pythonhosted.org/packages/46/26/45db59195929dde5832852c9de8533b2ac97dcc0d852d1f18aca33828122/rapidfuzz-3.14.1-cp311-cp311-win32.whl", hash = "sha256:4b42f7b9c58cbcfbfaddc5a6278b4ca3b6cd8983e7fd6af70ca791dff7105fb9", size = 1726574, upload-time = "2025-09-08T21:06:04.357Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5c/a4caf76535f35fceab25b2aaaed0baecf15b3d1fd40746f71985d20f8c4b/rapidfuzz-3.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:e5847f30d7d4edefe0cb37294d956d3495dd127c1c56e9128af3c2258a520bb4", size = 1547124, upload-time = "2025-09-08T21:06:06.002Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/66/aa93b52f95a314584d71fa0b76df00bdd4158aafffa76a350f1ae416396c/rapidfuzz-3.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:5087d8ad453092d80c042a08919b1cb20c8ad6047d772dc9312acd834da00f75", size = 816958, upload-time = "2025-09-08T21:06:07.509Z" },
-    { url = "https://files.pythonhosted.org/packages/df/77/2f4887c9b786f203e50b816c1cde71f96642f194e6fa752acfa042cf53fd/rapidfuzz-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:809515194f628004aac1b1b280c3734c5ea0ccbd45938c9c9656a23ae8b8f553", size = 1932216, upload-time = "2025-09-08T21:06:09.342Z" },
-    { url = "https://files.pythonhosted.org/packages/de/bd/b5e445d156cb1c2a87d36d8da53daf4d2a1d1729b4851660017898b49aa0/rapidfuzz-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0afcf2d6cb633d0d4260d8df6a40de2d9c93e9546e2c6b317ab03f89aa120ad7", size = 1393414, upload-time = "2025-09-08T21:06:10.959Z" },
-    { url = "https://files.pythonhosted.org/packages/de/bd/98d065dd0a4479a635df855616980eaae1a1a07a876db9400d421b5b6371/rapidfuzz-3.14.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5c1c3d07d53dcafee10599da8988d2b1f39df236aee501ecbd617bd883454fcd", size = 1377194, upload-time = "2025-09-08T21:06:12.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/8a/1265547b771128b686f3c431377ff1db2fa073397ed082a25998a7b06d4e/rapidfuzz-3.14.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e9ee3e1eb0a027717ee72fe34dc9ac5b3e58119f1bd8dd15bc19ed54ae3e62b", size = 1669573, upload-time = "2025-09-08T21:06:14.016Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/57/e73755c52fb451f2054196404ccc468577f8da023b3a48c80bce29ee5d4a/rapidfuzz-3.14.1-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:70c845b64a033a20c44ed26bc890eeb851215148cc3e696499f5f65529afb6cb", size = 2217833, upload-time = "2025-09-08T21:06:15.666Z" },
-    { url = "https://files.pythonhosted.org/packages/20/14/7399c18c460e72d1b754e80dafc9f65cb42a46cc8f29cd57d11c0c4acc94/rapidfuzz-3.14.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26db0e815213d04234298dea0d884d92b9cb8d4ba954cab7cf67a35853128a33", size = 3159012, upload-time = "2025-09-08T21:06:17.631Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/24f0226ddb5440cabd88605d2491f99ae3748a6b27b0bc9703772892ced7/rapidfuzz-3.14.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:6ad3395a416f8b126ff11c788531f157c7debeb626f9d897c153ff8980da10fb", size = 1227032, upload-time = "2025-09-08T21:06:21.06Z" },
-    { url = "https://files.pythonhosted.org/packages/40/43/1d54a4ad1a5fac2394d5f28a3108e2bf73c26f4f23663535e3139cfede9b/rapidfuzz-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:61c5b9ab6f730e6478aa2def566223712d121c6f69a94c7cc002044799442afd", size = 2395054, upload-time = "2025-09-08T21:06:23.482Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/71/e9864cd5b0f086c4a03791f5dfe0155a1b132f789fe19b0c76fbabd20513/rapidfuzz-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:13e0ea3d0c533969158727d1bb7a08c2cc9a816ab83f8f0dcfde7e38938ce3e6", size = 2524741, upload-time = "2025-09-08T21:06:26.825Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/0c/53f88286b912faf4a3b2619a60df4f4a67bd0edcf5970d7b0c1143501f0c/rapidfuzz-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6325ca435b99f4001aac919ab8922ac464999b100173317defb83eae34e82139", size = 2785311, upload-time = "2025-09-08T21:06:29.471Z" },
-    { url = "https://files.pythonhosted.org/packages/53/9a/229c26dc4f91bad323f07304ee5ccbc28f0d21c76047a1e4f813187d0bad/rapidfuzz-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:07a9fad3247e68798424bdc116c1094e88ecfabc17b29edf42a777520347648e", size = 3303630, upload-time = "2025-09-08T21:06:31.094Z" },
-    { url = "https://files.pythonhosted.org/packages/05/de/20e330d6d58cbf83da914accd9e303048b7abae2f198886f65a344b69695/rapidfuzz-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8ff5dbe78db0a10c1f916368e21d328935896240f71f721e073cf6c4c8cdedd", size = 4262364, upload-time = "2025-09-08T21:06:32.877Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/10/2327f83fad3534a8d69fe9cd718f645ec1fe828b60c0e0e97efc03bf12f8/rapidfuzz-3.14.1-cp312-cp312-win32.whl", hash = "sha256:9c83270e44a6ae7a39fc1d7e72a27486bccc1fa5f34e01572b1b90b019e6b566", size = 1711927, upload-time = "2025-09-08T21:06:34.669Z" },
-    { url = "https://files.pythonhosted.org/packages/78/8d/199df0370133fe9f35bc72f3c037b53c93c5c1fc1e8d915cf7c1f6bb8557/rapidfuzz-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:e06664c7fdb51c708e082df08a6888fce4c5c416d7e3cc2fa66dd80eb76a149d", size = 1542045, upload-time = "2025-09-08T21:06:36.364Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/c6/cc5d4bd1b16ea2657c80b745d8b1c788041a31fad52e7681496197b41562/rapidfuzz-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:6c7c26025f7934a169a23dafea6807cfc3fb556f1dd49229faf2171e5d8101cc", size = 813170, upload-time = "2025-09-08T21:06:38.001Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/f2/0024cc8eead108c4c29337abe133d72ddf3406ce9bbfbcfc110414a7ea07/rapidfuzz-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8d69f470d63ee824132ecd80b1974e1d15dd9df5193916901d7860cef081a260", size = 1926515, upload-time = "2025-09-08T21:06:39.834Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ae/6cb211f8930bea20fa989b23f31ee7f92940caaf24e3e510d242a1b28de4/rapidfuzz-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6f571d20152fc4833b7b5e781b36d5e4f31f3b5a596a3d53cf66a1bd4436b4f4", size = 1388431, upload-time = "2025-09-08T21:06:41.73Z" },
-    { url = "https://files.pythonhosted.org/packages/39/88/bfec24da0607c39e5841ced5594ea1b907d20f83adf0e3ee87fa454a425b/rapidfuzz-3.14.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61d77e09b2b6bc38228f53b9ea7972a00722a14a6048be9a3672fb5cb08bad3a", size = 1375664, upload-time = "2025-09-08T21:06:43.737Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/43/9f282ba539e404bdd7052c7371d3aaaa1a9417979d2a1d8332670c7f385a/rapidfuzz-3.14.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b41d95ef86a6295d353dc3bb6c80550665ba2c3bef3a9feab46074d12a9af8f", size = 1668113, upload-time = "2025-09-08T21:06:45.758Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/2f/0b3153053b1acca90969eb0867922ac8515b1a8a48706a3215c2db60e87c/rapidfuzz-3.14.1-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0591df2e856ad583644b40a2b99fb522f93543c65e64b771241dda6d1cfdc96b", size = 2212875, upload-time = "2025-09-08T21:06:47.447Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/9b/623001dddc518afaa08ed1fbbfc4005c8692b7a32b0f08b20c506f17a770/rapidfuzz-3.14.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f277801f55b2f3923ef2de51ab94689a0671a4524bf7b611de979f308a54cd6f", size = 3161181, upload-time = "2025-09-08T21:06:49.179Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b7/d8404ed5ad56eb74463e5ebf0a14f0019d7eb0e65e0323f709fe72e0884c/rapidfuzz-3.14.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:893fdfd4f66ebb67f33da89eb1bd1674b7b30442fdee84db87f6cb9074bf0ce9", size = 1225495, upload-time = "2025-09-08T21:06:51.056Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6c/b96af62bc7615d821e3f6b47563c265fd7379d7236dfbc1cbbcce8beb1d2/rapidfuzz-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fe2651258c1f1afa9b66f44bf82f639d5f83034f9804877a1bbbae2120539ad1", size = 2396294, upload-time = "2025-09-08T21:06:53.063Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/b7/c60c9d22a7debed8b8b751f506a4cece5c22c0b05e47a819d6b47bc8c14e/rapidfuzz-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ace21f7a78519d8e889b1240489cd021c5355c496cb151b479b741a4c27f0a25", size = 2529629, upload-time = "2025-09-08T21:06:55.188Z" },
-    { url = "https://files.pythonhosted.org/packages/25/94/a9ec7ccb28381f14de696ffd51c321974762f137679df986f5375d35264f/rapidfuzz-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:cb5acf24590bc5e57027283b015950d713f9e4d155fda5cfa71adef3b3a84502", size = 2782960, upload-time = "2025-09-08T21:06:57.339Z" },
-    { url = "https://files.pythonhosted.org/packages/68/80/04e5276d223060eca45250dbf79ea39940c0be8b3083661d58d57572c2c5/rapidfuzz-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:67ea46fa8cc78174bad09d66b9a4b98d3068e85de677e3c71ed931a1de28171f", size = 3298427, upload-time = "2025-09-08T21:06:59.319Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/63/24759b2a751562630b244e68ccaaf7a7525c720588fcc77c964146355aee/rapidfuzz-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:44e741d785de57d1a7bae03599c1cbc7335d0b060a35e60c44c382566e22782e", size = 4267736, upload-time = "2025-09-08T21:07:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a4/73f1b1f7f44d55f40ffbffe85e529eb9d7e7f7b2ffc0931760eadd163995/rapidfuzz-3.14.1-cp313-cp313-win32.whl", hash = "sha256:b1fe6001baa9fa36bcb565e24e88830718f6c90896b91ceffcb48881e3adddbc", size = 1710515, upload-time = "2025-09-08T21:07:03.16Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8b/a8fe5a6ee4d06fd413aaa9a7e0a23a8630c4b18501509d053646d18c2aa7/rapidfuzz-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:83b8cc6336709fa5db0579189bfd125df280a554af544b2dc1c7da9cdad7e44d", size = 1540081, upload-time = "2025-09-08T21:07:05.401Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/fe/4b0ac16c118a2367d85450b45251ee5362661e9118a1cef88aae1765ffff/rapidfuzz-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:cf75769662eadf5f9bd24e865c19e5ca7718e879273dce4e7b3b5824c4da0eb4", size = 812725, upload-time = "2025-09-08T21:07:07.148Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/cb/1ad9a76d974d153783f8e0be8dbe60ec46488fac6e519db804e299e0da06/rapidfuzz-3.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d937dbeda71c921ef6537c6d41a84f1b8112f107589c9977059de57a1d726dd6", size = 1945173, upload-time = "2025-09-08T21:07:08.893Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/61/959ed7460941d8a81cbf6552b9c45564778a36cf5e5aa872558b30fc02b2/rapidfuzz-3.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7a2d80cc1a4fcc7e259ed4f505e70b36433a63fa251f1bb69ff279fe376c5efd", size = 1413949, upload-time = "2025-09-08T21:07:11.033Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a0/f46fca44457ca1f25f23cc1f06867454fc3c3be118cd10b552b0ab3e58a2/rapidfuzz-3.14.1-cp313-cp313t-win32.whl", hash = "sha256:40875e0c06f1a388f1cab3885744f847b557e0b1642dfc31ff02039f9f0823ef", size = 1760666, upload-time = "2025-09-08T21:07:12.884Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/d0/7a5d9c04446f8b66882b0fae45b36a838cf4d31439b5d1ab48a9d17c8e57/rapidfuzz-3.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:876dc0c15552f3d704d7fb8d61bdffc872ff63bedf683568d6faad32e51bbce8", size = 1579760, upload-time = "2025-09-08T21:07:14.718Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/aa/2c03ae112320d0746f2c869cae68c413f3fe3b6403358556f2b747559723/rapidfuzz-3.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:61458e83b0b3e2abc3391d0953c47d6325e506ba44d6a25c869c4401b3bc222c", size = 832088, upload-time = "2025-09-08T21:07:17.03Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/36/53debca45fbe693bd6181fb05b6a2fd561c87669edb82ec0d7c1961a43f0/rapidfuzz-3.14.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e84d9a844dc2e4d5c4cabd14c096374ead006583304333c14a6fbde51f612a44", size = 1926336, upload-time = "2025-09-08T21:07:18.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/32/b874f48609665fcfeaf16cbaeb2bbc210deef2b88e996c51cfc36c3eb7c3/rapidfuzz-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:40301b93b99350edcd02dbb22e37ca5f2a75d0db822e9b3c522da451a93d6f27", size = 1389653, upload-time = "2025-09-08T21:07:20.667Z" },
-    { url = "https://files.pythonhosted.org/packages/97/25/f6c5a1ff4ec11edadacb270e70b8415f51fa2f0d5730c2c552b81651fbe3/rapidfuzz-3.14.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fedd5097a44808dddf341466866e5c57a18a19a336565b4ff50aa8f09eb528f6", size = 1380911, upload-time = "2025-09-08T21:07:22.584Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f3/d322202ef8fab463759b51ebfaa33228100510c82e6153bd7a922e150270/rapidfuzz-3.14.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e3e61c9e80d8c26709d8aa5c51fdd25139c81a4ab463895f8a567f8347b0548", size = 1673515, upload-time = "2025-09-08T21:07:24.417Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/b9/6b2a97f4c6be96cac3749f32301b8cdf751ce5617b1c8934c96586a0662b/rapidfuzz-3.14.1-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da011a373722fac6e64687297a1d17dc8461b82cb12c437845d5a5b161bc24b9", size = 2219394, upload-time = "2025-09-08T21:07:26.402Z" },
-    { url = "https://files.pythonhosted.org/packages/11/bf/afb76adffe4406e6250f14ce48e60a7eb05d4624945bd3c044cfda575fbc/rapidfuzz-3.14.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5967d571243cfb9ad3710e6e628ab68c421a237b76e24a67ac22ee0ff12784d6", size = 3163582, upload-time = "2025-09-08T21:07:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/42/34/e6405227560f61e956cb4c5de653b0f874751c5ada658d3532d6c1df328e/rapidfuzz-3.14.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:474f416cbb9099676de54aa41944c154ba8d25033ee460f87bb23e54af6d01c9", size = 1221116, upload-time = "2025-09-08T21:07:30.8Z" },
-    { url = "https://files.pythonhosted.org/packages/55/e6/5b757e2e18de384b11d1daf59608453f0baf5d5d8d1c43e1a964af4dc19a/rapidfuzz-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ae2d57464b59297f727c4e201ea99ec7b13935f1f056c753e8103da3f2fc2404", size = 2402670, upload-time = "2025-09-08T21:07:32.702Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c4/d753a415fe54531aa882e288db5ed77daaa72e05c1a39e1cbac00d23024f/rapidfuzz-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:57047493a1f62f11354c7143c380b02f1b355c52733e6b03adb1cb0fe8fb8816", size = 2521659, upload-time = "2025-09-08T21:07:35.218Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/28/d4e7fe1515430db98f42deb794c7586a026d302fe70f0216b638d89cf10f/rapidfuzz-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4acc20776f225ee37d69517a237c090b9fa7e0836a0b8bc58868e9168ba6ef6f", size = 2788552, upload-time = "2025-09-08T21:07:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/00/eab05473af7a2cafb4f3994bc6bf408126b8eec99a569aac6254ac757db4/rapidfuzz-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4373f914ff524ee0146919dea96a40a8200ab157e5a15e777a74a769f73d8a4a", size = 3306261, upload-time = "2025-09-08T21:07:39.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/31/2feb8dfcfcff6508230cd2ccfdde7a8bf988c6fda142fe9ce5d3eb15704d/rapidfuzz-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:37017b84953927807847016620d61251fe236bd4bcb25e27b6133d955bb9cafb", size = 4269522, upload-time = "2025-09-08T21:07:41.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/99/250538d73c8fbab60597c3d131a11ef2a634d38b44296ca11922794491ac/rapidfuzz-3.14.1-cp314-cp314-win32.whl", hash = "sha256:c8d1dd1146539e093b84d0805e8951475644af794ace81d957ca612e3eb31598", size = 1745018, upload-time = "2025-09-08T21:07:44.313Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/15/d50839d20ad0743aded25b08a98ffb872f4bfda4e310bac6c111fcf6ea1f/rapidfuzz-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:f51c7571295ea97387bac4f048d73cecce51222be78ed808263b45c79c40a440", size = 1587666, upload-time = "2025-09-08T21:07:46.917Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ff/d73fec989213fb6f0b6f15ee4bbdf2d88b0686197951a06b036111cd1c7d/rapidfuzz-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:01eab10ec90912d7d28b3f08f6c91adbaf93458a53f849ff70776ecd70dd7a7a", size = 835780, upload-time = "2025-09-08T21:07:49.256Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e7/f0a242687143cebd33a1fb165226b73bd9496d47c5acfad93de820a18fa8/rapidfuzz-3.14.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:60879fcae2f7618403c4c746a9a3eec89327d73148fb6e89a933b78442ff0669", size = 1945182, upload-time = "2025-09-08T21:07:51.84Z" },
-    { url = "https://files.pythonhosted.org/packages/96/29/ca8a3f8525e3d0e7ab49cb927b5fb4a54855f794c9ecd0a0b60a6c96a05f/rapidfuzz-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f94d61e44db3fc95a74006a394257af90fa6e826c900a501d749979ff495d702", size = 1413946, upload-time = "2025-09-08T21:07:53.702Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/ef/6fd10aa028db19c05b4ac7fe77f5613e4719377f630c709d89d7a538eea2/rapidfuzz-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:93b6294a3ffab32a9b5f9b5ca048fa0474998e7e8bb0f2d2b5e819c64cb71ec7", size = 1795851, upload-time = "2025-09-08T21:07:55.76Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/30/acd29ebd906a50f9e0f27d5f82a48cf5e8854637b21489bd81a2459985cf/rapidfuzz-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6cb56b695421538fdbe2c0c85888b991d833b8637d2f2b41faa79cea7234c000", size = 1626748, upload-time = "2025-09-08T21:07:58.166Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/f4/dfc7b8c46b1044a47f7ca55deceb5965985cff3193906cb32913121e6652/rapidfuzz-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7cd312c380d3ce9d35c3ec9726b75eee9da50e8a38e89e229a03db2262d3d96b", size = 853771, upload-time = "2025-09-08T21:08:00.816Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/10/0ed838b296fdac08ecbaa3a220fb4f1d887ff41b0be44fe8eade45bb650e/rapidfuzz-3.14.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:673ce55a9be5b772dade911909e42382c0828b8a50ed7f9168763fa6b9f7054d", size = 1860246, upload-time = "2025-09-08T21:08:02.762Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/70/a08f4a86387dec97508ead51cc7a4b3130d4e62ac0eae938a6d8e1feff14/rapidfuzz-3.14.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:45c62ada1980ebf4c64c4253993cc8daa018c63163f91db63bb3af69cb74c2e3", size = 1336749, upload-time = "2025-09-08T21:08:04.783Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/39/c12f76f69184bcfb9977d6404b2c5dac7dd4d70ee6803e61556e539d0097/rapidfuzz-3.14.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:4d51efb29c0df0d4f7f64f672a7624c2146527f0745e3572098d753676538800", size = 1512629, upload-time = "2025-09-08T21:08:06.697Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c7/1b17347e30f2b50dd976c54641aa12003569acb1bdaabf45a5cc6f471c58/rapidfuzz-3.14.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:4a21ccdf1bd7d57a1009030527ba8fae1c74bf832d0a08f6b67de8f5c506c96f", size = 1862602, upload-time = "2025-09-08T21:08:09.088Z" },
-    { url = "https://files.pythonhosted.org/packages/09/cf/95d0dacac77eda22499991bd5f304c77c5965fb27348019a48ec3fe4a3f6/rapidfuzz-3.14.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:589fb0af91d3aff318750539c832ea1100dbac2c842fde24e42261df443845f6", size = 1339548, upload-time = "2025-09-08T21:08:11.059Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/58/f515c44ba8c6fa5daa35134b94b99661ced852628c5505ead07b905c3fc7/rapidfuzz-3.14.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a4f18092db4825f2517d135445015b40033ed809a41754918a03ef062abe88a0", size = 1513859, upload-time = "2025-09-08T21:08:13.07Z" },
 ]
 
 [[package]]
@@ -2935,19 +2748,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sentry-sdk"
-version = "2.38.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/22/60fd703b34d94d216b2387e048ac82de3e86b63bc28869fb076f8bb0204a/sentry_sdk-2.38.0.tar.gz", hash = "sha256:792d2af45e167e2f8a3347143f525b9b6bac6f058fb2014720b40b84ccbeb985", size = 348116, upload-time = "2025-09-15T15:00:37.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/84/bde4c4bbb269b71bc09316af8eb00da91f67814d40337cc12ef9c8742541/sentry_sdk-2.38.0-py2.py3-none-any.whl", hash = "sha256:2324aea8573a3fa1576df7fb4d65c4eb8d9929c8fa5939647397a07179eef8d0", size = 370346, upload-time = "2025-09-15T15:00:35.821Z" },
-]
-
-[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3051,15 +2851,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]
@@ -3237,24 +3028,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-awscrt"
-version = "0.27.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/ce/5d84526a39f44c420ce61b16654193f8437d74b54f21597ea2ac65d89954/types_awscrt-0.27.6.tar.gz", hash = "sha256:9d3f1865a93b8b2c32f137514ac88cb048b5bc438739945ba19d972698995bfb", size = 16937, upload-time = "2025-08-13T01:54:54.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/af/e3d20e3e81d235b3964846adf46a334645a8a9b25a0d3d472743eb079552/types_awscrt-0.27.6-py3-none-any.whl", hash = "sha256:18aced46da00a57f02eb97637a32e5894dc5aa3dc6a905ba3e5ed85b9f3c526b", size = 39626, upload-time = "2025-08-13T01:54:53.454Z" },
-]
-
-[[package]]
-name = "types-s3transfer"
-version = "0.13.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/c5/23946fac96c9dd5815ec97afd1c8ad6d22efa76c04a79a4823f2f67692a5/types_s3transfer-0.13.1.tar.gz", hash = "sha256:ce488d79fdd7d3b9d39071939121eca814ec65de3aa36bdce1f9189c0a61cc80", size = 14181, upload-time = "2025-08-31T16:57:06.93Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/dc/b3f9b5c93eed6ffe768f4972661250584d5e4f248b548029026964373bcd/types_s3transfer-0.13.1-py3-none-any.whl", hash = "sha256:4ff730e464a3fd3785b5541f0f555c1bd02ad408cf82b6b7a95429f6b0d26b4a", size = 19617, upload-time = "2025-08-31T16:57:05.73Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3315,15 +3088,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz", hash = "sha256:6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815", size = 11140, upload-time = "2024-02-29T21:39:08.742Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl", hash = "sha256:2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d", size = 9065, upload-time = "2024-02-29T21:39:07.551Z" },
-]
-
-[[package]]
-name = "uuid6"
-version = "2025.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove runtime import side effects from core utils: no file logger, MAC probing, eager Rich import, or Opik tracing setup
- remove Opik and python-decouple dependencies and update docs/README to match
- switch runtime env reads to os.environ in LLM, memory, Redis, and workspace paths
- replace Pydantic event payload and summary config models with lightweight dataclasses while preserving event serialization helpers
- strengthen startup/import regression tests for simple agent initialization

## Verification
- uv run ruff check .
- uv run pytest -q
- git diff --check
- uv run hatch build

## Startup probe
Simple agent initialize loads none of: decouple, rich, opik, litellm, openai, workspace storage, advanced tools, artifact tools, memory tools, or skill tools; it also does not create omnicoreagent.log.