### PR TITLE
Split React tool action boundaries

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -24,7 +24,6 @@ from omnicoreagent.core.tools.tool_failure_handler import ToolFailureHandler
 from omnicoreagent.core.tools.tool_runtime_registry import ToolRuntimeRegistry
 from omnicoreagent.core.utils import (
     logger,
-    show_tool_response,
     BackgroundTaskManager,
 )
 from omnicoreagent.core.events.base import Event
@@ -40,8 +39,10 @@ from omnicoreagent.core.agents.initial_messages import AgentInitialMessagePrepar
 from omnicoreagent.core.agents.llm_step import AgentLlmStepRunner
 from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
 from omnicoreagent.core.agents import events as agent_events
+from omnicoreagent.core.agents.run_outcome import AgentRunOutcomeHandler
 from omnicoreagent.core.agents.session_state import AgentSessionStateStore
 from omnicoreagent.core.agents.subagent_runner import SubAgentCallRunner
+from omnicoreagent.core.agents.tool_action import AgentToolActionRunner
 from omnicoreagent.core.tools.tool_observation import ToolObservationHandler
 from omnicoreagent.core.agents.xml_parser import (
     parse_action_or_answer,
@@ -125,6 +126,13 @@ class BaseReactAgent:
             agent_name=self.agent_name,
             tool_call_timeout=self.tool_call_timeout,
         )
+        self.tool_action_runner = AgentToolActionRunner(
+            agent_name=self.agent_name,
+            tool_call_resolver=self.tool_call_resolver,
+            tool_failure_handler=self.tool_failure_handler,
+            tool_batch_runner=self.tool_batch_runner,
+            tool_observation_handler=self.tool_observation_handler,
+        )
         self.tool_runtime_registry = ToolRuntimeRegistry(
             register_internal_tool=self.register_internal_tool,
             tool_offloader=self.tool_offloader,
@@ -147,6 +155,7 @@ class BaseReactAgent:
             message_history_loader=self.message_history_loader,
             prompt_context_builder=self.prompt_context_builder,
         )
+        self.run_outcome_handler = AgentRunOutcomeHandler(agent_name=self.agent_name)
 
     def init_skills(self):
         if self.enable_agent_skills:
@@ -207,84 +216,20 @@ class BaseReactAgent:
         event_router: Callable[[str, Event], Any] = None,
         sub_agents: list = None,
     ):
-        session_state = self._get_session_state(session_id=session_id, debug=debug)
-
-        tool_call_result = await self.resolve_tool_call_request(
+        await self.tool_action_runner.run(
             parsed_response=parsed_response,
-            mcp_tools=mcp_tools,
-            sessions=sessions,
-            local_tools=local_tools,
-            sub_agents=sub_agents,
-        )
-
-        tools_results = []
-        obs_text = None
-
-        if isinstance(tool_call_result, ToolError):
-            (
-                tool_batch_name,
-                tool_batch_args,
-                obs_text,
-                tools_results,
-            ) = await self.tool_failure_handler.handle_validation_error(
-                tool_error=tool_call_result,
-                session_state=session_state,
-                session_id=session_id,
-                event_router=event_router,
-            )
-        else:
-            tool_call_result = list(tool_call_result)
-            tool_batch_name, tool_batch_args = await self.tool_batch_runner.start(
-                tool_call_results=tool_call_result,
-                response=response,
-                session_state=session_state,
-                add_message_to_history=add_message_to_history,
-                session_id=session_id,
-                event_router=event_router,
-            )
-            obs_text, tools_results = await self.tool_batch_runner.execute(
-                tool_call_results=tool_call_result,
-                session_state=session_state,
-                add_message_to_history=add_message_to_history,
-                session_id=session_id,
-                event_router=event_router,
-                tool_batch_name=tool_batch_name,
-                tool_batch_args=tool_batch_args,
-                parse_tool_observation=self.tool_observation_handler.parse,
-                build_tool_results_observation=(
-                    self.tool_observation_handler.build_results_observation
-                ),
-            )
-
-        if debug:
-            show_tool_response(
-                agent_name=self.agent_name,
-                tool_name=tool_batch_name,
-                tool_args=tool_batch_args,
-                observation=obs_text,
-            )
-
-        await self.tool_observation_handler.append_observations(
-            tools_results=tools_results,
-            session_state=session_state,
+            response=response,
+            session_state=self._get_session_state(session_id=session_id, debug=debug),
             add_message_to_history=add_message_to_history,
-            session_id=session_id,
-            debug=debug,
-        )
-
-        if isinstance(tool_call_result, (list, tuple)):
-            tool_call_results = list(tool_call_result)
-        else:
-            tool_call_results = [tool_call_result]
-
-        await self.tool_failure_handler.handle_loop_state(
-            tool_call_results=tool_call_results,
-            session_state=session_state,
             system_prompt=system_prompt,
+            reset_system_prompt=self.reset_system_prompt,
+            debug=debug,
+            sessions=sessions,
+            mcp_tools=mcp_tools,
+            local_tools=local_tools,
             session_id=session_id,
             event_router=event_router,
-            debug=debug,
-            reset_system_prompt=self.reset_system_prompt,
+            sub_agents=sub_agents,
         )
 
     async def reset_system_prompt(self, messages: list, system_prompt: str):
@@ -447,30 +392,15 @@ class BaseReactAgent:
                     logger.info(f"current steps: {current_steps}")
                 if parsed_response.answer is not None:
                     last_valid_response = parsed_response.answer
-
-                    session_state.messages.append(
-                        Message(
-                            role="assistant",
-                            content=parsed_response.answer,
-                        )
-                    )
-
-                    await agent_events.emit_final_answer(
+                    return await self.run_outcome_handler.handle_final_answer(
+                        answer=parsed_response.answer,
+                        session_state=session_state,
+                        add_message_to_history=add_message_to_history,
+                        session_id=session_id,
                         event_router=event_router,
-                        session_id=session_id,
-                        agent_name=self.agent_name,
-                        message=str(parsed_response.answer),
+                        run_usage=run_usage,
+                        start_time=start_time,
                     )
-                    await add_message_to_history(
-                        role="assistant",
-                        content=parsed_response.answer,
-                        session_id=session_id,
-                        metadata={"agent_name": self.agent_name},
-                    )
-
-                    session_state.state = AgentState.FINISHED
-                    run_usage.total_time = time.perf_counter() - start_time
-                    return {"answer": parsed_response.answer, "usage": run_usage}
 
                 if parsed_response.action is not None:
                     if parsed_response.agent_calls is not None:
@@ -512,24 +442,16 @@ class BaseReactAgent:
                     continue
                 if current_steps >= self.max_steps:
                     session_state.state = AgentState.STUCK
-                    if last_valid_response:
-                        max_steps_context = f"[SYSTEM_CONTEXT: MAX_STEPS_REACHED - Agent hit {self.max_steps} step limit]\n\n"
-                        return {
-                            "answer": max_steps_context + last_valid_response,
-                            "usage": run_usage,
-                        }
-
-                    else:
-                        return {
-                            "answer": f"[SYSTEM_CONTEXT: MAX_STEPS_REACHED - Agent hit {self.max_steps} step limit without valid response]",
-                            "usage": run_usage,
-                        }
+                    return self.run_outcome_handler.max_steps_result(
+                        max_steps=self.max_steps,
+                        last_valid_response=last_valid_response,
+                        run_usage=run_usage,
+                    )
 
         if session_state.state == AgentState.STUCK and last_valid_response:
-            loop_context = (
-                "[SYSTEM_CONTEXT: LOOP_DETECTED - Agent stuck in tool call loop]\n\n"
+            return self.run_outcome_handler.loop_stuck_result(
+                last_valid_response=last_valid_response
             )
-            return loop_context + last_valid_response
 
         run_usage.total_time = time.perf_counter() - start_time
         return {"answer": last_valid_response, "usage": run_usage}

--- a/src/omnicoreagent/core/agents/run_outcome.py
+++ b/src/omnicoreagent/core/agents/run_outcome.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+from typing import Any
+
+from omnicoreagent.core.agents import events as agent_events
+from omnicoreagent.core.events.base import Event
+from omnicoreagent.core.token_usage import Usage
+from omnicoreagent.core.types import AgentState, Message, SessionState
+
+
+class AgentRunOutcomeHandler:
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    async def handle_final_answer(
+        self,
+        *,
+        answer: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str,
+        event_router: Callable[[str, Event], Any] | None,
+        run_usage: Usage,
+        start_time: float,
+    ) -> dict[str, Any]:
+        session_state.messages.append(Message(role="assistant", content=answer))
+        await agent_events.emit_final_answer(
+            event_router=event_router,
+            session_id=session_id,
+            agent_name=self.agent_name,
+            message=str(answer),
+        )
+        await add_message_to_history(
+            role="assistant",
+            content=answer,
+            session_id=session_id,
+            metadata={"agent_name": self.agent_name},
+        )
+
+        session_state.state = AgentState.FINISHED
+        run_usage.total_time = time.perf_counter() - start_time
+        return {"answer": answer, "usage": run_usage}
+
+    def max_steps_result(
+        self,
+        *,
+        max_steps: int,
+        last_valid_response: str | None,
+        run_usage: Usage,
+    ) -> dict[str, Any]:
+        if last_valid_response:
+            context = (
+                "[SYSTEM_CONTEXT: MAX_STEPS_REACHED - "
+                f"Agent hit {max_steps} step limit]\n\n"
+            )
+            return {"answer": context + last_valid_response, "usage": run_usage}
+
+        return {
+            "answer": (
+                "[SYSTEM_CONTEXT: MAX_STEPS_REACHED - "
+                f"Agent hit {max_steps} step limit without valid response]"
+            ),
+            "usage": run_usage,
+        }
+
+    def loop_stuck_result(self, last_valid_response: str | None) -> str | None:
+        if not last_valid_response:
+            return None
+
+        return (
+            "[SYSTEM_CONTEXT: LOOP_DETECTED - Agent stuck in tool call loop]\n\n"
+            + last_valid_response
+        )

--- a/src/omnicoreagent/core/agents/tool_action.py
+++ b/src/omnicoreagent/core/agents/tool_action.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from omnicoreagent.core.events.base import Event
+from omnicoreagent.core.types import ParsedResponse, SessionState, ToolCallResult, ToolError
+from omnicoreagent.core.utils import show_tool_response
+
+
+class AgentToolActionRunner:
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        tool_call_resolver: Any,
+        tool_failure_handler: Any,
+        tool_batch_runner: Any,
+        tool_observation_handler: Any,
+    ):
+        self.agent_name = agent_name
+        self.tool_call_resolver = tool_call_resolver
+        self.tool_failure_handler = tool_failure_handler
+        self.tool_batch_runner = tool_batch_runner
+        self.tool_observation_handler = tool_observation_handler
+
+    async def resolve_tool_call_request(
+        self,
+        *,
+        parsed_response: ParsedResponse,
+        sessions: dict | None,
+        mcp_tools: dict | None,
+        local_tools: Any = None,
+        sub_agents: list | None = None,
+    ) -> ToolError | list[ToolCallResult]:
+        return await self.tool_call_resolver.resolve(
+            parsed_response=parsed_response,
+            sessions=sessions,
+            mcp_tools=mcp_tools,
+            local_tools=local_tools,
+            sub_agents=sub_agents,
+        )
+
+    async def run(
+        self,
+        *,
+        parsed_response: ParsedResponse,
+        response: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        system_prompt: str,
+        reset_system_prompt: Callable[..., Any],
+        debug: bool = False,
+        sessions: dict | None = None,
+        mcp_tools: dict | None = None,
+        local_tools: Any = None,
+        session_id: str | None = None,
+        event_router: Callable[[str | None, Event], Any] | None = None,
+        sub_agents: list | None = None,
+    ):
+        tool_call_result = await self.resolve_tool_call_request(
+            parsed_response=parsed_response,
+            mcp_tools=mcp_tools,
+            sessions=sessions,
+            local_tools=local_tools,
+            sub_agents=sub_agents,
+        )
+
+        tool_batch_name, tool_batch_args, obs_text, tools_results = (
+            await self._execute_or_handle_error(
+                tool_call_result=tool_call_result,
+                response=response,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                event_router=event_router,
+            )
+        )
+
+        if debug:
+            show_tool_response(
+                agent_name=self.agent_name,
+                tool_name=tool_batch_name,
+                tool_args=tool_batch_args,
+                observation=obs_text,
+            )
+
+        await self.tool_observation_handler.append_observations(
+            tools_results=tools_results,
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
+            session_id=session_id,
+            debug=debug,
+        )
+
+        await self.tool_failure_handler.handle_loop_state(
+            tool_call_results=self._as_tool_call_results(tool_call_result),
+            session_state=session_state,
+            system_prompt=system_prompt,
+            session_id=session_id,
+            event_router=event_router,
+            debug=debug,
+            reset_system_prompt=reset_system_prompt,
+        )
+
+    async def _execute_or_handle_error(
+        self,
+        *,
+        tool_call_result: ToolError | list[ToolCallResult],
+        response: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        event_router: Callable[[str | None, Event], Any] | None,
+    ) -> tuple[str, list[dict[str, Any]], str | None, list[dict[str, Any]]]:
+        if isinstance(tool_call_result, ToolError):
+            return await self.tool_failure_handler.handle_validation_error(
+                tool_error=tool_call_result,
+                session_state=session_state,
+                session_id=session_id,
+                event_router=event_router,
+            )
+
+        tool_call_results = list(tool_call_result)
+        tool_batch_name, tool_batch_args = await self.tool_batch_runner.start(
+            tool_call_results=tool_call_results,
+            response=response,
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
+            session_id=session_id,
+            event_router=event_router,
+        )
+        obs_text, tools_results = await self.tool_batch_runner.execute(
+            tool_call_results=tool_call_results,
+            session_state=session_state,
+            add_message_to_history=add_message_to_history,
+            session_id=session_id,
+            event_router=event_router,
+            tool_batch_name=tool_batch_name,
+            tool_batch_args=tool_batch_args,
+            parse_tool_observation=self.tool_observation_handler.parse,
+            build_tool_results_observation=(
+                self.tool_observation_handler.build_results_observation
+            ),
+        )
+        return tool_batch_name, tool_batch_args, obs_text, tools_results
+
+    def _as_tool_call_results(
+        self, tool_call_result: ToolError | list[ToolCallResult]
+    ) -> list[Any]:
+        if isinstance(tool_call_result, (list, tuple)):
+            return list(tool_call_result)
+        return [tool_call_result]

--- a/tests/test_agent_tool_action.py
+++ b/tests/test_agent_tool_action.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.agents.tool_action import AgentToolActionRunner
+from omnicoreagent.core.types import AgentState, ParsedResponse, SessionState, ToolError
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+def make_session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.IDLE,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+class ObservationHandler:
+    def __init__(self):
+        self.appended = None
+
+    async def parse(self, observation):
+        return observation
+
+    def build_results_observation(
+        self, tool_call_results, tools_results, session_state, session_id
+    ):
+        return "observation text"
+
+    async def append_observations(self, **kwargs):
+        self.appended = kwargs
+
+
+class FailureHandler:
+    def __init__(self):
+        self.loop_state = None
+
+    async def handle_validation_error(self, **kwargs):
+        return (
+            "missing_tool",
+            [{"query": "x"}],
+            "missing tool",
+            [
+                {
+                    "tool_name": "missing_tool",
+                    "args": {"query": "x"},
+                    "status": "error",
+                    "data": None,
+                    "message": "missing tool",
+                }
+            ],
+        )
+
+    async def handle_loop_state(self, **kwargs):
+        self.loop_state = kwargs
+
+
+@pytest.mark.asyncio
+async def test_tool_action_runner_handles_validation_error():
+    observation_handler = ObservationHandler()
+    failure_handler = FailureHandler()
+
+    async def resolve(**kwargs):
+        return ToolError(
+            observation="missing tool",
+            tool_name="missing_tool",
+            tool_args={"query": "x"},
+        )
+
+    runner = AgentToolActionRunner(
+        agent_name="agent",
+        tool_call_resolver=SimpleNamespace(resolve=resolve),
+        tool_failure_handler=failure_handler,
+        tool_batch_runner=SimpleNamespace(),
+        tool_observation_handler=observation_handler,
+    )
+
+    async def add_message_to_history(**kwargs):
+        raise AssertionError("Validation errors do not write tool history directly")
+
+    await runner.run(
+        parsed_response=ParsedResponse(action=True),
+        response="<tool_call />",
+        session_state=make_session_state(),
+        add_message_to_history=add_message_to_history,
+        system_prompt="system",
+        reset_system_prompt=lambda **kwargs: [],
+        session_id="chat1",
+    )
+
+    assert observation_handler.appended["tools_results"][0]["tool_name"] == "missing_tool"
+    assert failure_handler.loop_state["tool_call_results"][0].tool_name == "missing_tool"
+
+
+@pytest.mark.asyncio
+async def test_tool_action_runner_executes_resolved_tool_batch():
+    observation_handler = ObservationHandler()
+    failure_handler = FailureHandler()
+    calls = []
+    tool_call_result = SimpleNamespace(tool_name="search", tool_args={"q": "x"})
+
+    async def resolve(**kwargs):
+        calls.append(("resolve", kwargs))
+        return [tool_call_result]
+
+    async def start(**kwargs):
+        calls.append(("start", kwargs))
+        return "search", [{"q": "x"}]
+
+    async def execute(**kwargs):
+        calls.append(("execute", kwargs))
+        assert kwargs["parse_tool_observation"] == observation_handler.parse
+        assert kwargs["build_tool_results_observation"] == (
+            observation_handler.build_results_observation
+        )
+        return "observation text", [{"tool_name": "search", "status": "success"}]
+
+    runner = AgentToolActionRunner(
+        agent_name="agent",
+        tool_call_resolver=SimpleNamespace(resolve=resolve),
+        tool_failure_handler=failure_handler,
+        tool_batch_runner=SimpleNamespace(start=start, execute=execute),
+        tool_observation_handler=observation_handler,
+    )
+
+    async def add_message_to_history(**kwargs):
+        calls.append(("history", kwargs))
+
+    await runner.run(
+        parsed_response=ParsedResponse(action=True),
+        response="<tool_call />",
+        session_state=make_session_state(),
+        add_message_to_history=add_message_to_history,
+        system_prompt="system",
+        reset_system_prompt=lambda **kwargs: [],
+        session_id="chat1",
+        local_tools="registry",
+    )
+
+    assert [name for name, _ in calls] == ["resolve", "start", "execute"]
+    assert observation_handler.appended["tools_results"] == [
+        {"tool_name": "search", "status": "success"}
+    ]
+    assert failure_handler.loop_state["tool_call_results"] == [tool_call_result]

--- a/tests/test_run_outcome.py
+++ b/tests/test_run_outcome.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from omnicoreagent.core.agents.run_outcome import AgentRunOutcomeHandler
+from omnicoreagent.core.events.base import EventType
+from omnicoreagent.core.token_usage import Usage
+from omnicoreagent.core.types import AgentState, SessionState
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+def make_session_state():
+    return SessionState(
+        messages=[],
+        state=AgentState.RUNNING,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_final_answer_updates_state_history_event_and_usage():
+    handler = AgentRunOutcomeHandler(agent_name="agent")
+    session_state = make_session_state()
+    history = []
+    events = []
+    run_usage = Usage()
+
+    async def add_message_to_history(**kwargs):
+        history.append(kwargs)
+
+    async def event_router(session_id, event):
+        events.append({"session_id": session_id, "event": event})
+
+    result = await handler.handle_final_answer(
+        answer="done",
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat1",
+        event_router=event_router,
+        run_usage=run_usage,
+        start_time=0,
+    )
+
+    assert result["answer"] == "done"
+    assert result["usage"] is run_usage
+    assert run_usage.total_time > 0
+    assert session_state.state == AgentState.FINISHED
+    assert session_state.messages[-1].content == "done"
+    assert history == [
+        {
+            "role": "assistant",
+            "content": "done",
+            "session_id": "chat1",
+            "metadata": {"agent_name": "agent"},
+        }
+    ]
+    assert events[0]["event"].type == EventType.FINAL_ANSWER
+    assert events[0]["event"].payload.message == "done"
+
+
+def test_max_steps_result_preserves_last_valid_response():
+    run_usage = Usage()
+    result = AgentRunOutcomeHandler("agent").max_steps_result(
+        max_steps=5,
+        last_valid_response="partial",
+        run_usage=run_usage,
+    )
+
+    assert "MAX_STEPS_REACHED" in result["answer"]
+    assert result["answer"].endswith("partial")
+    assert result["usage"] is run_usage
+
+
+def test_max_steps_result_handles_no_valid_response():
+    result = AgentRunOutcomeHandler("agent").max_steps_result(
+        max_steps=5,
+        last_valid_response=None,
+        run_usage=Usage(),
+    )
+
+    assert "without valid response" in result["answer"]
+
+
+def test_loop_stuck_result_requires_last_valid_response():
+    handler = AgentRunOutcomeHandler("agent")
+
+    assert handler.loop_stuck_result(None) is None
+    assert handler.loop_stuck_result("partial").endswith("partial")


### PR DESCRIPTION
## Summary
- move ReAct tool-action orchestration out of BaseReactAgent into AgentToolActionRunner
- move final-answer, max-step, and stuck-loop response handling into AgentRunOutcomeHandler
- keep BaseReactAgent as the high-level loop coordinator and reduce its size to 457 lines
- add focused tests for tool action execution/error flow and run outcome handling

## Tests
- uv run ruff check src tests
- uv run pytest -q