### PR TITLE
Split React loop runtime helpers

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -1,29 +1,21 @@
 from __future__ import annotations
 
-import asyncio
 import time
 
 from collections.abc import Callable
-from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, Tuple
-from omnicoreagent.core.system_prompts import (
-    AgentPromptContextBuilder,
-    FAST_CONVERSATION_SUMMARY_PROMPT,
-)
+from typing import TYPE_CHECKING, Any
+from omnicoreagent.core.system_prompts import AgentPromptContextBuilder
 from omnicoreagent.core.token_usage import (
     Usage,
-    UsageLimitExceeded,
     UsageLimits,
-    session_stats,
-    usage,
 )
 from omnicoreagent.core.types import (
     AgentState,
     Message,
     ParsedResponse,
+    SessionState,
     ToolCallResult,
     ToolError,
-    SessionState,
 )
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.tools.tool_batch_runner import ToolBatchRunner
@@ -31,19 +23,11 @@ from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
 from omnicoreagent.core.tools.tool_failure_handler import ToolFailureHandler
 from omnicoreagent.core.tools.tool_runtime_registry import ToolRuntimeRegistry
 from omnicoreagent.core.utils import (
-    RobustLoopDetector,
     logger,
     show_tool_response,
     BackgroundTaskManager,
 )
-from omnicoreagent.core.events.base import (
-    Event,
-    EventType,
-    FinalAnswerPayload,
-    AgentMessagePayload,
-    UserMessagePayload,
-    AgentThoughtPayload,
-)
+from omnicoreagent.core.events.base import Event
 from omnicoreagent.core.context_manager import (
     AgentLoopContextManager,
     ContextManagementConfig,
@@ -52,15 +36,14 @@ from omnicoreagent.core.tool_response_offloader import (
     ToolResponseOffloader,
     OffloadConfig,
 )
-from omnicoreagent.core.agents.llm_response import (
-    extract_response_content,
-    extract_response_usage,
-)
+from omnicoreagent.core.agents.initial_messages import AgentInitialMessagePreparer
+from omnicoreagent.core.agents.llm_step import AgentLlmStepRunner
 from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
+from omnicoreagent.core.agents import events as agent_events
+from omnicoreagent.core.agents.session_state import AgentSessionStateStore
 from omnicoreagent.core.agents.subagent_runner import SubAgentCallRunner
 from omnicoreagent.core.tools.tool_observation import ToolObservationHandler
 from omnicoreagent.core.agents.xml_parser import (
-    extract_thought,
     parse_action_or_answer,
 )
 
@@ -106,13 +89,21 @@ class BaseReactAgent:
             request_limit=self.request_limit, total_tokens_limit=self.total_tokens_limit
         )
 
-        self._session_states: dict[Tuple[str, str], SessionState] = {}
+        self.session_state_store = AgentSessionStateStore(agent_name=self.agent_name)
+        self._session_states = self.session_state_store.states
         self.background_task_manager = BackgroundTaskManager()
         self.init_skills()
         self.register_internal_tool = ToolRegistry()
 
         self.context_manager = AgentLoopContextManager(
             ContextManagementConfig.from_dict(context_management_config or {})
+        )
+        self.llm_step_runner = AgentLlmStepRunner(
+            agent_name=self.agent_name,
+            context_manager=self.context_manager,
+            usage_limits=self.usage_limits,
+            limits_enabled=self._limits_enabled,
+            request_limit=self.request_limit,
         )
 
         self.tool_offloader = ToolResponseOffloader(
@@ -151,6 +142,11 @@ class BaseReactAgent:
             is_tool_offload_enabled=lambda: self.tool_offloader.config.enabled,
             skill_manager=self.skill_manager,
         )
+        self.initial_message_preparer = AgentInitialMessagePreparer(
+            tool_runtime_registry=self.tool_runtime_registry,
+            message_history_loader=self.message_history_loader,
+            prompt_context_builder=self.prompt_context_builder,
+        )
 
     def init_skills(self):
         if self.enable_agent_skills:
@@ -163,16 +159,7 @@ class BaseReactAgent:
             )
 
     def _get_session_state(self, session_id: str, debug: bool) -> SessionState:
-        key = (session_id, self.agent_name)
-        if key not in self._session_states:
-            self._session_states[key] = SessionState(
-                messages=[],
-                state=AgentState.IDLE,
-                loop_detector=RobustLoopDetector(debug=debug),
-                assistant_with_tool_calls=None,
-                pending_tool_responses=[],
-            )
-        return self._session_states[key]
+        return self.session_state_store.get(session_id=session_id, debug=debug)
 
     async def extract_action_or_answer(
         self,
@@ -182,16 +169,12 @@ class BaseReactAgent:
         debug: bool = False,
     ) -> ParsedResponse:
         """Parse LLM response to extract a final answer, tool call, or agent call using XML format only."""
-        thought = extract_thought(response)
-        if thought:
-            event = Event(
-                type=EventType.AGENT_THOUGHT,
-                payload=AgentThoughtPayload(message=thought),
-                agent_name=self.agent_name,
-            )
-            if event_router:
-                await event_router(session_id=session_id, event=event)
-
+        await agent_events.emit_agent_thought_from_response(
+            event_router=event_router,
+            session_id=session_id,
+            agent_name=self.agent_name,
+            response=response,
+        )
         return parse_action_or_answer(response, debug=debug)
 
     async def resolve_tool_call_request(
@@ -310,24 +293,15 @@ class BaseReactAgent:
         messages.extend(old_messages)
         return messages
 
-    @asynccontextmanager
-    async def agent_session_state_context(
+    def agent_session_state_context(
         self, new_state: AgentState, session_id: str, debug: bool
     ):
         """Context manager to change the agent session state"""
-        session_state = self._get_session_state(session_id=session_id, debug=debug)
-        if not isinstance(new_state, AgentState):
-            raise ValueError(f"Invalid agent state: {new_state}")
-        previous_state = session_state.state
-        session_state.state = new_state
-        try:
-            yield
-        except Exception as e:
-            session_state.state = AgentState.ERROR
-            logger.error(f"Error in agent state context: {e}")
-            raise
-        finally:
-            session_state.state = previous_state
+        return self.session_state_store.state_context(
+            new_state=new_state,
+            session_id=session_id,
+            debug=debug,
+        )
 
     async def prepare_initial_messages(
         self,
@@ -340,59 +314,15 @@ class BaseReactAgent:
         debug: bool = False,
         sub_agents: list = None,
     ) -> None:
-        """
-        Prepare the full initial message list for the LLM by concurrently:
-        - Building tool registry
-        - Loading prior message history
-        - Injecting current user query
-        """
-        tasks = {}
-
-        tasks["tools"] = self.tool_runtime_registry.render_prompt_registry(
-            mcp_tools=mcp_tools, local_tools=local_tools
-        )
-
-        tasks["history"] = self.message_history_loader.load(
-            message_history=message_history,
-            session_id=session_id,
+        await self.initial_message_preparer.prepare(
             session_state=session_state,
-        )
-
-        try:
-            results = await asyncio.wait_for(
-                asyncio.gather(
-                    tasks["tools"],
-                    tasks["history"],
-                    return_exceptions=True,
-                ),
-                timeout=20.0,
-            )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Timeout during initial message preparation (20s). Proceeding with defaults."
-            )
-            results = ["No tools available", None]
-
-        for r in results:
-            if isinstance(r, BaseException):
-                logger.error(f"prepare_initial_messages error: {r}", exc_info=True)
-
-        tools_section = (
-            results[0]
-            if not isinstance(results[0], BaseException)
-            else "No tools available"
-        )
-
-        updated_system_prompt = await self.prompt_context_builder.build_system_prompt(
-            base_system_prompt=system_prompt,
-            tools_section=tools_section,
+            system_prompt=system_prompt,
+            session_id=session_id,
+            message_history=message_history,
+            mcp_tools=mcp_tools,
+            local_tools=local_tools,
             sub_agents=sub_agents,
         )
-
-        session_state.messages.insert(
-            0, Message(role="system", content=updated_system_prompt)
-        )
-        self.prompt_context_builder.inject_current_datetime(session_state.messages)
 
     async def execute_sub_agent_calls(
         self,
@@ -445,23 +375,18 @@ class BaseReactAgent:
         """Execute ReAct loop with JSON communication
         kwargs: if mcp is enbale then it will be sessions and availables_tools else it will be local_tools
         """
-        session_state = self._get_session_state(session_id=session_id, debug=debug)
-        session_state.messages = []
-        session_state.assistant_with_tool_calls = None
-        session_state.pending_tool_responses = []
-        session_state.loop_detector.reset()
+        session_state = self.session_state_store.reset_for_run(
+            session_id=session_id, debug=debug
+        )
         start_time = time.perf_counter()
         run_usage = Usage()
 
-        event = Event(
-            type=EventType.USER_MESSAGE,
-            payload=UserMessagePayload(
-                message=query,
-            ),
+        await agent_events.emit_user_message(
+            event_router=event_router,
+            session_id=session_id,
             agent_name=self.agent_name,
+            message=query,
         )
-        if event_router:
-            await event_router(session_id=session_id, event=event)
 
         await add_message_to_history(
             role="user",
@@ -499,116 +424,18 @@ class BaseReactAgent:
                 session_state.state not in [AgentState.FINISHED]
                 and current_steps < self.max_steps
             ):
-                if debug:
-                    logger.info(
-                        f"Sending {len(session_state.messages)} messages to LLM"
-                    )
                 current_steps += 1
-                if self._limits_enabled:
-                    self.usage_limits.check_before_request(usage=usage)
-
-                try:
-                    if self.context_manager.should_trigger(session_state.messages):
-
-                        async def _summarize_for_context(msgs):
-                            """Summarize messages for context management."""
-                            history_text = "\n".join(
-                                [
-                                    f"{m.role if hasattr(m, 'role') else m.get('role', 'unknown')}: "
-                                    f"{m.content if hasattr(m, 'content') else m.get('content', '')}"
-                                    for m in msgs
-                                ]
-                            )
-                            summary_msgs = [
-                                {
-                                    "role": "system",
-                                    "content": FAST_CONVERSATION_SUMMARY_PROMPT,
-                                },
-                                {
-                                    "role": "user",
-                                    "content": f"Here is the conversation history: {history_text}",
-                                },
-                            ]
-                            response = await llm_connection.llm_call(summary_msgs)
-                            return extract_response_content(response, default="")
-
-                        session_state.messages = (
-                            await self.context_manager.manage_context(
-                                messages=session_state.messages,
-                                summarize_fn=_summarize_for_context,
-                            )
-                        )
-                        if debug:
-                            logger.info(
-                                f"Context managed: now {len(session_state.messages)} messages"
-                            )
-
-                    async def make_llm_call():
-                        return await llm_connection.llm_call(session_state.messages)
-
-                    response = await make_llm_call()
-
-                    if response:
-                        message_content = extract_response_content(
-                            response,
-                            strip=False,
-                        )
-
-                        event = Event(
-                            type=EventType.AGENT_MESSAGE,
-                            payload=AgentMessagePayload(
-                                message=message_content,
-                            ),
-                            agent_name=self.agent_name,
-                        )
-                        if event_router:
-                            # Await to ensure event is queued before continuing
-                            await event_router(session_id=session_id, event=event)
-
-                        request_usage = extract_response_usage(response)
-                        if request_usage:
-                            usage.incr(request_usage)
-                            run_usage.incr(request_usage)
-
-                            if self._limits_enabled:
-                                self.usage_limits.check_tokens(usage)
-                                remaining_tokens = self.usage_limits.remaining_tokens(
-                                    usage
-                                )
-                                used_tokens = usage.total_tokens
-                                used_requests = usage.requests
-                                remaining_requests = self.request_limit - used_requests
-                                session_stats.update(
-                                    {
-                                        "used_requests": used_requests,
-                                        "used_tokens": used_tokens,
-                                        "remaining_requests": remaining_requests,
-                                        "remaining_tokens": remaining_tokens,
-                                        "request_tokens": request_usage.request_tokens,
-                                        "response_tokens": request_usage.response_tokens,
-                                        "total_tokens": request_usage.total_tokens,
-                                    }
-                                )
-                                if debug:
-                                    logger.info(
-                                        f"API Call Stats - Requests: {used_requests}/{self.request_limit}, "
-                                        f"Tokens: {used_tokens}/{self.usage_limits.total_tokens_limit}, "
-                                        f"Request Tokens: {request_usage.request_tokens}, "
-                                        f"Response Tokens: {request_usage.response_tokens}, "
-                                        f"Total Tokens: {request_usage.total_tokens}, "
-                                        f"Remaining Requests: {remaining_requests}, "
-                                        f"Remaining Tokens: {remaining_tokens}"
-                                    )
-                        response = extract_response_content(response)
-                except UsageLimitExceeded as e:
-                    error_message = f"Usage limit error: {e}"
-                    logger.error(error_message)
-                    return {"answer": error_message, "usage": run_usage}
-
-                except Exception as e:
-                    error_message = "Model encountered an error, please do retry again"
-                    logger.error(f"{error_message}: {e}")
-                    return {"answer": error_message, "usage": run_usage}
+                llm_step = await self.llm_step_runner.run(
+                    session_state=session_state,
+                    llm_connection=llm_connection,
+                    run_usage=run_usage,
+                    session_id=session_id,
+                    event_router=event_router,
+                    debug=debug,
+                )
+                if llm_step.error_result is not None:
+                    return llm_step.error_result
+                response = llm_step.response
 
                 parsed_response = await self.extract_action_or_answer(
                     response=response,
@@ -628,17 +455,12 @@ class BaseReactAgent:
                         )
                     )
 
-                    event = Event(
-                        type=EventType.FINAL_ANSWER,
-                        payload=FinalAnswerPayload(
-                            message=str(parsed_response.answer),
-                        ),
+                    await agent_events.emit_final_answer(
+                        event_router=event_router,
+                        session_id=session_id,
                         agent_name=self.agent_name,
+                        message=str(parsed_response.answer),
                     )
-                    if event_router:
-                        # CRITICAL: Await the event emission to ensure it's in the queue
-                        # before run() returns. This prevents race conditions with SSE streaming.
-                        await event_router(session_id=session_id, event=event)
                     await add_message_to_history(
                         role="assistant",
                         content=parsed_response.answer,

--- a/src/omnicoreagent/core/agents/events.py
+++ b/src/omnicoreagent/core/agents/events.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from omnicoreagent.core.agents.xml_parser import extract_thought
+from omnicoreagent.core.events.base import (
+    AgentMessagePayload,
+    AgentThoughtPayload,
+    Event,
+    EventType,
+    FinalAnswerPayload,
+    UserMessagePayload,
+)
+
+
+async def emit_event(
+    *,
+    event_router: Callable | None,
+    session_id: str,
+    event: Event,
+):
+    if event_router:
+        await event_router(session_id=session_id, event=event)
+
+
+async def emit_user_message(
+    *,
+    event_router: Callable | None,
+    session_id: str,
+    agent_name: str,
+    message: str,
+):
+    await emit_event(
+        event_router=event_router,
+        session_id=session_id,
+        event=Event(
+            type=EventType.USER_MESSAGE,
+            payload=UserMessagePayload(message=message),
+            agent_name=agent_name,
+        ),
+    )
+
+
+async def emit_agent_message(
+    *,
+    event_router: Callable | None,
+    session_id: str,
+    agent_name: str,
+    message: str,
+):
+    await emit_event(
+        event_router=event_router,
+        session_id=session_id,
+        event=Event(
+            type=EventType.AGENT_MESSAGE,
+            payload=AgentMessagePayload(message=message),
+            agent_name=agent_name,
+        ),
+    )
+
+
+async def emit_agent_thought_from_response(
+    *,
+    event_router: Callable | None,
+    session_id: str,
+    agent_name: str,
+    response: str,
+):
+    thought = extract_thought(response)
+    if not thought:
+        return
+
+    await emit_event(
+        event_router=event_router,
+        session_id=session_id,
+        event=Event(
+            type=EventType.AGENT_THOUGHT,
+            payload=AgentThoughtPayload(message=thought),
+            agent_name=agent_name,
+        ),
+    )
+
+
+async def emit_final_answer(
+    *,
+    event_router: Callable | None,
+    session_id: str,
+    agent_name: str,
+    message: str,
+):
+    await emit_event(
+        event_router=event_router,
+        session_id=session_id,
+        event=Event(
+            type=EventType.FINAL_ANSWER,
+            payload=FinalAnswerPayload(message=message),
+            agent_name=agent_name,
+        ),
+    )

--- a/src/omnicoreagent/core/agents/initial_messages.py
+++ b/src/omnicoreagent/core/agents/initial_messages.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from omnicoreagent.core.types import Message, SessionState
+from omnicoreagent.core.utils import logger
+
+
+class AgentInitialMessagePreparer:
+    def __init__(
+        self,
+        *,
+        tool_runtime_registry: Any,
+        message_history_loader: Any,
+        prompt_context_builder: Any,
+        timeout_seconds: float = 20.0,
+    ):
+        self.tool_runtime_registry = tool_runtime_registry
+        self.message_history_loader = message_history_loader
+        self.prompt_context_builder = prompt_context_builder
+        self.timeout_seconds = timeout_seconds
+
+    async def prepare(
+        self,
+        *,
+        session_state: SessionState,
+        system_prompt: str,
+        session_id: str,
+        message_history: Callable[[], Any],
+        mcp_tools: dict | None = None,
+        local_tools: Any = None,
+        sub_agents: list | None = None,
+    ) -> None:
+        tools_task = self.tool_runtime_registry.render_prompt_registry(
+            mcp_tools=mcp_tools, local_tools=local_tools
+        )
+        history_task = self.message_history_loader.load(
+            message_history=message_history,
+            session_id=session_id,
+            session_state=session_state,
+        )
+
+        try:
+            results = await asyncio.wait_for(
+                asyncio.gather(
+                    tools_task,
+                    history_task,
+                    return_exceptions=True,
+                ),
+                timeout=self.timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timeout during initial message preparation "
+                f"({self.timeout_seconds:g}s). Proceeding with defaults."
+            )
+            results = ["No tools available", None]
+
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.error(f"prepare_initial_messages error: {result}", exc_info=True)
+
+        tools_section = (
+            results[0]
+            if not isinstance(results[0], BaseException)
+            else "No tools available"
+        )
+
+        updated_system_prompt = await self.prompt_context_builder.build_system_prompt(
+            base_system_prompt=system_prompt,
+            tools_section=tools_section,
+            sub_agents=sub_agents,
+        )
+
+        session_state.messages.insert(
+            0, Message(role="system", content=updated_system_prompt)
+        )
+        self.prompt_context_builder.inject_current_datetime(session_state.messages)

--- a/src/omnicoreagent/core/agents/llm_step.py
+++ b/src/omnicoreagent/core/agents/llm_step.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from omnicoreagent.core.agents import events as agent_events
+from omnicoreagent.core.agents.llm_response import (
+    extract_response_content,
+    extract_response_usage,
+)
+from omnicoreagent.core.system_prompts import FAST_CONVERSATION_SUMMARY_PROMPT
+from omnicoreagent.core.token_usage import (
+    Usage,
+    UsageLimitExceeded,
+    UsageLimits,
+    session_stats,
+    usage,
+)
+from omnicoreagent.core.types import SessionState
+from omnicoreagent.core.utils import logger
+
+
+@dataclass
+class AgentLlmStepResult:
+    response: str | None = None
+    error_result: dict[str, Any] | None = None
+
+
+class AgentLlmStepRunner:
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        context_manager: Any,
+        usage_limits: UsageLimits,
+        limits_enabled: bool,
+        request_limit: int,
+    ):
+        self.agent_name = agent_name
+        self.context_manager = context_manager
+        self.usage_limits = usage_limits
+        self.limits_enabled = limits_enabled
+        self.request_limit = request_limit
+
+    async def run(
+        self,
+        *,
+        session_state: SessionState,
+        llm_connection: Any,
+        run_usage: Usage,
+        session_id: str,
+        event_router: Any = None,
+        debug: bool = False,
+    ) -> AgentLlmStepResult:
+        if debug:
+            logger.info(f"Sending {len(session_state.messages)} messages to LLM")
+
+        try:
+            if self.limits_enabled:
+                self.usage_limits.check_before_request(usage=usage)
+
+            if self.context_manager.should_trigger(session_state.messages):
+                session_state.messages = await self.context_manager.manage_context(
+                    messages=session_state.messages,
+                    summarize_fn=self._build_context_summarizer(llm_connection),
+                )
+                if debug:
+                    logger.info(
+                        f"Context managed: now {len(session_state.messages)} messages"
+                    )
+
+            response = await llm_connection.llm_call(session_state.messages)
+            if response:
+                await self._record_response(
+                    response=response,
+                    run_usage=run_usage,
+                    session_id=session_id,
+                    event_router=event_router,
+                    debug=debug,
+                )
+                response = extract_response_content(response)
+            return AgentLlmStepResult(response=response)
+
+        except UsageLimitExceeded as e:
+            error_message = f"Usage limit error: {e}"
+            logger.error(error_message)
+            return AgentLlmStepResult(
+                error_result={"answer": error_message, "usage": run_usage}
+            )
+
+        except Exception as e:
+            error_message = "Model encountered an error, please do retry again"
+            logger.error(f"{error_message}: {e}")
+            return AgentLlmStepResult(
+                error_result={"answer": error_message, "usage": run_usage}
+            )
+
+    def _build_context_summarizer(self, llm_connection: Any):
+        async def summarize_for_context(messages):
+            history_text = "\n".join(
+                [
+                    f"{message.role if hasattr(message, 'role') else message.get('role', 'unknown')}: "
+                    f"{message.content if hasattr(message, 'content') else message.get('content', '')}"
+                    for message in messages
+                ]
+            )
+            summary_messages = [
+                {
+                    "role": "system",
+                    "content": FAST_CONVERSATION_SUMMARY_PROMPT,
+                },
+                {
+                    "role": "user",
+                    "content": f"Here is the conversation history: {history_text}",
+                },
+            ]
+            response = await llm_connection.llm_call(summary_messages)
+            return extract_response_content(response, default="")
+
+        return summarize_for_context
+
+    async def _record_response(
+        self,
+        *,
+        response: Any,
+        run_usage: Usage,
+        session_id: str,
+        event_router: Any,
+        debug: bool,
+    ):
+        message_content = extract_response_content(response, strip=False)
+        await agent_events.emit_agent_message(
+            event_router=event_router,
+            session_id=session_id,
+            agent_name=self.agent_name,
+            message=message_content,
+        )
+
+        request_usage = extract_response_usage(response)
+        if not request_usage:
+            return
+
+        usage.incr(request_usage)
+        run_usage.incr(request_usage)
+
+        if not self.limits_enabled:
+            return
+
+        self.usage_limits.check_tokens(usage)
+        remaining_tokens = self.usage_limits.remaining_tokens(usage)
+        used_tokens = usage.total_tokens
+        used_requests = usage.requests
+        remaining_requests = self.request_limit - used_requests
+        session_stats.update(
+            {
+                "used_requests": used_requests,
+                "used_tokens": used_tokens,
+                "remaining_requests": remaining_requests,
+                "remaining_tokens": remaining_tokens,
+                "request_tokens": request_usage.request_tokens,
+                "response_tokens": request_usage.response_tokens,
+                "total_tokens": request_usage.total_tokens,
+            }
+        )
+        if debug:
+            logger.info(
+                f"API Call Stats - Requests: {used_requests}/{self.request_limit}, "
+                f"Tokens: {used_tokens}/{self.usage_limits.total_tokens_limit}, "
+                f"Request Tokens: {request_usage.request_tokens}, "
+                f"Response Tokens: {request_usage.response_tokens}, "
+                f"Total Tokens: {request_usage.total_tokens}, "
+                f"Remaining Requests: {remaining_requests}, "
+                f"Remaining Tokens: {remaining_tokens}"
+            )

--- a/src/omnicoreagent/core/agents/session_state.py
+++ b/src/omnicoreagent/core/agents/session_state.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from omnicoreagent.core.types import AgentState, SessionState
+from omnicoreagent.core.utils import RobustLoopDetector, logger
+
+
+class AgentSessionStateStore:
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+        self.states: dict[tuple[str, str], SessionState] = {}
+
+    def get(self, session_id: str, debug: bool) -> SessionState:
+        key = (session_id, self.agent_name)
+        if key not in self.states:
+            self.states[key] = SessionState(
+                messages=[],
+                state=AgentState.IDLE,
+                loop_detector=RobustLoopDetector(debug=debug),
+                assistant_with_tool_calls=None,
+                pending_tool_responses=[],
+            )
+        return self.states[key]
+
+    def reset_for_run(self, session_id: str, debug: bool) -> SessionState:
+        session_state = self.get(session_id=session_id, debug=debug)
+        session_state.messages = []
+        session_state.assistant_with_tool_calls = None
+        session_state.pending_tool_responses = []
+        session_state.loop_detector.reset()
+        return session_state
+
+    @asynccontextmanager
+    async def state_context(
+        self, *, new_state: AgentState, session_id: str, debug: bool
+    ):
+        if not isinstance(new_state, AgentState):
+            raise ValueError(f"Invalid agent state: {new_state}")
+
+        session_state = self.get(session_id=session_id, debug=debug)
+        previous_state = session_state.state
+        session_state.state = new_state
+        try:
+            yield
+        except Exception as e:
+            session_state.state = AgentState.ERROR
+            logger.error(f"Error in agent state context: {e}")
+            raise
+        finally:
+            session_state.state = previous_state

--- a/tests/test_agent_events.py
+++ b/tests/test_agent_events.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from omnicoreagent.core.agents import events as agent_events
+from omnicoreagent.core.events.base import EventType
+
+
+@pytest.mark.asyncio
+async def test_emit_agent_thought_only_emits_when_response_has_thought():
+    emitted = []
+
+    async def event_router(session_id, event):
+        emitted.append({"session_id": session_id, "event": event})
+
+    await agent_events.emit_agent_thought_from_response(
+        event_router=event_router,
+        session_id="chat1",
+        agent_name="agent",
+        response="<thought>Need a tool.</thought><final_answer>done</final_answer>",
+    )
+    await agent_events.emit_agent_thought_from_response(
+        event_router=event_router,
+        session_id="chat1",
+        agent_name="agent",
+        response="<final_answer>done</final_answer>",
+    )
+
+    assert len(emitted) == 1
+    assert emitted[0]["session_id"] == "chat1"
+    assert emitted[0]["event"].type == EventType.AGENT_THOUGHT
+    assert emitted[0]["event"].payload.message == "Need a tool."
+
+
+@pytest.mark.asyncio
+async def test_emit_user_agent_and_final_answer_events():
+    emitted = []
+
+    async def event_router(session_id, event):
+        emitted.append((session_id, event))
+
+    await agent_events.emit_user_message(
+        event_router=event_router,
+        session_id="chat1",
+        agent_name="agent",
+        message="hello",
+    )
+    await agent_events.emit_agent_message(
+        event_router=event_router,
+        session_id="chat1",
+        agent_name="agent",
+        message="working",
+    )
+    await agent_events.emit_final_answer(
+        event_router=event_router,
+        session_id="chat1",
+        agent_name="agent",
+        message="done",
+    )
+
+    assert [event.type for _, event in emitted] == [
+        EventType.USER_MESSAGE,
+        EventType.AGENT_MESSAGE,
+        EventType.FINAL_ANSWER,
+    ]
+    assert [event.payload.message for _, event in emitted] == [
+        "hello",
+        "working",
+        "done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emit_event_ignores_missing_router():
+    await agent_events.emit_user_message(
+        event_router=None,
+        session_id="chat1",
+        agent_name="agent",
+        message="hello",
+    )

--- a/tests/test_agent_session_state.py
+++ b/tests/test_agent_session_state.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from omnicoreagent.core.agents.session_state import AgentSessionStateStore
+from omnicoreagent.core.types import AgentState, Message
+
+
+def test_session_state_store_reuses_state_per_session_and_agent():
+    store = AgentSessionStateStore(agent_name="agent")
+
+    first = store.get(session_id="chat1", debug=False)
+    second = store.get(session_id="chat1", debug=True)
+    other = store.get(session_id="chat2", debug=False)
+
+    assert first is second
+    assert first is not other
+    assert ("chat1", "agent") in store.states
+
+
+def test_reset_for_run_clears_transient_loop_state():
+    store = AgentSessionStateStore(agent_name="agent")
+    state = store.get(session_id="chat1", debug=False)
+    state.messages = [Message(role="user", content="hello")]
+    state.assistant_with_tool_calls = Message(role="assistant", content="tool")
+    state.pending_tool_responses = [Message(role="tool", content="done")]
+
+    reset = store.reset_for_run(session_id="chat1", debug=False)
+
+    assert reset is state
+    assert reset.messages == []
+    assert reset.assistant_with_tool_calls is None
+    assert reset.pending_tool_responses == []
+
+
+@pytest.mark.asyncio
+async def test_state_context_restores_previous_state():
+    store = AgentSessionStateStore(agent_name="agent")
+    state = store.get(session_id="chat1", debug=False)
+    state.state = AgentState.IDLE
+
+    async with store.state_context(
+        new_state=AgentState.RUNNING, session_id="chat1", debug=False
+    ):
+        assert state.state == AgentState.RUNNING
+
+    assert state.state == AgentState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_state_context_marks_error_then_restores_previous_state():
+    store = AgentSessionStateStore(agent_name="agent")
+    state = store.get(session_id="chat1", debug=False)
+
+    with pytest.raises(RuntimeError):
+        async with store.state_context(
+            new_state=AgentState.RUNNING, session_id="chat1", debug=False
+        ):
+            raise RuntimeError("boom")
+
+    assert state.state == AgentState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_state_context_rejects_invalid_state():
+    store = AgentSessionStateStore(agent_name="agent")
+
+    with pytest.raises(ValueError, match="Invalid agent state"):
+        async with store.state_context(
+            new_state="running", session_id="chat1", debug=False
+        ):
+            pass

--- a/tests/test_initial_messages.py
+++ b/tests/test_initial_messages.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.agents.initial_messages import AgentInitialMessagePreparer
+from omnicoreagent.core.types import AgentState, SessionState
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+def make_session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+class PromptBuilder:
+    def __init__(self):
+        self.injected = False
+        self.calls = []
+
+    async def build_system_prompt(self, **kwargs):
+        self.calls.append(kwargs)
+        return f"{kwargs['base_system_prompt']}\n{kwargs['tools_section']}"
+
+    def inject_current_datetime(self, messages):
+        self.injected = True
+
+
+@pytest.mark.asyncio
+async def test_initial_message_preparer_loads_tools_history_and_system_prompt():
+    session_state = make_session_state()
+    prompt_builder = PromptBuilder()
+    history_loaded = False
+
+    async def render_prompt_registry(**kwargs):
+        assert kwargs["mcp_tools"] == {"server": []}
+        assert kwargs["local_tools"] == "registry"
+        return "tools section"
+
+    async def load(**kwargs):
+        nonlocal history_loaded
+        history_loaded = True
+        assert kwargs["session_id"] == "chat1"
+
+    preparer = AgentInitialMessagePreparer(
+        tool_runtime_registry=SimpleNamespace(
+            render_prompt_registry=render_prompt_registry
+        ),
+        message_history_loader=SimpleNamespace(load=load),
+        prompt_context_builder=prompt_builder,
+    )
+
+    await preparer.prepare(
+        session_state=session_state,
+        system_prompt="system",
+        session_id="chat1",
+        message_history=lambda: [],
+        mcp_tools={"server": []},
+        local_tools="registry",
+        sub_agents=["agent"],
+    )
+
+    assert history_loaded is True
+    assert prompt_builder.injected is True
+    assert session_state.messages[0].role == "system"
+    assert session_state.messages[0].content == "system\ntools section"
+    assert prompt_builder.calls[0]["sub_agents"] == ["agent"]
+
+
+@pytest.mark.asyncio
+async def test_initial_message_preparer_falls_back_when_tools_fail():
+    session_state = make_session_state()
+    prompt_builder = PromptBuilder()
+
+    async def render_prompt_registry(**kwargs):
+        raise RuntimeError("tool render failed")
+
+    async def load(**kwargs):
+        return None
+
+    preparer = AgentInitialMessagePreparer(
+        tool_runtime_registry=SimpleNamespace(
+            render_prompt_registry=render_prompt_registry
+        ),
+        message_history_loader=SimpleNamespace(load=load),
+        prompt_context_builder=prompt_builder,
+    )
+
+    await preparer.prepare(
+        session_state=session_state,
+        system_prompt="system",
+        session_id="chat1",
+        message_history=lambda: [],
+    )
+
+    assert session_state.messages[0].content == "system\nNo tools available"
+
+
+@pytest.mark.asyncio
+async def test_initial_message_preparer_times_out_to_defaults():
+    session_state = make_session_state()
+    prompt_builder = PromptBuilder()
+
+    async def render_prompt_registry(**kwargs):
+        await asyncio.sleep(0.05)
+        return "late tools"
+
+    async def load(**kwargs):
+        await asyncio.sleep(0.05)
+
+    preparer = AgentInitialMessagePreparer(
+        tool_runtime_registry=SimpleNamespace(
+            render_prompt_registry=render_prompt_registry
+        ),
+        message_history_loader=SimpleNamespace(load=load),
+        prompt_context_builder=prompt_builder,
+        timeout_seconds=0.001,
+    )
+
+    await preparer.prepare(
+        session_state=session_state,
+        system_prompt="system",
+        session_id="chat1",
+        message_history=lambda: [],
+    )
+
+    assert session_state.messages[0].content == "system\nNo tools available"

--- a/tests/test_llm_step.py
+++ b/tests/test_llm_step.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.agents import llm_step
+from omnicoreagent.core.agents.llm_step import AgentLlmStepRunner
+from omnicoreagent.core.token_usage import Usage, UsageLimits
+from omnicoreagent.core.types import AgentState, Message, SessionState
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+def make_session_state(messages=None):
+    return SessionState(
+        messages=messages or [Message(role="user", content="hello")],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+class NoContextManager:
+    def should_trigger(self, messages):
+        return False
+
+
+class TriggeringContextManager:
+    def should_trigger(self, messages):
+        return True
+
+    async def manage_context(self, *, messages, summarize_fn):
+        summary = await summarize_fn(messages)
+        return [Message(role="system", content=summary)]
+
+
+def make_runner(context_manager=None, *, limits_enabled=False, request_limit=0):
+    return AgentLlmStepRunner(
+        agent_name="agent",
+        context_manager=context_manager or NoContextManager(),
+        usage_limits=UsageLimits(
+            request_limit=request_limit,
+            total_tokens_limit=1000,
+        ),
+        limits_enabled=limits_enabled,
+        request_limit=request_limit,
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_step_calls_model_emits_message_and_records_usage(monkeypatch):
+    monkeypatch.setattr(llm_step, "usage", Usage())
+    emitted = []
+
+    async def event_router(session_id, event):
+        emitted.append({"session_id": session_id, "event": event})
+
+    class LlmConnection:
+        async def llm_call(self, messages):
+            return {
+                "choices": [{"message": {"content": "<final_answer>done</final_answer>"}}],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 4,
+                    "total_tokens": 7,
+                },
+            }
+
+    run_usage = Usage()
+    result = await make_runner().run(
+        session_state=make_session_state(),
+        llm_connection=LlmConnection(),
+        run_usage=run_usage,
+        session_id="chat1",
+        event_router=event_router,
+    )
+
+    assert result.response == "<final_answer>done</final_answer>"
+    assert result.error_result is None
+    assert run_usage.requests == 1
+    assert run_usage.total_tokens == 7
+    assert emitted[0]["session_id"] == "chat1"
+    assert emitted[0]["event"].payload.message == "<final_answer>done</final_answer>"
+
+
+@pytest.mark.asyncio
+async def test_llm_step_manages_context_before_model_call(monkeypatch):
+    monkeypatch.setattr(llm_step, "usage", Usage())
+    calls = []
+
+    class LlmConnection:
+        async def llm_call(self, messages):
+            calls.append(messages)
+            if isinstance(messages[0], dict):
+                return "summary"
+            return "<final_answer>done</final_answer>"
+
+    session_state = make_session_state()
+    result = await make_runner(TriggeringContextManager()).run(
+        session_state=session_state,
+        llm_connection=LlmConnection(),
+        run_usage=Usage(),
+        session_id="chat1",
+    )
+
+    assert result.response == "<final_answer>done</final_answer>"
+    assert session_state.messages == [Message(role="system", content="summary")]
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_llm_step_returns_usage_limit_error(monkeypatch):
+    monkeypatch.setattr(llm_step, "usage", Usage(requests=1))
+    runner = make_runner(limits_enabled=True, request_limit=1)
+
+    result = await runner.run(
+        session_state=make_session_state(),
+        llm_connection=SimpleNamespace(llm_call=None),
+        run_usage=Usage(),
+        session_id="chat1",
+    )
+
+    assert result.response is None
+    assert result.error_result["answer"].startswith("Usage limit error:")
+
+
+@pytest.mark.asyncio
+async def test_llm_step_returns_model_error(monkeypatch):
+    monkeypatch.setattr(llm_step, "usage", Usage())
+
+    class LlmConnection:
+        async def llm_call(self, messages):
+            raise RuntimeError("provider down")
+
+    result = await make_runner().run(
+        session_state=make_session_state(),
+        llm_connection=LlmConnection(),
+        run_usage=Usage(),
+        session_id="chat1",
+    )
+
+    assert result.response is None
+    assert result.error_result["answer"] == (
+        "Model encountered an error, please do retry again"
+    )
+    assert isinstance(result.error_result["usage"], Usage)


### PR DESCRIPTION
## Summary
- move ReAct loop event emission into focused agent event helpers
- move session state lifecycle into AgentSessionStateStore
- move initial message preparation into AgentInitialMessagePreparer
- move context-aware LLM call, usage accounting, and model error handling into AgentLlmStepRunner
- add focused tests for each extracted runtime helper

## Tests
- uv run ruff check src tests
- uv run pytest -q