### PR TITLE
Slim runtime config and loop types

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import asyncio
 import time
 
 import json
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from typing import Any, Tuple
+from typing import TYPE_CHECKING, Any, Tuple
 from omnicoreagent.core.system_prompts import (
     AgentPromptContextBuilder,
     FAST_CONVERSATION_SUMMARY_PROMPT,
@@ -62,11 +64,13 @@ from omnicoreagent.core.tool_response_offloader import (
 )
 from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
 from omnicoreagent.core.tools.tool_observation import ToolObservationHandler
-from omnicoreagent.core.guardrails import PromptInjectionGuard
 from omnicoreagent.core.agents.xml_parser import (
     extract_thought,
     parse_action_or_answer,
 )
+
+if TYPE_CHECKING:
+    from omnicoreagent.core.guardrails import PromptInjectionGuard
 
 class BaseReactAgent:
     """Autonomous agent implementing the ReAct paradigm for task solving through iterative reasoning and tool usage."""

--- a/src/omnicoreagent/core/agents/react_agent.py
+++ b/src/omnicoreagent/core/agents/react_agent.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from omnicoreagent.core.agents.base import BaseReactAgent
-from omnicoreagent.core.guardrails import PromptInjectionGuard
 from omnicoreagent.runtime_config import AgentConfig
+
+if TYPE_CHECKING:
+    from omnicoreagent.core.guardrails import PromptInjectionGuard
 
 
 class ReactAgent(BaseReactAgent):

--- a/src/omnicoreagent/core/tools/tool_call_resolver.py
+++ b/src/omnicoreagent/core/tools/tool_call_resolver.py
@@ -1,7 +1,8 @@
-import json
-from typing import Any
+from __future__ import annotations
 
-from omnicoreagent.core.guardrails import PromptInjectionGuard
+import json
+from typing import TYPE_CHECKING, Any
+
 from omnicoreagent.core.tools.tools_handler import (
     LocalToolHandler,
     MCPToolHandler,
@@ -9,6 +10,9 @@ from omnicoreagent.core.tools.tools_handler import (
 )
 from omnicoreagent.core.types import ParsedResponse, ToolCallResult, ToolError
 from omnicoreagent.core.utils import logger, normalize_tool_args
+
+if TYPE_CHECKING:
+    from omnicoreagent.core.guardrails import PromptInjectionGuard
 
 
 class ToolCallResolver:

--- a/src/omnicoreagent/core/tools/tool_observation.py
+++ b/src/omnicoreagent/core/tools/tool_observation.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import json
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from omnicoreagent.core.guardrails import PromptInjectionGuard
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
 from omnicoreagent.core.types import AgentState, Message, SessionState, ToolCallResult
 from omnicoreagent.core.utils import build_xml_observations_block, logger
+
+if TYPE_CHECKING:
+    from omnicoreagent.core.guardrails import PromptInjectionGuard
 
 TOOL_OUTPUT_OFFLOAD_EXCLUDED_TOOLS = frozenset(
     {

--- a/src/omnicoreagent/core/tools/tools_handler.py
+++ b/src/omnicoreagent/core/tools/tools_handler.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from omnicoreagent.core.guardrails import PromptInjectionGuard
+if TYPE_CHECKING:
+    from omnicoreagent.core.guardrails import PromptInjectionGuard
 
 logger = logging.getLogger(__name__)
 

--- a/src/omnicoreagent/core/types.py
+++ b/src/omnicoreagent/core/types.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
 from enum import Enum
-from typing import Any, Optional
-from uuid import UUID, uuid4
-from pydantic import BaseModel, Field, model_validator
 import json
+from typing import Any
+from uuid import UUID, uuid4
 
 
 class AgentState(str, Enum):
@@ -13,108 +15,6 @@ class AgentState(str, Enum):
     FINISHED = "finished"
     ERROR = "error"
     STUCK = "stuck"
-
-
-class ToolFunction(BaseModel):
-    name: str
-    arguments: str
-
-
-class ToolCall(BaseModel):
-    id: str = Field(default_factory=lambda: str(uuid4()))
-    type: str = "function"
-    function: ToolFunction
-
-
-class ToolCallMetadata(BaseModel):
-    has_tool_calls: bool = False
-    tool_calls: list[ToolCall] = []
-    tool_call_id: UUID | None = None
-    agent_name: str | None = None
-
-
-class Message(BaseModel):
-    role: str
-    content: str
-    tool_call_id: Optional[str] = None
-    tool_calls: Optional[str] = None
-    metadata: Optional[ToolCallMetadata] = None
-    timestamp: Optional[str] = None
-
-    @model_validator(mode="before")
-    def ensure_content_is_string(cls, values):
-        c = values.get("content")
-        if not isinstance(c, str):
-            try:
-                values["content"] = json.dumps(c, ensure_ascii=False)
-            except Exception:
-                values["content"] = str(c)
-        return values
-
-
-class ParsedResponse(BaseModel):
-    action: bool | None = None
-    data: str | None = None
-    error: str | None = None
-    answer: str | None = None
-    tool_calls: bool | None = None
-    agent_calls: bool | None = None
-
-
-class ToolCallResult(BaseModel):
-    tool_executor: Any
-    tool_name: str
-    tool_args: dict
-    tool_call_id: str | None = None
-
-
-class ToolError(BaseModel):
-    observation: str
-    tool_name: str
-    tool_args: dict | None = None
-
-
-class ToolData(BaseModel):
-    action: bool
-    tool_name: str | None = None
-    tool_args: dict | None = None
-    error: str | None = None
-
-
-class ToolCallRecord(BaseModel):
-    tool_name: str
-    tool_args: str
-    observation: str
-
-
-class ToolParameter(BaseModel):
-    type: str
-    description: str
-
-
-class ToolRegistryEntry(BaseModel):
-    name: str
-    description: str
-    parameters: list[ToolParameter] = []
-
-
-class ToolExecutorConfig(BaseModel):
-    handler: Any
-    tool_data: dict[str, Any]
-    available_tools: dict[str, Any]
-
-
-class LoopDetectorConfig(BaseModel):
-    max_repeats: int = 3
-    similarity_threshold: float = 0.9
-
-
-class SessionState(BaseModel):
-    messages: list[Message]
-    state: AgentState
-    loop_detector: Any
-    assistant_with_tool_calls: dict | None
-    pending_tool_responses: list[dict]
 
 
 class ContextInclusion(str, Enum):
@@ -123,11 +23,175 @@ class ContextInclusion(str, Enum):
     ALL_SERVERS = "allServers"
 
 
-class AgentState(str, Enum):
-    IDLE = "idle"
-    RUNNING = "running"
-    TOOL_CALLING = "tool_calling"
-    OBSERVING = "observing"
-    FINISHED = "finished"
-    ERROR = "error"
-    STUCK = "stuck"
+def _to_plain(value: Any, *, exclude_none: bool = False) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, UUID):
+        return str(value)
+    if is_dataclass(value):
+        return {
+            key: _to_plain(item, exclude_none=exclude_none)
+            for key, item in asdict(value).items()
+            if not (exclude_none and item is None)
+        }
+    if isinstance(value, dict):
+        return {
+            key: _to_plain(item, exclude_none=exclude_none)
+            for key, item in value.items()
+            if not (exclude_none and item is None)
+        }
+    if isinstance(value, list):
+        return [_to_plain(item, exclude_none=exclude_none) for item in value]
+    if isinstance(value, tuple):
+        return [_to_plain(item, exclude_none=exclude_none) for item in value]
+    return value
+
+
+class SerializableRecord:
+    @classmethod
+    def model_validate(cls, value: Any):
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            return cls(**value)
+        raise ValueError(f"{cls.__name__} requires a dict or {cls.__name__} instance")
+
+    def model_dump(self, *, exclude_none: bool = False, **_: Any) -> dict[str, Any]:
+        return _to_plain(self, exclude_none=exclude_none)
+
+    def dict(self, *, exclude_none: bool = False, **kwargs: Any) -> dict[str, Any]:
+        return self.model_dump(exclude_none=exclude_none, **kwargs)
+
+    def json(self, *, exclude_none: bool = False, **kwargs: Any) -> str:
+        return json.dumps(self.model_dump(exclude_none=exclude_none, **kwargs))
+
+
+@dataclass
+class ToolFunction(SerializableRecord):
+    name: str
+    arguments: str
+
+
+@dataclass
+class ToolCall(SerializableRecord):
+    function: ToolFunction | dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid4()))
+    type: str = "function"
+
+    def __post_init__(self):
+        if isinstance(self.function, dict):
+            self.function = ToolFunction(**self.function)
+
+
+@dataclass
+class ToolCallMetadata(SerializableRecord):
+    has_tool_calls: bool = False
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    tool_call_id: UUID | str | None = None
+    agent_name: str | None = None
+
+    def __post_init__(self):
+        self.tool_calls = [
+            call if isinstance(call, ToolCall) else ToolCall(**call)
+            for call in self.tool_calls
+        ]
+
+
+@dataclass
+class Message(SerializableRecord):
+    role: str
+    content: str
+    tool_call_id: str | None = None
+    tool_calls: str | None = None
+    metadata: ToolCallMetadata | dict[str, Any] | None = None
+    timestamp: str | None = None
+
+    def __post_init__(self):
+        if not isinstance(self.content, str):
+            try:
+                self.content = json.dumps(self.content, ensure_ascii=False)
+            except Exception:
+                self.content = str(self.content)
+        if isinstance(self.metadata, dict):
+            self.metadata = ToolCallMetadata(**self.metadata)
+
+
+@dataclass
+class ParsedResponse(SerializableRecord):
+    action: bool | None = None
+    data: str | None = None
+    error: str | None = None
+    answer: str | None = None
+    tool_calls: bool | None = None
+    agent_calls: bool | None = None
+
+
+@dataclass
+class ToolCallResult(SerializableRecord):
+    tool_executor: Any
+    tool_name: str
+    tool_args: dict
+    tool_call_id: str | None = None
+
+
+@dataclass
+class ToolError(SerializableRecord):
+    observation: str
+    tool_name: str
+    tool_args: dict | None = None
+
+
+@dataclass
+class ToolData(SerializableRecord):
+    action: bool
+    tool_name: str | None = None
+    tool_args: dict | None = None
+    error: str | None = None
+
+
+@dataclass
+class ToolCallRecord(SerializableRecord):
+    tool_name: str
+    tool_args: str
+    observation: str
+
+
+@dataclass
+class ToolParameter(SerializableRecord):
+    type: str
+    description: str
+
+
+@dataclass
+class ToolRegistryEntry(SerializableRecord):
+    name: str
+    description: str
+    parameters: list[ToolParameter] = field(default_factory=list)
+
+    def __post_init__(self):
+        self.parameters = [
+            param if isinstance(param, ToolParameter) else ToolParameter(**param)
+            for param in self.parameters
+        ]
+
+
+@dataclass
+class ToolExecutorConfig(SerializableRecord):
+    handler: Any
+    tool_data: dict[str, Any]
+    available_tools: dict[str, Any]
+
+
+@dataclass
+class LoopDetectorConfig(SerializableRecord):
+    max_repeats: int = 3
+    similarity_threshold: float = 0.9
+
+
+@dataclass
+class SessionState(SerializableRecord):
+    messages: list[Message]
+    state: AgentState
+    loop_detector: Any
+    assistant_with_tool_calls: dict | None
+    pending_tool_responses: list[dict]

--- a/src/omnicoreagent/runtime_config.py
+++ b/src/omnicoreagent/runtime_config.py
@@ -1,6 +1,7 @@
-from typing import Any
+from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any
 
 from omnicoreagent.config_types import (
     MCPToolConfig as MCPToolConfig,
@@ -12,138 +13,157 @@ from omnicoreagent.config_types import (
 )
 
 
-class AgentConfig(BaseModel):
+def _default_memory_config() -> dict[str, Any]:
+    return {
+        "mode": "sliding_window",
+        "value": 10000,
+        "summary": {"enabled": False, "retention_policy": "keep"},
+    }
+
+
+def _default_context_management() -> dict[str, Any]:
+    return {
+        "enabled": False,
+        "mode": "token_budget",
+        "value": 100000,
+        "threshold_percent": 75,
+        "strategy": "truncate",
+        "preserve_recent": 4,
+    }
+
+
+def _default_tool_offload() -> dict[str, Any]:
+    return {
+        "enabled": False,
+        "threshold_tokens": 500,
+        "threshold_bytes": 2000,
+        "max_preview_tokens": 150,
+        "max_preview_lines": 10,
+    }
+
+
+@dataclass
+class AgentConfig:
     agent_name: str = "OmniCoreAgent"
-    request_limit: int = Field(default=0, description="0 = unlimited")
-    total_tokens_limit: int = Field(default=0, description="0 = unlimited")
-    max_steps: int = Field(default=15, gt=0, le=1000)
-    tool_call_timeout: int = Field(default=30, gt=1, le=1000)
+    request_limit: int = 0
+    total_tokens_limit: int = 0
+    max_steps: int = 15
+    tool_call_timeout: int = 30
+    mcp_enabled: bool = False
     enable_advanced_tool_use: bool = False
     enable_subagents: bool = False
     enable_agent_skills: bool = False
-    memory_config: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "mode": "sliding_window",
-            "value": 10000,
-            "summary": {"enabled": False, "retention_policy": "keep"},
-        }
-    )
+    memory_config: dict[str, Any] = field(default_factory=_default_memory_config)
     enable_workspace_memory: bool = False
-    guardrail_config: dict[str, Any] = Field(default_factory=dict)
+    guardrail_config: dict[str, Any] = field(default_factory=dict)
     guardrail_mode: str = "full"
-    context_management: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "enabled": False,
-            "mode": "token_budget",
-            "value": 100000,
-            "threshold_percent": 75,
-            "strategy": "truncate",
-            "preserve_recent": 4,
-        }
+    context_management: dict[str, Any] = field(
+        default_factory=_default_context_management
     )
-    tool_offload: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "enabled": False,
-            "threshold_tokens": 500,
-            "threshold_bytes": 2000,
-            "max_preview_tokens": 150,
-            "max_preview_lines": 10,
-        }
-    )
+    tool_offload: dict[str, Any] = field(default_factory=_default_tool_offload)
 
-    @field_validator("request_limit", "total_tokens_limit", mode="before")
-    @classmethod
-    def convert_none_to_zero(cls, value):
-        return 0 if value is None else value
+    def __post_init__(self):
+        self.request_limit = 0 if self.request_limit is None else self.request_limit
+        self.total_tokens_limit = (
+            0 if self.total_tokens_limit is None else self.total_tokens_limit
+        )
+        self.guardrail_config = self.guardrail_config or {}
+        self.memory_config = self.memory_config or _default_memory_config()
+        self.context_management = _merge_defaults(
+            _default_context_management(), self.context_management
+        )
+        self.tool_offload = _merge_defaults(_default_tool_offload(), self.tool_offload)
 
-    @field_validator("guardrail_config", mode="before")
-    @classmethod
-    def default_guardrail_config(cls, value):
-        return {} if value is None else value
+        _validate_range("max_steps", self.max_steps, minimum=1, maximum=1000)
+        _validate_range("tool_call_timeout", self.tool_call_timeout, minimum=2, maximum=1000)
+        _validate_context_management(self.context_management)
+        _validate_tool_offload(self.tool_offload)
 
-    @field_validator("context_management")
-    @classmethod
-    def validate_context_management(cls, value):
-        if value is None:
-            return {}
-
-        preserve_recent = value.get("preserve_recent", 4)
-        if preserve_recent < 4:
-            raise ValueError(
-                f"context_management.preserve_recent must be at least 4, got {preserve_recent}"
-            )
-
-        allowed_modes = {"sliding_window", "token_budget"}
-        mode = value.get("mode", "token_budget")
-        if mode not in allowed_modes:
-            raise ValueError(
-                f"context_management.mode must be one of {allowed_modes}, got '{mode}'"
-            )
-
-        allowed_strategies = {"truncate", "summarize_and_truncate"}
-        strategy = value.get("strategy", "truncate")
-        if strategy not in allowed_strategies:
-            raise ValueError(
-                f"context_management.strategy must be one of {allowed_strategies}, got '{strategy}'"
-            )
-
-        threshold = value.get("threshold_percent", 75)
-        if not (1 <= threshold <= 100):
-            raise ValueError(
-                f"context_management.threshold_percent must be between 1 and 100, got {threshold}"
-            )
-
-        context_value = value.get("value", 100000)
-        if context_value <= 0:
-            raise ValueError(
-                f"context_management.value must be positive, got {context_value}"
-            )
-
-        return value
-
-    @field_validator("tool_offload")
-    @classmethod
-    def validate_tool_offload(cls, value):
-        if value is None:
-            return {}
-
-        threshold_tokens = value.get("threshold_tokens", 500)
-        if threshold_tokens <= 0:
-            raise ValueError(
-                f"tool_offload.threshold_tokens must be positive, got {threshold_tokens}"
-            )
-
-        threshold_bytes = value.get("threshold_bytes", 2000)
-        if threshold_bytes <= 0:
-            raise ValueError(
-                f"tool_offload.threshold_bytes must be positive, got {threshold_bytes}"
-            )
-
-        max_preview_tokens = value.get("max_preview_tokens", 150)
-        if max_preview_tokens <= 0:
-            raise ValueError(
-                f"tool_offload.max_preview_tokens must be positive, got {max_preview_tokens}"
-            )
-
-        max_preview_lines = value.get("max_preview_lines", 10)
-        if max_preview_lines <= 0:
-            raise ValueError(
-                f"tool_offload.max_preview_lines must be positive, got {max_preview_lines}"
-            )
-
-        retention_days = value.get("retention_days")
-        if retention_days is not None and retention_days < 0:
-            raise ValueError(
-                f"tool_offload.retention_days must be non-negative, got {retention_days}"
-            )
-
-        return value
-
-    @model_validator(mode="after")
-    def enable_required_harness_defaults(self):
         if self.enable_subagents:
             self.enable_workspace_memory = True
-        return self
+
+    def model_dump(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def model_copy(self, *, update: dict[str, Any] | None = None) -> AgentConfig:
+        return replace(self, **(update or {}))
+
+
+def _merge_defaults(defaults: dict[str, Any], value: dict[str, Any] | None) -> dict[str, Any]:
+    if value is None:
+        return defaults
+    return {**defaults, **value}
+
+
+def _validate_range(name: str, value: int, *, minimum: int, maximum: int):
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}, got {value}")
+
+
+def _validate_context_management(value: dict[str, Any]):
+    preserve_recent = value.get("preserve_recent", 4)
+    if preserve_recent < 4:
+        raise ValueError(
+            f"context_management.preserve_recent must be at least 4, got {preserve_recent}"
+        )
+
+    allowed_modes = {"sliding_window", "token_budget"}
+    mode = value.get("mode", "token_budget")
+    if mode not in allowed_modes:
+        raise ValueError(
+            f"context_management.mode must be one of {allowed_modes}, got '{mode}'"
+        )
+
+    allowed_strategies = {"truncate", "summarize_and_truncate"}
+    strategy = value.get("strategy", "truncate")
+    if strategy not in allowed_strategies:
+        raise ValueError(
+            f"context_management.strategy must be one of {allowed_strategies}, got '{strategy}'"
+        )
+
+    threshold = value.get("threshold_percent", 75)
+    if not (1 <= threshold <= 100):
+        raise ValueError(
+            f"context_management.threshold_percent must be between 1 and 100, got {threshold}"
+        )
+
+    context_value = value.get("value", 100000)
+    if context_value <= 0:
+        raise ValueError(
+            f"context_management.value must be positive, got {context_value}"
+        )
+
+
+def _validate_tool_offload(value: dict[str, Any]):
+    threshold_tokens = value.get("threshold_tokens", 500)
+    if threshold_tokens <= 0:
+        raise ValueError(
+            f"tool_offload.threshold_tokens must be positive, got {threshold_tokens}"
+        )
+
+    threshold_bytes = value.get("threshold_bytes", 2000)
+    if threshold_bytes <= 0:
+        raise ValueError(
+            f"tool_offload.threshold_bytes must be positive, got {threshold_bytes}"
+        )
+
+    max_preview_tokens = value.get("max_preview_tokens", 150)
+    if max_preview_tokens <= 0:
+        raise ValueError(
+            f"tool_offload.max_preview_tokens must be positive, got {max_preview_tokens}"
+        )
+
+    max_preview_lines = value.get("max_preview_lines", 10)
+    if max_preview_lines <= 0:
+        raise ValueError(
+            f"tool_offload.max_preview_lines must be positive, got {max_preview_lines}"
+        )
+
+    retention_days = value.get("retention_days")
+    if retention_days is not None and retention_days < 0:
+        raise ValueError(
+            f"tool_offload.retention_days must be non-negative, got {retention_days}"
+        )
 
 
 def normalize_agent_config(

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -247,6 +247,8 @@ watched_modules = [
     "rich.console",
     "litellm",
     "openai",
+    "pydantic",
+    "omnicoreagent.core.guardrails",
     "omnicoreagent.core.tools.advance_tools.advanced_tools_use",
     "omnicoreagent.core.tools.advance_tools_use",
     "omnicoreagent.core.tools.artifact_tool",

--- a/tests/test_tool_response_offloader.py
+++ b/tests/test_tool_response_offloader.py
@@ -28,7 +28,6 @@ from omnicoreagent.core.tool_response_offloader import (
 from omnicoreagent.core.tools.artifact_tool import build_tool_registry_artifact_tool
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.runtime_config import AgentConfig
-from pydantic import ValidationError
 
 
 # ============================================================================
@@ -110,8 +109,8 @@ class TestAgentConfigToolOffloadValidation:
         assert config.tool_offload["enabled"] is True
 
     def test_invalid_threshold_tokens_rejected(self):
-        """Test negative threshold_tokens raises ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
+        """Test negative threshold_tokens raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
             AgentConfig(
                 agent_name="test",
                 max_steps=10,
@@ -121,8 +120,8 @@ class TestAgentConfigToolOffloadValidation:
         assert "threshold_tokens must be positive" in str(exc_info.value)
 
     def test_invalid_threshold_bytes_rejected(self):
-        """Test negative threshold_bytes raises ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
+        """Test negative threshold_bytes raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
             AgentConfig(
                 agent_name="test",
                 max_steps=10,
@@ -132,8 +131,8 @@ class TestAgentConfigToolOffloadValidation:
         assert "threshold_bytes must be positive" in str(exc_info.value)
 
     def test_invalid_max_preview_tokens_rejected(self):
-        """Test negative max_preview_tokens raises ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
+        """Test negative max_preview_tokens raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
             AgentConfig(
                 agent_name="test",
                 max_steps=10,
@@ -143,8 +142,8 @@ class TestAgentConfigToolOffloadValidation:
         assert "max_preview_tokens must be positive" in str(exc_info.value)
 
     def test_invalid_retention_days_rejected(self):
-        """Test negative retention_days raises ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
+        """Test negative retention_days raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
             AgentConfig(
                 agent_name="test",
                 max_steps=10,


### PR DESCRIPTION
## Summary
- replace runtime AgentConfig Pydantic model with a lightweight dataclass plus explicit validation
- replace core ReAct loop type models with lightweight dataclasses while preserving model_dump/model_validate helpers
- keep guardrails lazy when guardrail_mode is off by removing type-only guardrail imports from the runtime stack
- strengthen startup regression coverage so simple initialization does not load Pydantic, guardrails, provider clients, workspace storage, or optional tools

## Verification
- uv run ruff check .
- uv run pytest -q
- git diff --check
- uv run hatch build

## Startup probe
Simple agent.initialize() with guardrails off loads none of: pydantic, decouple, rich, opik, litellm, openai, omnicoreagent.core.guardrails, workspace, or workspace_storage.