### PR TITLE
Add internal event trace summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ print(result["response"])
 | 12 | **Workflows** | Sequential, Parallel, and Router agent orchestration | [Workflows →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/workflows) |
 | 13 | **BM25 Tool Retrieval** | Auto-discover relevant tools from 1000+ using BM25 search | [Advanced Tools →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/advanced-tools) |
 | 14 | **Guardrails** | Prompt injection protection with configurable sensitivity | [Guardrails →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/guardrails) |
-| 15 | **Observability** | Per-request metrics + Opik distributed tracing | [Observability →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/observability) |
+| 15 | **Observability** | Per-request metrics, event streams, and in-house agent traces | [Observability →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/observability) |
 | 16 | **Universal Models** | 9 providers via LiteLLM (OpenAI, Anthropic, Gemini, Groq, Ollama, etc.) | [Models →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/models) |
 | 17 | **OmniServe** | Turn any agent into a production REST/SSE API with one command | [OmniServe →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/omniserve) |
 

--- a/docs/core-concepts/architecture.mdx
+++ b/docs/core-concepts/architecture.mdx
@@ -102,7 +102,7 @@ The framework provides a unified interface for all external actions:
 | Feature | Architectural Implementation |
 |---------|------------------------------|
 | **Multi-Tenancy** | Session IDs isolate conversation states across different users. |
-| **Observability** | Native Opik tracing and Redis Stream event logging. |
+| **Observability** | Native event streaming, in-house trace summaries, and Redis Stream event logging. |
 | **Fault Tolerance**| Built-in retries for tool calls and automatic connection recovery for MCP. |
 | **Scalability** | Distributed memory backends allow agents to scale horizontally across servers. |
 

--- a/docs/core-concepts/events.mdx
+++ b/docs/core-concepts/events.mdx
@@ -1,12 +1,12 @@
 ---
 title: Event System
-description: 'Real-time event streaming with runtime switching for observability and debugging'
+description: 'Real-time event streaming and in-house trace summaries for observability and debugging'
 icon: 'signal-stream'
 ---
 
 # Event System
 
-Real-time event streaming with runtime switching. Track every tool call, agent thought, and message in real-time.
+Real-time event streaming with runtime switching. Track every tool call, agent thought, message, and final answer, then build a compact trace summary from the stored events.
 
 ---
 
@@ -49,10 +49,15 @@ async for event in agent.stream_events(session_id):
 | `agent_thought` | Agent's internal reasoning step |
 | `tool_call_started` | Tool execution begins |
 | `tool_call_result` | Tool execution completes |
+| `tool_call_error` | Tool validation or execution failed |
 | `final_answer` | Agent produces final response |
-| `sub_agent_started` | Sub-agent delegation begins |
-| `sub_agent_result` | Sub-agent returns result |
-| `sub_agent_error` | Sub-agent encountered an error |
+| `sub_agent_call_started` | Sub-agent delegation begins |
+| `sub_agent_call_result` | Sub-agent returns result |
+| `sub_agent_call_error` | Sub-agent encountered an error |
+| `background_task_started` | Background task begins |
+| `background_task_completed` | Background task completes |
+| `background_task_error` | Background task failed |
+| `background_agent_status` | Background agent status changed |
 
 ---
 
@@ -66,6 +71,25 @@ for event in events:
     print(f"[{event.timestamp}] {event.type}: {event.payload}")
 ```
 
+---
+
+## Agent Trace
+
+```python
+trace = await agent.get_trace(session_id="user_1")
+
+print(trace["summary"]["total_events"])
+print(trace["summary"]["tool_calls"])
+print(trace["summary"]["tool_errors"])
+
+for step in trace["steps"]:
+    print(step["index"], step["event_type"], step["elapsed_ms"])
+```
+
+The trace is built from the event history. It gives you ordered steps, elapsed
+time between steps, event counts, tool/sub-agent error counts, and the latest
+final answer.
+
 <Tip>
-Enable events when you need real-time monitoring, debugging, or building UIs that show agent progress. Essential for production observability.
+Enable events when you need real-time monitoring, debugging, or building UIs that show agent progress. Use traces when you need a compact session-level view for debugging, feedback loops, or evaluation.
 </Tip>

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -85,7 +85,6 @@ The base install stays focused on the core agent harness. Add heavier production
 | `s3` | AWS S3 and Cloudflare R2 workspace storage |
 | `serve` | OmniServe REST/SSE API server |
 | `background` | APScheduler background task execution |
-| `observability` | Opik tracing |
 | `tokenizer` | tiktoken token counting |
 | `all` | Every optional integration |
 
@@ -145,7 +144,7 @@ python -c "import omnicoreagent; print(omnicoreagent.__version__)"
     pip install "omnicoreagent[redis]"
     ```
 
-    Use `postgres`, `mongodb`, `s3`, `serve`, `background`, `observability`, or `all` for other optional integrations.
+    Use `postgres`, `mongodb`, `s3`, `serve`, `background`, `tokenizer`, or `all` for other optional integrations.
   </Accordion>
   <Accordion title="Getting Help">
     If you encounter issues:

--- a/docs/how-to-guides/observability.mdx
+++ b/docs/how-to-guides/observability.mdx
@@ -6,7 +6,7 @@ icon: 'chart-line'
 
 # Production Observability & Metrics
 
-Monitor your agents with built-in metrics and distributed tracing.
+Monitor your agents with built-in metrics, event streams, and in-house trace summaries.
 
 ---
 
@@ -38,7 +38,28 @@ tracing service.
 - Total runtime
 - Average response time
 
+---
+
+## Agent Trace
+
+Every run emits typed events. You can retrieve the full event history or ask
+OmniCoreAgent to build a compact trace summary from those events.
+
+```python
+trace = await agent.get_trace(session_id=result["session_id"])
+
+print(trace["summary"]["duration_ms"])
+print(trace["summary"]["tool_calls"])
+print(trace["summary"]["tool_errors"])
+
+for step in trace["steps"]:
+    print(step["event_type"], step["elapsed_ms"], step["payload"])
+```
+
+The trace is intentionally internal and dependency-free. It is the base layer for
+debugging, feedback loops, and future evaluation workflows.
+
 <Tip>
-Use metrics for cost and performance monitoring. Deeper agent tracing and
-observability will be handled by OmniCoreAgent's internal observability layer.
+Use metrics for cost and performance monitoring, events for live UI streaming,
+and traces for compact session-level debugging.
 </Tip>

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -203,6 +203,7 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/prometheus` | No | Prometheus metrics |
 | `GET` | `/tools` | Yes* | List available tools |
 | `GET` | `/metrics` | Yes* | Agent usage metrics |
+| `GET` | `/events/{session_id}/trace` | Yes* | Compact agent trace summary |
 | `GET` | `/docs` | No | Swagger UI |
 | `GET` | `/redoc` | No | ReDoc UI |
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -124,7 +124,7 @@ asyncio.run(main())
     9+ providers — OpenAI, Anthropic, Gemini, Groq, DeepSeek, and more
   </Card>
   <Card title="Observability" icon="chart-line" href="/docs/how-to-guides/observability">
-    Opik tracing, per-request metrics, and production monitoring
+    In-house agent traces, event streams, and runtime metrics
   </Card>
   <Card title="Configuration" icon="gear" href="/docs/how-to-guides/configuration">
     Environment variables, agent settings, and model configuration

--- a/src/omnicoreagent/agent.py
+++ b/src/omnicoreagent/agent.py
@@ -490,6 +490,10 @@ class OmniCoreAgent:
     async def get_events(self, session_id: str):
         return await self.event_router.get_events(session_id=session_id)
 
+    async def get_trace(self, session_id: str) -> Dict[str, Any]:
+        trace = await self.event_router.get_trace(session_id=session_id)
+        return trace.model_dump()
+
     async def get_event_store_type(self) -> str:
         """Get the current event store type."""
         return self.event_router.get_event_store_type()

--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -34,7 +34,6 @@ from omnicoreagent.core.utils import (
     RobustLoopDetector,
     logger,
     show_tool_response,
-    track,
     BackgroundTaskManager,
 )
 from omnicoreagent.core.events.base import (
@@ -211,7 +210,6 @@ class BaseReactAgent:
             sub_agents=sub_agents,
         )
 
-    @track("tool_execution")
     async def act(
         self,
         parsed_response: ParsedResponse,
@@ -429,7 +427,6 @@ class BaseReactAgent:
             debug=debug,
         )
 
-    @track("agent_execution")
     async def run(
         self,
         system_prompt: str,
@@ -546,7 +543,6 @@ class BaseReactAgent:
                                 f"Context managed: now {len(session_state.messages)} messages"
                             )
 
-                    @track("llm_call")
                     async def make_llm_call():
                         return await llm_connection.llm_call(session_state.messages)
 
@@ -658,40 +654,31 @@ class BaseReactAgent:
                     if parsed_response.agent_calls is not None:
                         agent_calls = parsed_response.data
 
-                        @track("sub_agent_action_execution")
-                        async def execute_sub_agent_calls():
-                            await self.execute_sub_agent_calls(
-                                response=response,
-                                agent_calls=agent_calls,
-                                sub_agents=sub_agents,
-                                session_id=session_id,
-                                session_state=session_state,
-                                add_message_to_history=add_message_to_history,
-                                run_usage=run_usage,
-                                event_router=event_router,
-                                debug=debug,
-                            )
-
-                        await execute_sub_agent_calls()
+                        await self.execute_sub_agent_calls(
+                            response=response,
+                            agent_calls=agent_calls,
+                            sub_agents=sub_agents,
+                            session_id=session_id,
+                            session_state=session_state,
+                            add_message_to_history=add_message_to_history,
+                            run_usage=run_usage,
+                            event_router=event_router,
+                            debug=debug,
+                        )
                     else:
-
-                        @track("action_execution")
-                        async def execute_action():
-                            await self.act(
-                                parsed_response=parsed_response,
-                                response=response,
-                                add_message_to_history=add_message_to_history,
-                                system_prompt=system_prompt,
-                                mcp_tools=mcp_tools,
-                                debug=debug,
-                                sessions=sessions,
-                                local_tools=runtime_local_tools,
-                                session_id=session_id,
-                                event_router=event_router,
-                                sub_agents=sub_agents,
-                            )
-
-                        await execute_action()
+                        await self.act(
+                            parsed_response=parsed_response,
+                            response=response,
+                            add_message_to_history=add_message_to_history,
+                            system_prompt=system_prompt,
+                            mcp_tools=mcp_tools,
+                            debug=debug,
+                            sessions=sessions,
+                            local_tools=runtime_local_tools,
+                            session_id=session_id,
+                            event_router=event_router,
+                            sub_agents=sub_agents,
+                        )
 
                 if parsed_response.error is not None:
                     session_state.messages.append(

--- a/src/omnicoreagent/core/agents/message_history.py
+++ b/src/omnicoreagent/core/agents/message_history.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from omnicoreagent.core.types import Message, SessionState
-from omnicoreagent.core.utils import logger, track
+from omnicoreagent.core.utils import logger
 
 
 class AgentMessageHistoryLoader:
@@ -17,7 +17,6 @@ class AgentMessageHistoryLoader:
     def __init__(self, agent_name: str):
         self.agent_name = agent_name
 
-    @track("memory_processing")
     async def load(
         self,
         *,

--- a/src/omnicoreagent/core/events/__init__.py
+++ b/src/omnicoreagent/core/events/__init__.py
@@ -9,7 +9,12 @@ This package provides event handling and routing:
 """
 
 from .event_router import EventRouter
+from .trace import AgentTrace, TraceStep, TraceSummary, build_event_trace
 
 __all__ = [
+    "AgentTrace",
     "EventRouter",
+    "TraceStep",
+    "TraceSummary",
+    "build_event_trace",
 ]

--- a/src/omnicoreagent/core/events/event_router.py
+++ b/src/omnicoreagent/core/events/event_router.py
@@ -1,12 +1,10 @@
-"""
-Event Router for dynamic event store selection.
-"""
+"""Event router for dynamic event store selection."""
 
-from typing import Optional, Dict, Any, List
 from omnicoreagent._optional import load_optional
-from omnicoreagent.core.utils import logger
 from omnicoreagent.core.events.base import BaseEventStore, Event
 from omnicoreagent.core.events.in_memory import InMemoryEventStore
+from omnicoreagent.core.events.trace import AgentTrace, build_event_trace
+from omnicoreagent.core.utils import logger
 
 
 class EventRouter:
@@ -20,7 +18,7 @@ class EventRouter:
             event_store_type: Type of event store ("in_memory", "redis_stream")
         """
         self.event_store_type = event_store_type
-        self._event_store: Optional[BaseEventStore] = None
+        self._event_store: BaseEventStore | None = None
 
         self._initialize_event_store()
 
@@ -71,12 +69,17 @@ class EventRouter:
 
         await self._event_store.append(session_id=session_id, event=event)
 
-    async def get_events(self, session_id: str) -> List[Event]:
+    async def get_events(self, session_id: str) -> list[Event]:
         """Get events from the current event store."""
         if not self._event_store:
             raise RuntimeError("No event store available")
 
         return await self._event_store.get_events(session_id=session_id)
+
+    async def get_trace(self, session_id: str) -> AgentTrace:
+        """Build an internal trace from stored session events."""
+        events = await self.get_events(session_id=session_id)
+        return build_event_trace(session_id=session_id, events=events)
 
     async def stream(self, session_id: str):
         """Stream events from the current event store."""
@@ -94,7 +97,7 @@ class EventRouter:
         """Check if the event store is available."""
         return self._event_store is not None
 
-    def get_event_store_info(self) -> Dict[str, Any]:
+    def get_event_store_info(self) -> dict[str, object]:
         """Get information about the current event store."""
         return {"type": self.event_store_type, "available": self.is_available()}
 

--- a/src/omnicoreagent/core/events/in_memory.py
+++ b/src/omnicoreagent/core/events/in_memory.py
@@ -1,6 +1,7 @@
-from collections import defaultdict
 import asyncio
-from typing import AsyncIterator, Set
+from collections import defaultdict
+from collections.abc import AsyncIterator
+
 from omnicoreagent.core.events.base import BaseEventStore, Event
 
 
@@ -16,15 +17,13 @@ class InMemoryEventStore(BaseEventStore):
     def __init__(self):
         self.logs: dict[str, list[Event]] = defaultdict(list)
         # Map session_id -> set of subscriber queues
-        self._subscribers: dict[str, Set[asyncio.Queue]] = defaultdict(set)
+        self._subscribers: dict[str, set[asyncio.Queue]] = defaultdict(set)
         self._lock = asyncio.Lock()
 
     async def append(self, session_id: str, event: Event) -> None:
         """Store event and broadcast to all active subscribers."""
-        self.logs[session_id].append(event)
-
-        # Fan-out to all active subscribers for this session
         async with self._lock:
+            self.logs[session_id].append(event)
             dead_queues = set()
             for queue in self._subscribers[session_id]:
                 try:
@@ -36,7 +35,8 @@ class InMemoryEventStore(BaseEventStore):
 
     async def get_events(self, session_id: str) -> list[Event]:
         """Get all historical events for a session."""
-        return self.logs[session_id]
+        async with self._lock:
+            return list(self.logs[session_id])
 
     async def stream(self, session_id: str) -> AsyncIterator[Event]:
         """

--- a/src/omnicoreagent/core/events/redis_stream.py
+++ b/src/omnicoreagent/core/events/redis_stream.py
@@ -1,7 +1,8 @@
 import os
 
 import redis.asyncio as redis
-from typing import AsyncIterator, List
+from collections.abc import AsyncIterator
+
 from omnicoreagent.core.events.base import BaseEventStore, Event
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
@@ -9,12 +10,12 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 
 class RedisStreamEventStore(BaseEventStore):
     """
-    Redis Streams-based event store.
-    
+    Redis Streams event store.
+
     Key design: stream() starts from '$' (latest) so only events published
     AFTER the stream call are received. Historical events are available via get_events().
     """
-    
+
     def __init__(self):
         self.redis = redis.from_url(REDIS_URL, decode_responses=True)
 
@@ -23,7 +24,7 @@ class RedisStreamEventStore(BaseEventStore):
         stream_name = f"omnicoreagent_events:{session_id}"
         await self.redis.xadd(stream_name, {"event": event.json()})
 
-    async def get_events(self, session_id: str) -> List[Event]:
+    async def get_events(self, session_id: str) -> list[Event]:
         """Get all historical events for a session."""
         stream_name = f"omnicoreagent_events:{session_id}"
         events = await self.redis.xrange(stream_name, min="-", max="+")
@@ -32,7 +33,7 @@ class RedisStreamEventStore(BaseEventStore):
     async def stream(self, session_id: str) -> AsyncIterator[Event]:
         """
         Stream events for a session.
-        
+
         Starts from '$' (latest) so only events published AFTER this call
         are received. Does NOT replay historical events.
         """

--- a/src/omnicoreagent/core/events/trace.py
+++ b/src/omnicoreagent/core/events/trace.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from omnicoreagent.core.events.base import Event, EventType, _to_plain
+
+
+@dataclass
+class TraceStep:
+    index: int
+    event_id: str
+    event_type: str
+    agent_name: str
+    timestamp: str
+    payload: dict[str, Any]
+    elapsed_ms: float | None = None
+    since_previous_ms: float | None = None
+
+    def model_dump(self) -> dict[str, Any]:
+        return _to_plain(self)
+
+
+@dataclass
+class TraceSummary:
+    session_id: str
+    total_events: int
+    event_counts: dict[str, int] = field(default_factory=dict)
+    started_at: str | None = None
+    ended_at: str | None = None
+    duration_ms: float | None = None
+    tool_calls: int = 0
+    tool_errors: int = 0
+    sub_agent_calls: int = 0
+    sub_agent_errors: int = 0
+    background_errors: int = 0
+    final_answer: str | None = None
+
+    def model_dump(self) -> dict[str, Any]:
+        return _to_plain(self)
+
+
+@dataclass
+class AgentTrace:
+    session_id: str
+    summary: TraceSummary
+    steps: list[TraceStep] = field(default_factory=list)
+
+    def model_dump(self) -> dict[str, Any]:
+        return _to_plain(self)
+
+
+def build_event_trace(session_id: str, events: list[Event]) -> AgentTrace:
+    """Build a compact internal trace from session events."""
+    ordered_events = sorted(events, key=lambda event: event.timestamp)
+    steps: list[TraceStep] = []
+
+    first_timestamp = ordered_events[0].timestamp if ordered_events else None
+    previous_timestamp: datetime | None = None
+
+    for index, event in enumerate(ordered_events, start=1):
+        elapsed_ms = (
+            _duration_ms(first_timestamp, event.timestamp)
+            if first_timestamp is not None
+            else None
+        )
+        since_previous_ms = (
+            _duration_ms(previous_timestamp, event.timestamp)
+            if previous_timestamp is not None
+            else None
+        )
+        payload = event.payload.model_dump()
+        steps.append(
+            TraceStep(
+                index=index,
+                event_id=event.event_id,
+                event_type=event.type.value,
+                agent_name=event.agent_name,
+                timestamp=event.timestamp.isoformat(),
+                payload=payload,
+                elapsed_ms=elapsed_ms,
+                since_previous_ms=since_previous_ms,
+            )
+        )
+        previous_timestamp = event.timestamp
+
+    summary = _build_summary(session_id=session_id, events=ordered_events)
+    return AgentTrace(session_id=session_id, summary=summary, steps=steps)
+
+
+def _build_summary(session_id: str, events: list[Event]) -> TraceSummary:
+    counts = Counter(event.type.value for event in events)
+    first_timestamp = events[0].timestamp if events else None
+    last_timestamp = events[-1].timestamp if events else None
+    final_answer = None
+
+    for event in reversed(events):
+        if event.type == EventType.FINAL_ANSWER:
+            final_answer = getattr(event.payload, "message", None)
+            break
+
+    return TraceSummary(
+        session_id=session_id,
+        total_events=len(events),
+        event_counts=dict(counts),
+        started_at=first_timestamp.isoformat() if first_timestamp else None,
+        ended_at=last_timestamp.isoformat() if last_timestamp else None,
+        duration_ms=(
+            _duration_ms(first_timestamp, last_timestamp)
+            if first_timestamp and last_timestamp
+            else None
+        ),
+        tool_calls=counts.get(EventType.TOOL_CALL_STARTED.value, 0),
+        tool_errors=counts.get(EventType.TOOL_CALL_ERROR.value, 0),
+        sub_agent_calls=counts.get(EventType.SUB_AGENT_CALL_STARTED.value, 0),
+        sub_agent_errors=counts.get(EventType.SUB_AGENT_CALL_ERROR.value, 0),
+        background_errors=counts.get(EventType.BACKGROUND_TASK_ERROR.value, 0),
+        final_answer=final_answer,
+    )
+
+
+def _duration_ms(start: datetime, end: datetime) -> float:
+    return round((end - start).total_seconds() * 1000, 3)

--- a/src/omnicoreagent/core/utils.py
+++ b/src/omnicoreagent/core/utils.py
@@ -755,17 +755,6 @@ def build_xml_observations_block(tools_results):
     return "\n".join(lines)
 
 
-def track(name_or_func=None):
-    """No-op trace decorator placeholder for internal observability hooks."""
-    if callable(name_or_func):
-        return name_or_func
-
-    def decorator(func):
-        return func
-
-    return decorator
-
-
 def get_json_schema(f) -> dict:
     """
     Generate a JSON schema for the arguments of a function.

--- a/src/omnicoreagent/serve/__init__.py
+++ b/src/omnicoreagent/serve/__init__.py
@@ -8,7 +8,7 @@ Transforms any agent into a full REST/SSE API server with:
 - Metrics and tools listing
 - Configurable middleware (CORS, auth, logging, rate limiting)
 - Prometheus metrics endpoint
-- OpenTelemetry tracing support
+- Agent event streaming and in-house trace summaries
 - Retry logic and circuit breaker for resilience
 - Proper lifecycle management
 

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -116,6 +116,14 @@ class EventsResponse(BaseModel):
     count: int = Field(..., description="Number of events")
 
 
+class TraceResponse(BaseModel):
+    """Response model for session trace endpoint."""
+
+    session_id: str = Field(..., description="Session ID")
+    summary: Dict[str, Any] = Field(..., description="Trace summary")
+    steps: List[Dict[str, Any]] = Field(..., description="Ordered trace steps")
+
+
 class ErrorResponse(BaseModel):
     """Standard error response model."""
 

--- a/src/omnicoreagent/serve/observability.py
+++ b/src/omnicoreagent/serve/observability.py
@@ -1,16 +1,12 @@
-"""
-OmniServe Observability - OpenTelemetry Integration.
+"""OmniServe observability.
 
-Provides distributed tracing, metrics, and Prometheus endpoint.
-Requires: opentelemetry-api, opentelemetry-sdk, opentelemetry-instrumentation-fastapi
-
-Optional dependencies:
-    pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-prometheus
-    pip install opentelemetry-instrumentation-fastapi opentelemetry-instrumentation-httpx
+Provides lightweight in-process request metrics and a Prometheus endpoint.
+Agent-level traces are built from OmniCoreAgent events, not external tracing
+libraries.
 """
 
 import time
-from typing import TYPE_CHECKING, Dict, Callable
+from typing import TYPE_CHECKING, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import PlainTextResponse
@@ -22,34 +18,19 @@ if TYPE_CHECKING:
     from .config import OmniServeConfig
 
 
-# Check if OpenTelemetry is available
-OTEL_AVAILABLE = False
-try:
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-
-    OTEL_AVAILABLE = True
-except ImportError:
-    pass
-
-
-# Simple in-memory metrics for when OpenTelemetry is not installed
 class SimpleMetrics:
     """Simple metrics tracker for Prometheus-style output."""
 
     def __init__(self):
-        self.counters: Dict[str, int] = {
+        self.counters: dict[str, int] = {
             "omniserve_requests_total": 0,
             "omniserve_requests_success": 0,
             "omniserve_requests_error": 0,
         }
-        self.histograms: Dict[str, list] = {
+        self.histograms: dict[str, list[float]] = {
             "omniserve_request_duration_seconds": [],
         }
-        self.gauges: Dict[str, float] = {
+        self.gauges: dict[str, float] = {
             "omniserve_active_requests": 0,
         }
 
@@ -158,43 +139,6 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             metrics.inc_counter(f"omniserve_requests_{path}_total")
 
 
-def setup_opentelemetry(app: FastAPI, service_name: str = "omniserve") -> None:
-    """
-    Set up OpenTelemetry tracing and metrics.
-
-    Args:
-        app: FastAPI application
-        service_name: Name for the service in traces
-    """
-    if not OTEL_AVAILABLE:
-        logger.warning(
-            "OmniServe: OpenTelemetry not installed. "
-            "Install with: pip install opentelemetry-api opentelemetry-sdk "
-            "opentelemetry-instrumentation-fastapi"
-        )
-        return
-
-    try:
-        # Create resource
-        resource = Resource.create({SERVICE_NAME: service_name})
-
-        # Set up tracing
-        tracer_provider = TracerProvider(resource=resource)
-
-        # Add console exporter for development (replace with OTLP for production)
-        tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-
-        trace.set_tracer_provider(tracer_provider)
-
-        # Instrument FastAPI
-        FastAPIInstrumentor.instrument_app(app)
-
-        logger.info("OmniServe: OpenTelemetry tracing enabled")
-
-    except Exception as e:
-        logger.warning(f"OmniServe: Failed to setup OpenTelemetry: {e}")
-
-
 def add_prometheus_endpoint(app: FastAPI) -> None:
     """
     Add Prometheus metrics endpoint at /prometheus.
@@ -247,9 +191,4 @@ def setup_observability(
     # Add metrics middleware (always enabled)
     add_metrics_middleware(app)
 
-    # Add Prometheus endpoint
     add_prometheus_endpoint(app)
-
-    # Set up OpenTelemetry if available
-    if OTEL_AVAILABLE:
-        setup_opentelemetry(app, service_name)

--- a/src/omnicoreagent/serve/routes.py
+++ b/src/omnicoreagent/serve/routes.py
@@ -23,6 +23,7 @@ from .models import (
     MetricsResponse,
     SessionHistoryResponse,
     EventsResponse,
+    TraceResponse,
     ErrorResponse,
 )
 from .sse import run_agent_stream, stream_session_events
@@ -244,6 +245,23 @@ def create_agent_router() -> APIRouter:
             session_id=session_id,
             events=events_list,
             count=len(events_list),
+        )
+
+    @router.get(
+        "/events/{session_id}/trace",
+        response_model=TraceResponse,
+        summary="Get session trace",
+        description="Build a compact trace summary from stored session events.",
+    )
+    async def get_trace(request: Request, session_id: str) -> TraceResponse:
+        """Get a compact trace for a session."""
+        agent: AgentType = request.app.state.agent
+        trace = await agent.get_trace(session_id)
+
+        return TraceResponse(
+            session_id=session_id,
+            summary=trace.get("summary", {}),
+            steps=trace.get("steps", []),
         )
 
     # =========================================================================

--- a/src/omnicoreagent/serve/server.py
+++ b/src/omnicoreagent/serve/server.py
@@ -106,7 +106,7 @@ class OmniServe:
         # Setup middleware
         setup_all_middleware(app, self.config)
 
-        # Setup observability (metrics, tracing)
+        # Setup observability metrics
         from .observability import setup_observability
         setup_observability(app, self.config, service_name=self.agent.name)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,9 +1,21 @@
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
 from omnicoreagent.core.events.base import (
+    AgentMessagePayload,
     Event,
     EventType,
+    FinalAnswerPayload,
+    SubAgentCallErrorPayload,
+    SubAgentCallStartedPayload,
+    ToolCallErrorPayload,
     ToolCallStartedPayload,
     UserMessagePayload,
 )
+from omnicoreagent.core.events.event_router import EventRouter
+from omnicoreagent.core.events.in_memory import InMemoryEventStore
+from omnicoreagent.core.events.trace import build_event_trace
 
 
 def test_event_payloads_keep_model_dump_compatibility():
@@ -32,3 +44,139 @@ def test_event_serializes_and_parses_without_pydantic():
         "tool_args": {"q": "test"},
         "tool_call_id": None,
     }
+
+
+def test_build_event_trace_orders_events_and_summarizes_runtime():
+    start = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+    events = [
+        Event(
+            type=EventType.FINAL_ANSWER,
+            payload=FinalAnswerPayload(message="done"),
+            agent_name="agent",
+            timestamp=start + timedelta(milliseconds=30),
+            event_id="final",
+        ),
+        Event(
+            type=EventType.USER_MESSAGE,
+            payload=UserMessagePayload(message="hello"),
+            agent_name="agent",
+            timestamp=start,
+            event_id="user",
+        ),
+        Event(
+            type=EventType.TOOL_CALL_STARTED,
+            payload=ToolCallStartedPayload(
+                tool_name="search",
+                tool_args={"query": "runtime"},
+                tool_call_id="tool-call-1",
+            ),
+            agent_name="agent",
+            timestamp=start + timedelta(milliseconds=10),
+            event_id="tool-start",
+        ),
+        Event(
+            type=EventType.TOOL_CALL_ERROR,
+            payload=ToolCallErrorPayload(
+                tool_name="search",
+                error_message="failed",
+            ),
+            agent_name="agent",
+            timestamp=start + timedelta(milliseconds=20),
+            event_id="tool-error",
+        ),
+        Event(
+            type=EventType.SUB_AGENT_CALL_STARTED,
+            payload=SubAgentCallStartedPayload(
+                agent_name="worker",
+                session_id="sub-session",
+                timestamp=start.isoformat(),
+                run_count=1,
+                kwargs={"task": "inspect"},
+            ),
+            agent_name="agent",
+            timestamp=start + timedelta(milliseconds=25),
+            event_id="sub-start",
+        ),
+        Event(
+            type=EventType.SUB_AGENT_CALL_ERROR,
+            payload=SubAgentCallErrorPayload(
+                agent_name="worker",
+                session_id="sub-session",
+                timestamp=start.isoformat(),
+                error="failed",
+                error_count=1,
+            ),
+            agent_name="agent",
+            timestamp=start + timedelta(milliseconds=26),
+            event_id="sub-error",
+        ),
+    ]
+
+    trace = build_event_trace(session_id="chat1", events=events)
+    dumped = trace.model_dump()
+
+    assert [step.event_id for step in trace.steps] == [
+        "user",
+        "tool-start",
+        "tool-error",
+        "sub-start",
+        "sub-error",
+        "final",
+    ]
+    assert trace.steps[0].elapsed_ms == 0
+    assert trace.steps[1].since_previous_ms == 10
+    assert trace.summary.total_events == 6
+    assert trace.summary.duration_ms == 30
+    assert trace.summary.tool_calls == 1
+    assert trace.summary.tool_errors == 1
+    assert trace.summary.sub_agent_calls == 1
+    assert trace.summary.sub_agent_errors == 1
+    assert trace.summary.final_answer == "done"
+    assert dumped["summary"]["event_counts"]["tool_call_error"] == 1
+
+
+@pytest.mark.asyncio
+async def test_in_memory_event_store_returns_snapshot():
+    store = InMemoryEventStore()
+    event = Event(
+        type=EventType.AGENT_MESSAGE,
+        payload=AgentMessagePayload(message="hello"),
+        agent_name="agent",
+    )
+
+    await store.append("chat2", event)
+    first_read = await store.get_events("chat2")
+    first_read.clear()
+    second_read = await store.get_events("chat2")
+
+    assert second_read == [event]
+
+
+@pytest.mark.asyncio
+async def test_event_router_builds_trace_from_store():
+    router = EventRouter(event_store_type="in_memory")
+    await router.append(
+        "chat3",
+        Event(
+            type=EventType.USER_MESSAGE,
+            payload=UserMessagePayload(message="hello"),
+            agent_name="agent",
+        ),
+    )
+    await router.append(
+        "chat3",
+        Event(
+            type=EventType.FINAL_ANSWER,
+            payload=FinalAnswerPayload(message="done"),
+            agent_name="agent",
+        ),
+    )
+
+    trace = await router.get_trace("chat3")
+
+    assert trace.summary.total_events == 2
+    assert trace.summary.final_answer == "done"
+    assert [step.event_type for step in trace.steps] == [
+        "user_message",
+        "final_answer",
+    ]

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -242,7 +242,6 @@ from omnicoreagent import OmniCoreAgent
 
 watched_modules = [
     "decouple",
-    "opik",
     "rich",
     "rich.console",
     "litellm",
@@ -297,7 +296,6 @@ print(json.dumps({
     "log_file_created": Path("omnicoreagent.log").exists(),
     "decouple_loaded": "decouple" in sys.modules,
     "rich_loaded": any(module == "rich" or module.startswith("rich.") for module in sys.modules),
-    "opik_loaded": "opik" in sys.modules,
 }))
 """,
     )
@@ -307,5 +305,4 @@ print(json.dumps({
         "log_file_created": False,
         "decouple_loaded": False,
         "rich_loaded": False,
-        "opik_loaded": False,
     }

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -108,6 +108,13 @@ class TestEndpoints:
         agent.run = AsyncMock(return_value={"response": "Agent response"})
         # Mock get_metrics
         agent.get_metrics = AsyncMock(return_value={"total_tokens": 100})
+        agent.get_trace = AsyncMock(
+            return_value={
+                "session_id": "test-endpoint-session",
+                "summary": {"total_events": 2, "tool_calls": 1},
+                "steps": [{"index": 1, "event_type": "user_message"}],
+            }
+        )
         
         server = OmniServe(agent=agent, config=OmniServeConfig())
         return TestClient(server.app)
@@ -135,6 +142,14 @@ class TestEndpoints:
         resp = server_client.get("/prometheus")
         assert resp.status_code == 200
         assert "omniserve_requests_total" in resp.text
+
+    def test_trace_endpoint(self, server_client):
+        resp = server_client.get("/events/test-endpoint-session/trace")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "test-endpoint-session"
+        assert data["summary"]["tool_calls"] == 1
+        assert data["steps"][0]["event_type"] == "user_message"
 
 # =============================================================================
 # Test Resilience


### PR DESCRIPTION
## Summary
- add dependency-free event trace summaries from stored session events
- expose traces through OmniCoreAgent.get_trace() and OmniServe /events/{session_id}/trace
- remove stale no-op track decorators and external OpenTelemetry setup
- tighten in-memory event store snapshots and update event/observability docs

## Verification
- uv run ruff check .
- uv run pytest -q
- git diff --check
- uv run hatch build