### PR TITLE
Extract ReAct loop runtime boundaries

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import time
 
-import json
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Tuple
@@ -37,12 +36,7 @@ from omnicoreagent.core.utils import (
     show_tool_response,
     track,
     BackgroundTaskManager,
-    resolve_agent,
-    build_kwargs,
-    build_sub_agents_observation_xml,
-    show_sub_agent_call_result,
 )
-from datetime import datetime
 from omnicoreagent.core.events.base import (
     Event,
     EventType,
@@ -50,9 +44,6 @@ from omnicoreagent.core.events.base import (
     AgentMessagePayload,
     UserMessagePayload,
     AgentThoughtPayload,
-    SubAgentCallStartedPayload,
-    SubAgentCallResultPayload,
-    SubAgentCallErrorPayload,
 )
 from omnicoreagent.core.context_manager import (
     AgentLoopContextManager,
@@ -62,7 +53,12 @@ from omnicoreagent.core.tool_response_offloader import (
     ToolResponseOffloader,
     OffloadConfig,
 )
+from omnicoreagent.core.agents.llm_response import (
+    extract_response_content,
+    extract_response_usage,
+)
 from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
+from omnicoreagent.core.agents.subagent_runner import SubAgentCallRunner
 from omnicoreagent.core.tools.tool_observation import ToolObservationHandler
 from omnicoreagent.core.agents.xml_parser import (
     extract_thought,
@@ -134,6 +130,7 @@ class BaseReactAgent:
         self.message_history_loader = AgentMessageHistoryLoader(
             agent_name=self.agent_name
         )
+        self.subagent_runner = SubAgentCallRunner(agent_name=self.agent_name)
         self.tool_batch_runner = ToolBatchRunner(
             agent_name=self.agent_name,
             tool_call_timeout=self.tool_call_timeout,
@@ -420,158 +417,16 @@ class BaseReactAgent:
         3. Formats results into proper XML observations
         4. Adds observations to message history
         """
-        event = Event(
-            type=EventType.SUB_AGENT_CALL_STARTED,
-            payload=SubAgentCallStartedPayload(
-                agent_name=self.agent_name,
-                session_id=session_id,
-                timestamp=str(datetime.now()),
-                run_count=0,
-                kwargs={"agent_calls": agent_calls},
-            ),
-            agent_name=self.agent_name,
-        )
-        if event_router:
-            await event_router(session_id=session_id, event=event)
-        metadata = {"agent_calls": agent_calls}
-        await add_message_to_history(
-            role="assistant",
-            content=response,
-            metadata=metadata,
+        await self.subagent_runner.execute(
+            response=response,
+            agent_calls=agent_calls,
+            sub_agents=sub_agents,
             session_id=session_id,
-        )
-        session_state.messages.append(Message(role="assistant", content=response))
-
-        if isinstance(agent_calls, str):
-            agent_calls = json.loads(agent_calls)
-
-        async def execute_single_agent(call: dict) -> tuple[str, Any]:
-            """Execute a single agent, handling MCP connection if needed."""
-            agent_name = call.get("agent")
-            if not agent_name:
-                raise ValueError("agent_call missing 'agent' field")
-
-            try:
-                agent = resolve_agent(agent_name, sub_agents)
-                params = call.get("parameters", {})
-                params["session_id"] = session_id
-                kwargs = build_kwargs(agent, params)
-
-                if hasattr(agent, "mcp_tools") and agent.mcp_tools:
-                    logger.info(f"Connecting MCP servers for {agent_name}...")
-                    await agent.connect_mcp_servers()
-
-                logger.info(f"Running sub-agent: {agent_name}")
-                result = await agent.run(**kwargs)
-                await agent.cleanup_mcp_servers()
-                return agent_name, result
-
-            except Exception as e:
-                logger.error(f"Error executing agent {agent_name}: {e}", exc_info=True)
-                return agent_name, e
-
-        logger.info(
-            f"Executing {len(agent_calls)} sub-agents with concurrent MCP connections..."
-        )
-        tasks = [execute_single_agent(call) for call in agent_calls]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        observations = []
-
-        for result in results:
-            if isinstance(result, Exception):
-                logger.error(f"Unexpected top-level exception: {result}")
-                obs = {
-                    "agent_name": "unknown",
-                    "status": "error",
-                    "output": str(result),
-                }
-                observations.append(obs)
-            else:
-                agent_name, obs_data = result
-
-                if isinstance(obs_data, Exception):
-                    logger.error(f"Agent {agent_name} execution failed: {obs_data}")
-                    obs = {
-                        "agent_name": agent_name,
-                        "status": "error",
-                        "output": str(obs_data),
-                    }
-                    observations.append(obs)
-                    event = Event(
-                        type=EventType.SUB_AGENT_CALL_ERROR,
-                        payload=SubAgentCallErrorPayload(
-                            agent_name=agent_name,
-                            session_id=session_id,
-                            timestamp=str(datetime.now()),
-                            error=str(obs_data),
-                            error_count=0,
-                        ),
-                        agent_name=self.agent_name,
-                    )
-                    if event_router:
-                        await event_router(session_id=session_id, event=event)
-                else:
-                    if isinstance(obs_data, dict):
-                        agent_response = obs_data.get(
-                            "response", obs_data.get("output", str(obs_data))
-                        )
-                        obs = {
-                            "agent_name": agent_name,
-                            "status": "success",
-                            "output": agent_response,
-                        }
-                    elif isinstance(obs_data, str):
-                        obs = {
-                            "agent_name": agent_name,
-                            "status": "success",
-                            "output": obs_data,
-                        }
-                    else:
-                        obs = {
-                            "agent_name": agent_name,
-                            "status": "success",
-                            "output": str(obs_data),
-                        }
-
-                    logger.info(f"Agent {agent_name} completed successfully")
-                    observations.append(obs)
-                    if isinstance(obs_data, dict):
-                        sub_usage = obs_data.get("metric")
-                        if sub_usage and isinstance(sub_usage, Usage):
-                            run_usage.incr(sub_usage)
-                            usage.incr(sub_usage)
-
-                    event = Event(
-                        type=EventType.SUB_AGENT_CALL_RESULT,
-                        payload=SubAgentCallResultPayload(
-                            agent_name=agent_name,
-                            session_id=session_id,
-                            timestamp=str(datetime.now()),
-                            run_count=0,
-                            result=obs_data,
-                        ),
-                        agent_name=self.agent_name,
-                    )
-                    if event_router:
-                        await event_router(session_id=session_id, event=event)
-
-        xml_obs_block = build_sub_agents_observation_xml(observations)
-        agent_call_result = {
-            "agent_name": self.agent_name,
-            "agent_calls": agent_calls,
-            "output": observations,
-        }
-
-        if debug:
-            show_sub_agent_call_result(agent_call_result)
-
-        session_state.messages.append(Message(role="user", content=xml_obs_block))
-        await add_message_to_history(
-            role="user",
-            content=xml_obs_block,
-            session_id=session_id,
-            metadata={"agent_name": self.agent_name, "sub_agent_results": True},
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
+            run_usage=run_usage,
+            event_router=event_router,
+            debug=debug,
         )
 
     @track("agent_execution")
@@ -678,24 +533,7 @@ class BaseReactAgent:
                                 },
                             ]
                             response = await llm_connection.llm_call(summary_msgs)
-                            if hasattr(response, "choices") and response.choices:
-                                response = response.choices[0].message.content.strip()
-                            elif hasattr(response, "message"):
-                                response = response.message.content.strip()
-                            elif hasattr(response, "text"):
-                                response = response.text.strip()
-                            elif hasattr(response, "content"):
-                                response = response.content.strip()
-                            elif isinstance(response, dict) and "choices" in response:
-                                response = response["choices"][0]["message"][
-                                    "content"
-                                ].strip()
-                            elif isinstance(response, str):
-                                pass
-                            else:
-                                response = ""
-
-                            return response
+                            return extract_response_content(response, default="")
 
                         session_state.messages = (
                             await self.context_manager.manage_context(
@@ -715,13 +553,10 @@ class BaseReactAgent:
                     response = await make_llm_call()
 
                     if response:
-                        # Extract the actual message content from the response
-                        if hasattr(response, "choices") and response.choices:
-                            message_content = response.choices[0].message.content
-                        elif hasattr(response, "content"):
-                            message_content = response.content
-                        else:
-                            message_content = str(response)
+                        message_content = extract_response_content(
+                            response,
+                            strip=False,
+                        )
 
                         event = Event(
                             type=EventType.AGENT_MESSAGE,
@@ -734,13 +569,8 @@ class BaseReactAgent:
                             # Await to ensure event is queued before continuing
                             await event_router(session_id=session_id, event=event)
 
-                        if hasattr(response, "usage"):
-                            request_usage = Usage(
-                                requests=1,
-                                request_tokens=response.usage.prompt_tokens,
-                                response_tokens=response.usage.completion_tokens,
-                                total_tokens=response.usage.total_tokens,
-                            )
+                        request_usage = extract_response_usage(response)
+                        if request_usage:
                             usage.incr(request_usage)
                             run_usage.incr(request_usage)
 
@@ -773,24 +603,7 @@ class BaseReactAgent:
                                         f"Remaining Requests: {remaining_requests}, "
                                         f"Remaining Tokens: {remaining_tokens}"
                                     )
-                        if hasattr(response, "choices") and response.choices:
-                            response = response.choices[0].message.content.strip()
-                        elif hasattr(response, "message"):
-                            response = response.message.content.strip()
-                        elif hasattr(response, "text"):
-                            response = response.text.strip()
-                        elif hasattr(response, "content"):
-                            response = response.content.strip()
-                        elif isinstance(response, dict) and "choices" in response:
-                            response = response["choices"][0]["message"][
-                                "content"
-                            ].strip()
-                        elif isinstance(response, str):
-                            pass
-                        else:
-                            raise Exception(
-                                f"No valid response content found in LLM response: {type(response)}"
-                            )
+                        response = extract_response_content(response)
                 except UsageLimitExceeded as e:
                     error_message = f"Usage limit error: {e}"
                     logger.error(error_message)

--- a/src/omnicoreagent/core/agents/llm_response.py
+++ b/src/omnicoreagent/core/agents/llm_response.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.core.token_usage import Usage
+
+
+def extract_response_content(
+    response: Any,
+    *,
+    strip: bool = True,
+    default: str | None = None,
+) -> str:
+    """Extract text content from supported LLM response shapes."""
+    content = _raw_response_content(response)
+    if content is None:
+        if default is not None:
+            return default
+        raise ValueError(f"No valid response content found in LLM response: {type(response)}")
+
+    if not isinstance(content, str):
+        content = str(content)
+    return content.strip() if strip else content
+
+
+def extract_response_usage(response: Any) -> Usage | None:
+    """Extract token usage from supported LLM response objects."""
+    raw_usage = getattr(response, "usage", None)
+    if raw_usage is None and isinstance(response, dict):
+        raw_usage = response.get("usage")
+    if raw_usage is None:
+        return None
+
+    def get_value(name: str, default: int = 0) -> int:
+        if isinstance(raw_usage, dict):
+            value = raw_usage.get(name, default)
+        else:
+            value = getattr(raw_usage, name, default)
+        return int(value or 0)
+
+    return Usage(
+        requests=1,
+        request_tokens=get_value("prompt_tokens"),
+        response_tokens=get_value("completion_tokens"),
+        total_tokens=get_value("total_tokens"),
+    )
+
+
+def _raw_response_content(response: Any) -> Any:
+    if response is None:
+        return None
+
+    choices = getattr(response, "choices", None)
+    if choices:
+        return choices[0].message.content
+
+    if hasattr(response, "message"):
+        return response.message.content
+    if hasattr(response, "text"):
+        return response.text
+    if hasattr(response, "content"):
+        return response.content
+
+    if isinstance(response, dict):
+        choices = response.get("choices")
+        if choices:
+            return choices[0]["message"]["content"]
+        for key in ("message", "text", "content"):
+            if key in response:
+                value = response[key]
+                if isinstance(value, dict) and "content" in value:
+                    return value["content"]
+                return value
+
+    if isinstance(response, str):
+        return response
+
+    return None

--- a/src/omnicoreagent/core/agents/subagent_runner.py
+++ b/src/omnicoreagent/core/agents/subagent_runner.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+from omnicoreagent.core.events.base import (
+    Event,
+    EventType,
+    SubAgentCallErrorPayload,
+    SubAgentCallResultPayload,
+    SubAgentCallStartedPayload,
+)
+from omnicoreagent.core.token_usage import Usage, usage
+from omnicoreagent.core.types import Message
+from omnicoreagent.core.utils import (
+    build_kwargs,
+    build_sub_agents_observation_xml,
+    logger,
+    resolve_agent,
+    show_sub_agent_call_result,
+)
+
+
+class SubAgentCallRunner:
+    """Execute model-requested sub-agent calls and append observations."""
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    async def execute(
+        self,
+        response: str,
+        agent_calls: list | str,
+        sub_agents: list,
+        session_id: str,
+        session_state: Any,
+        add_message_to_history: Callable[..., Any],
+        run_usage: Usage,
+        event_router: Callable[..., Any] | None = None,
+        debug: bool = False,
+    ):
+        agent_calls = self._normalize_agent_calls(agent_calls)
+        await self._emit_started(
+            agent_calls=agent_calls,
+            session_id=session_id,
+            event_router=event_router,
+        )
+        await self._record_assistant_call(
+            response=response,
+            agent_calls=agent_calls,
+            session_id=session_id,
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
+        )
+
+        logger.info(
+            f"Executing {len(agent_calls)} sub-agents with concurrent MCP connections..."
+        )
+        results = await asyncio.gather(
+            *[
+                self._execute_single_agent(call, sub_agents, session_id)
+                for call in agent_calls
+            ],
+            return_exceptions=True,
+        )
+
+        observations = await self._collect_observations(
+            results=results,
+            run_usage=run_usage,
+            session_id=session_id,
+            event_router=event_router,
+        )
+
+        await self._append_observation_block(
+            observations=observations,
+            agent_calls=agent_calls,
+            session_id=session_id,
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
+            debug=debug,
+        )
+
+    def _normalize_agent_calls(self, agent_calls: list | str) -> list[dict[str, Any]]:
+        if isinstance(agent_calls, str):
+            return json.loads(agent_calls)
+        return list(agent_calls)
+
+    async def _emit_started(
+        self,
+        agent_calls: list[dict[str, Any]],
+        session_id: str,
+        event_router: Callable[..., Any] | None,
+    ):
+        if not event_router:
+            return
+        event = Event(
+            type=EventType.SUB_AGENT_CALL_STARTED,
+            payload=SubAgentCallStartedPayload(
+                agent_name=self.agent_name,
+                session_id=session_id,
+                timestamp=str(datetime.now()),
+                run_count=0,
+                kwargs={"agent_calls": agent_calls},
+            ),
+            agent_name=self.agent_name,
+        )
+        await event_router(session_id=session_id, event=event)
+
+    async def _record_assistant_call(
+        self,
+        response: str,
+        agent_calls: list[dict[str, Any]],
+        session_id: str,
+        session_state: Any,
+        add_message_to_history: Callable[..., Any],
+    ):
+        await add_message_to_history(
+            role="assistant",
+            content=response,
+            metadata={"agent_calls": agent_calls},
+            session_id=session_id,
+        )
+        session_state.messages.append(Message(role="assistant", content=response))
+
+    async def _execute_single_agent(
+        self,
+        call: dict[str, Any],
+        sub_agents: list,
+        session_id: str,
+    ) -> tuple[str, Any]:
+        agent_name = call.get("agent")
+        if not agent_name:
+            raise ValueError("agent_call missing 'agent' field")
+
+        try:
+            agent = resolve_agent(agent_name, sub_agents)
+            params = call.get("parameters", {})
+            params["session_id"] = session_id
+            kwargs = build_kwargs(agent, params)
+
+            if hasattr(agent, "mcp_tools") and agent.mcp_tools:
+                logger.info(f"Connecting MCP servers for {agent_name}...")
+                await agent.connect_mcp_servers()
+
+            logger.info(f"Running sub-agent: {agent_name}")
+            result = await agent.run(**kwargs)
+            await agent.cleanup_mcp_servers()
+            return agent_name, result
+
+        except Exception as e:
+            logger.error(f"Error executing agent {agent_name}: {e}", exc_info=True)
+            return agent_name, e
+
+    async def _collect_observations(
+        self,
+        results: list[Any],
+        run_usage: Usage,
+        session_id: str,
+        event_router: Callable[..., Any] | None,
+    ) -> list[dict[str, Any]]:
+        observations = []
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error(f"Unexpected top-level exception: {result}")
+                observations.append(
+                    {
+                        "agent_name": "unknown",
+                        "status": "error",
+                        "output": str(result),
+                    }
+                )
+                continue
+
+            agent_name, obs_data = result
+            if isinstance(obs_data, Exception):
+                observations.append(
+                    await self._handle_agent_error(
+                        agent_name=agent_name,
+                        error=obs_data,
+                        session_id=session_id,
+                        event_router=event_router,
+                    )
+                )
+                continue
+
+            observations.append(
+                await self._handle_agent_success(
+                    agent_name=agent_name,
+                    result=obs_data,
+                    session_id=session_id,
+                    run_usage=run_usage,
+                    event_router=event_router,
+                )
+            )
+        return observations
+
+    async def _handle_agent_error(
+        self,
+        agent_name: str,
+        error: Exception,
+        session_id: str,
+        event_router: Callable[..., Any] | None,
+    ) -> dict[str, Any]:
+        logger.error(f"Agent {agent_name} execution failed: {error}")
+        if event_router:
+            event = Event(
+                type=EventType.SUB_AGENT_CALL_ERROR,
+                payload=SubAgentCallErrorPayload(
+                    agent_name=agent_name,
+                    session_id=session_id,
+                    timestamp=str(datetime.now()),
+                    error=str(error),
+                    error_count=0,
+                ),
+                agent_name=self.agent_name,
+            )
+            await event_router(session_id=session_id, event=event)
+        return {
+            "agent_name": agent_name,
+            "status": "error",
+            "output": str(error),
+        }
+
+    async def _handle_agent_success(
+        self,
+        agent_name: str,
+        result: Any,
+        session_id: str,
+        run_usage: Usage,
+        event_router: Callable[..., Any] | None,
+    ) -> dict[str, Any]:
+        output = self._extract_agent_output(result)
+        logger.info(f"Agent {agent_name} completed successfully")
+        if isinstance(result, dict):
+            sub_usage = result.get("metric")
+            if sub_usage and isinstance(sub_usage, Usage):
+                run_usage.incr(sub_usage)
+                usage.incr(sub_usage)
+
+        if event_router:
+            event = Event(
+                type=EventType.SUB_AGENT_CALL_RESULT,
+                payload=SubAgentCallResultPayload(
+                    agent_name=agent_name,
+                    session_id=session_id,
+                    timestamp=str(datetime.now()),
+                    run_count=0,
+                    result=result,
+                ),
+                agent_name=self.agent_name,
+            )
+            await event_router(session_id=session_id, event=event)
+
+        return {
+            "agent_name": agent_name,
+            "status": "success",
+            "output": output,
+        }
+
+    def _extract_agent_output(self, result: Any) -> str:
+        if isinstance(result, dict):
+            return result.get("response", result.get("output", str(result)))
+        if isinstance(result, str):
+            return result
+        return str(result)
+
+    async def _append_observation_block(
+        self,
+        observations: list[dict[str, Any]],
+        agent_calls: list[dict[str, Any]],
+        session_id: str,
+        session_state: Any,
+        add_message_to_history: Callable[..., Any],
+        debug: bool,
+    ):
+        xml_obs_block = build_sub_agents_observation_xml(observations)
+        agent_call_result = {
+            "agent_name": self.agent_name,
+            "agent_calls": agent_calls,
+            "output": observations,
+        }
+
+        if debug:
+            show_sub_agent_call_result(agent_call_result)
+
+        session_state.messages.append(Message(role="user", content=xml_obs_block))
+        await add_message_to_history(
+            role="user",
+            content=xml_obs_block,
+            session_id=session_id,
+            metadata={"agent_name": self.agent_name, "sub_agent_results": True},
+        )

--- a/tests/test_llm_response.py
+++ b/tests/test_llm_response.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.agents.llm_response import (
+    extract_response_content,
+    extract_response_usage,
+)
+
+
+def test_extract_response_content_from_choices_object():
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="  hello  "),
+            )
+        ]
+    )
+
+    assert extract_response_content(response) == "hello"
+    assert extract_response_content(response, strip=False) == "  hello  "
+
+
+def test_extract_response_content_from_dict_choices():
+    response = {"choices": [{"message": {"content": "answer"}}]}
+
+    assert extract_response_content(response) == "answer"
+
+
+def test_extract_response_content_returns_default_for_unknown_shape():
+    assert extract_response_content(object(), default="") == ""
+
+
+def test_extract_response_content_rejects_unknown_shape_without_default():
+    with pytest.raises(ValueError, match="No valid response content"):
+        extract_response_content(object())
+
+
+def test_extract_response_usage_from_object():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        )
+    )
+
+    usage = extract_response_usage(response)
+
+    assert usage.requests == 1
+    assert usage.request_tokens == 10
+    assert usage.response_tokens == 5
+    assert usage.total_tokens == 15
+
+
+def test_extract_response_usage_from_dict():
+    usage = extract_response_usage(
+        {
+            "usage": {
+                "prompt_tokens": 7,
+                "completion_tokens": 3,
+                "total_tokens": 10,
+            }
+        }
+    )
+
+    assert usage.requests == 1
+    assert usage.request_tokens == 7
+    assert usage.response_tokens == 3
+    assert usage.total_tokens == 10

--- a/tests/test_subagent_runner.py
+++ b/tests/test_subagent_runner.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.agents.subagent_runner import SubAgentCallRunner
+from omnicoreagent.core.events.base import EventType
+from omnicoreagent.core.token_usage import Usage
+from omnicoreagent.core.types import AgentState, SessionState
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+class FakeAgent:
+    def __init__(self, name, result):
+        self.name = name
+        self.result = result
+        self.mcp_tools = []
+        self.cleaned = False
+
+    async def run(self, task=None, session_id=None):
+        self.kwargs = {"task": task, "session_id": session_id}
+        return self.result
+
+    async def cleanup_mcp_servers(self):
+        self.cleaned = True
+
+
+def _session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagent_runner_records_successful_outputs():
+    runner = SubAgentCallRunner(agent_name="parent")
+    sub_agent = FakeAgent("research", {"response": "done"})
+    history = []
+    events = []
+
+    async def add_message_to_history(**kwargs):
+        history.append(kwargs)
+
+    async def event_router(session_id, event):
+        events.append((session_id, event))
+
+    state = _session_state()
+    await runner.execute(
+        response="<agent_calls />",
+        agent_calls=[{"agent": "research", "parameters": {"task": "look"}}],
+        sub_agents=[sub_agent],
+        session_id="s1",
+        session_state=state,
+        add_message_to_history=add_message_to_history,
+        run_usage=Usage(),
+        event_router=event_router,
+    )
+
+    assert sub_agent.kwargs == {"task": "look", "session_id": "s1"}
+    assert sub_agent.cleaned is True
+    assert history[0]["role"] == "assistant"
+    assert history[1]["role"] == "user"
+    assert "done" in history[1]["content"]
+    assert [event.type for _, event in events] == [
+        EventType.SUB_AGENT_CALL_STARTED,
+        EventType.SUB_AGENT_CALL_RESULT,
+    ]
+    assert len(state.messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_subagent_runner_returns_error_observation_for_failed_agent():
+    runner = SubAgentCallRunner(agent_name="parent")
+    failing_agent = FakeAgent("worker", RuntimeError("boom"))
+    history = []
+    events = []
+
+    async def add_message_to_history(**kwargs):
+        history.append(kwargs)
+
+    async def event_router(session_id, event):
+        events.append(event)
+
+    await runner.execute(
+        response="<agent_calls />",
+        agent_calls='[{"agent": "worker", "parameters": {}}]',
+        sub_agents=[failing_agent],
+        session_id="s1",
+        session_state=_session_state(),
+        add_message_to_history=add_message_to_history,
+        run_usage=Usage(),
+        event_router=event_router,
+    )
+
+    assert "boom" in history[-1]["content"]
+    assert [event.type for event in events] == [
+        EventType.SUB_AGENT_CALL_STARTED,
+        EventType.SUB_AGENT_CALL_ERROR,
+    ]
+
+
+def test_subagent_runner_extracts_result_output():
+    runner = SubAgentCallRunner(agent_name="parent")
+
+    assert runner._extract_agent_output({"output": "artifact written"}) == "artifact written"
+    assert runner._extract_agent_output("plain output") == "plain output"
+    assert runner._extract_agent_output(SimpleNamespace(value=1)) == "namespace(value=1)"


### PR DESCRIPTION
## Summary
- extract LLM response content and usage normalization out of BaseReactAgent
- extract dynamic sub-agent execution into a dedicated SubAgentCallRunner
- reduce BaseReactAgent by removing duplicated response parsing and embedded sub-agent orchestration
- add focused tests for LLM response normalization and sub-agent call execution

## Verification
- uv run ruff check .
- uv run pytest -q
- git diff --check
- uv run hatch build