### PR TITLE
Extract React loop step handling

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -37,6 +37,7 @@ from omnicoreagent.core.tool_response_offloader import (
 )
 from omnicoreagent.core.agents.initial_messages import AgentInitialMessagePreparer
 from omnicoreagent.core.agents.llm_step import AgentLlmStepRunner
+from omnicoreagent.core.agents.loop_step import AgentLoopStepHandler
 from omnicoreagent.core.agents.message_history import AgentMessageHistoryLoader
 from omnicoreagent.core.agents import events as agent_events
 from omnicoreagent.core.agents.run_outcome import AgentRunOutcomeHandler
@@ -156,6 +157,14 @@ class BaseReactAgent:
             prompt_context_builder=self.prompt_context_builder,
         )
         self.run_outcome_handler = AgentRunOutcomeHandler(agent_name=self.agent_name)
+        self.loop_step_handler = AgentLoopStepHandler(
+            agent_name=self.agent_name,
+            max_steps=self.max_steps,
+            run_outcome_handler=self.run_outcome_handler,
+            tool_action_runner=self.tool_action_runner,
+            subagent_runner=self.subagent_runner,
+            reset_system_prompt=self.reset_system_prompt,
+        )
 
     def init_skills(self):
         if self.enable_agent_skills:
@@ -388,65 +397,27 @@ class BaseReactAgent:
                     session_id=session_id,
                     event_router=event_router,
                 )
-                if debug:
-                    logger.info(f"current steps: {current_steps}")
-                if parsed_response.answer is not None:
-                    last_valid_response = parsed_response.answer
-                    return await self.run_outcome_handler.handle_final_answer(
-                        answer=parsed_response.answer,
-                        session_state=session_state,
-                        add_message_to_history=add_message_to_history,
-                        session_id=session_id,
-                        event_router=event_router,
-                        run_usage=run_usage,
-                        start_time=start_time,
-                    )
-
-                if parsed_response.action is not None:
-                    if parsed_response.agent_calls is not None:
-                        agent_calls = parsed_response.data
-
-                        await self.execute_sub_agent_calls(
-                            response=response,
-                            agent_calls=agent_calls,
-                            sub_agents=sub_agents,
-                            session_id=session_id,
-                            session_state=session_state,
-                            add_message_to_history=add_message_to_history,
-                            run_usage=run_usage,
-                            event_router=event_router,
-                            debug=debug,
-                        )
-                    else:
-                        await self.act(
-                            parsed_response=parsed_response,
-                            response=response,
-                            add_message_to_history=add_message_to_history,
-                            system_prompt=system_prompt,
-                            mcp_tools=mcp_tools,
-                            debug=debug,
-                            sessions=sessions,
-                            local_tools=runtime_local_tools,
-                            session_id=session_id,
-                            event_router=event_router,
-                            sub_agents=sub_agents,
-                        )
-
-                if parsed_response.error is not None:
-                    session_state.messages.append(
-                        Message(
-                            role="user",
-                            content=parsed_response.error,
-                        )
-                    )
-                    continue
-                if current_steps >= self.max_steps:
-                    session_state.state = AgentState.STUCK
-                    return self.run_outcome_handler.max_steps_result(
-                        max_steps=self.max_steps,
-                        last_valid_response=last_valid_response,
-                        run_usage=run_usage,
-                    )
+                step_result = await self.loop_step_handler.handle(
+                    parsed_response=parsed_response,
+                    response=response,
+                    session_state=session_state,
+                    add_message_to_history=add_message_to_history,
+                    system_prompt=system_prompt,
+                    session_id=session_id,
+                    run_usage=run_usage,
+                    start_time=start_time,
+                    current_steps=current_steps,
+                    last_valid_response=last_valid_response,
+                    debug=debug,
+                    sessions=sessions,
+                    mcp_tools=mcp_tools,
+                    local_tools=runtime_local_tools,
+                    event_router=event_router,
+                    sub_agents=sub_agents,
+                )
+                last_valid_response = step_result.last_valid_response
+                if step_result.should_return:
+                    return step_result.run_result
 
         if session_state.state == AgentState.STUCK and last_valid_response:
             return self.run_outcome_handler.loop_stuck_result(

--- a/src/omnicoreagent/core/agents/loop_step.py
+++ b/src/omnicoreagent/core/agents/loop_step.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from omnicoreagent.core.events.base import Event
+from omnicoreagent.core.token_usage import Usage
+from omnicoreagent.core.types import AgentState, Message, ParsedResponse, SessionState
+from omnicoreagent.core.utils import logger
+
+
+@dataclass
+class AgentLoopStepResult:
+    run_result: Any = None
+    last_valid_response: str | None = None
+
+    @property
+    def should_return(self) -> bool:
+        return self.run_result is not None
+
+
+class AgentLoopStepHandler:
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        max_steps: int,
+        run_outcome_handler: Any,
+        tool_action_runner: Any,
+        subagent_runner: Any,
+        reset_system_prompt: Callable[..., Any],
+    ):
+        self.agent_name = agent_name
+        self.max_steps = max_steps
+        self.run_outcome_handler = run_outcome_handler
+        self.tool_action_runner = tool_action_runner
+        self.subagent_runner = subagent_runner
+        self.reset_system_prompt = reset_system_prompt
+
+    async def handle(
+        self,
+        *,
+        parsed_response: ParsedResponse,
+        response: str,
+        session_state: SessionState,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        system_prompt: str,
+        session_id: str,
+        run_usage: Usage,
+        start_time: float,
+        current_steps: int,
+        last_valid_response: str | None,
+        debug: bool = False,
+        sessions: dict | None = None,
+        mcp_tools: dict | None = None,
+        local_tools: Any = None,
+        event_router: Callable[[str, Event], Any] | None = None,
+        sub_agents: list | None = None,
+    ) -> AgentLoopStepResult:
+        if debug:
+            logger.info(f"current steps: {current_steps}")
+
+        if parsed_response.answer is not None:
+            last_valid_response = parsed_response.answer
+            return AgentLoopStepResult(
+                run_result=await self.run_outcome_handler.handle_final_answer(
+                    answer=parsed_response.answer,
+                    session_state=session_state,
+                    add_message_to_history=add_message_to_history,
+                    session_id=session_id,
+                    event_router=event_router,
+                    run_usage=run_usage,
+                    start_time=start_time,
+                ),
+                last_valid_response=last_valid_response,
+            )
+
+        if parsed_response.action is not None:
+            if parsed_response.agent_calls is not None:
+                await self.subagent_runner.execute(
+                    response=response,
+                    agent_calls=parsed_response.data,
+                    sub_agents=sub_agents,
+                    session_id=session_id,
+                    session_state=session_state,
+                    add_message_to_history=add_message_to_history,
+                    run_usage=run_usage,
+                    event_router=event_router,
+                    debug=debug,
+                )
+            else:
+                await self.tool_action_runner.run(
+                    parsed_response=parsed_response,
+                    response=response,
+                    session_state=session_state,
+                    add_message_to_history=add_message_to_history,
+                    system_prompt=system_prompt,
+                    reset_system_prompt=self.reset_system_prompt,
+                    debug=debug,
+                    sessions=sessions,
+                    mcp_tools=mcp_tools,
+                    local_tools=local_tools,
+                    session_id=session_id,
+                    event_router=event_router,
+                    sub_agents=sub_agents,
+                )
+
+        if parsed_response.error is not None:
+            session_state.messages.append(
+                Message(role="user", content=parsed_response.error)
+            )
+            return AgentLoopStepResult(last_valid_response=last_valid_response)
+
+        if current_steps >= self.max_steps:
+            session_state.state = AgentState.STUCK
+            return AgentLoopStepResult(
+                run_result=self.run_outcome_handler.max_steps_result(
+                    max_steps=self.max_steps,
+                    last_valid_response=last_valid_response,
+                    run_usage=run_usage,
+                ),
+                last_valid_response=last_valid_response,
+            )
+
+        return AgentLoopStepResult(last_valid_response=last_valid_response)

--- a/tests/test_loop_step.py
+++ b/tests/test_loop_step.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from omnicoreagent.core.agents.loop_step import AgentLoopStepHandler
+from omnicoreagent.core.token_usage import Usage
+from omnicoreagent.core.types import AgentState, ParsedResponse, SessionState
+from omnicoreagent.core.utils import RobustLoopDetector
+
+
+def make_session_state() -> SessionState:
+    return SessionState(
+        messages=[],
+        state=AgentState.RUNNING,
+        loop_detector=RobustLoopDetector(debug=False),
+        assistant_with_tool_calls=None,
+        pending_tool_responses=[],
+    )
+
+
+class OutcomeHandler:
+    def __init__(self):
+        self.final_answer_kwargs = None
+        self.max_steps_kwargs = None
+
+    async def handle_final_answer(self, **kwargs):
+        self.final_answer_kwargs = kwargs
+        return {"answer": kwargs["answer"], "usage": kwargs["run_usage"]}
+
+    def max_steps_result(self, **kwargs):
+        self.max_steps_kwargs = kwargs
+        return {"answer": "MAX_STEPS_REACHED", "usage": kwargs["run_usage"]}
+
+
+class ToolActionRunner:
+    def __init__(self):
+        self.kwargs = None
+
+    async def run(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class SubAgentRunner:
+    def __init__(self):
+        self.kwargs = None
+
+    async def execute(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def make_handler(
+    *,
+    outcome_handler: OutcomeHandler | None = None,
+    tool_action_runner: ToolActionRunner | None = None,
+    subagent_runner: SubAgentRunner | None = None,
+    max_steps: int = 5,
+) -> AgentLoopStepHandler:
+    return AgentLoopStepHandler(
+        agent_name="agent",
+        max_steps=max_steps,
+        run_outcome_handler=outcome_handler or OutcomeHandler(),
+        tool_action_runner=tool_action_runner or ToolActionRunner(),
+        subagent_runner=subagent_runner or SubAgentRunner(),
+        reset_system_prompt=lambda messages, system_prompt: messages,
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_step_handles_final_answer():
+    outcome_handler = OutcomeHandler()
+    handler = make_handler(outcome_handler=outcome_handler)
+    run_usage = Usage()
+
+    result = await handler.handle(
+        parsed_response=ParsedResponse(answer="done"),
+        response="<final_answer>done</final_answer>",
+        session_state=make_session_state(),
+        add_message_to_history=SimpleNamespace(),
+        system_prompt="system",
+        session_id="chat1",
+        run_usage=run_usage,
+        start_time=1.0,
+        current_steps=1,
+        last_valid_response=None,
+    )
+
+    assert result.should_return is True
+    assert result.run_result == {"answer": "done", "usage": run_usage}
+    assert result.last_valid_response == "done"
+    assert outcome_handler.final_answer_kwargs["answer"] == "done"
+    assert outcome_handler.final_answer_kwargs["session_id"] == "chat1"
+
+
+@pytest.mark.asyncio
+async def test_loop_step_dispatches_subagent_calls():
+    subagent_runner = SubAgentRunner()
+    handler = make_handler(subagent_runner=subagent_runner)
+    agent_calls = [{"name": "worker", "task": "check docs"}]
+    run_usage = Usage()
+    session_state = make_session_state()
+
+    result = await handler.handle(
+        parsed_response=ParsedResponse(
+            action=True,
+            agent_calls=True,
+            data=agent_calls,
+        ),
+        response="<agent_calls />",
+        session_state=session_state,
+        add_message_to_history=SimpleNamespace(),
+        system_prompt="system",
+        session_id="chat1",
+        run_usage=run_usage,
+        start_time=1.0,
+        current_steps=1,
+        last_valid_response="previous",
+        sub_agents=["worker"],
+    )
+
+    assert result.should_return is False
+    assert result.last_valid_response == "previous"
+    assert subagent_runner.kwargs["agent_calls"] == agent_calls
+    assert subagent_runner.kwargs["sub_agents"] == ["worker"]
+    assert subagent_runner.kwargs["session_state"] is session_state
+    assert subagent_runner.kwargs["run_usage"] is run_usage
+
+
+@pytest.mark.asyncio
+async def test_loop_step_dispatches_tool_action():
+    tool_action_runner = ToolActionRunner()
+    handler = make_handler(tool_action_runner=tool_action_runner)
+    parsed_response = ParsedResponse(
+        action=True,
+        tool_calls=True,
+        data='[{"tool": "search", "parameters": {"query": "runtime"}}]',
+    )
+    session_state = make_session_state()
+
+    result = await handler.handle(
+        parsed_response=parsed_response,
+        response="<tool_calls />",
+        session_state=session_state,
+        add_message_to_history=SimpleNamespace(),
+        system_prompt="system",
+        session_id="chat1",
+        run_usage=Usage(),
+        start_time=1.0,
+        current_steps=1,
+        last_valid_response=None,
+        sessions={"server": "session"},
+        mcp_tools={"server": [{"name": "search"}]},
+        local_tools="registry",
+        event_router=SimpleNamespace(),
+        sub_agents=["worker"],
+    )
+
+    assert result.should_return is False
+    assert tool_action_runner.kwargs["parsed_response"] is parsed_response
+    assert tool_action_runner.kwargs["session_state"] is session_state
+    assert tool_action_runner.kwargs["local_tools"] == "registry"
+    assert tool_action_runner.kwargs["mcp_tools"] == {"server": [{"name": "search"}]}
+    assert tool_action_runner.kwargs["sub_agents"] == ["worker"]
+
+
+@pytest.mark.asyncio
+async def test_loop_step_appends_parser_error():
+    handler = make_handler()
+    session_state = make_session_state()
+
+    result = await handler.handle(
+        parsed_response=ParsedResponse(error="Response must use XML format."),
+        response="plain text",
+        session_state=session_state,
+        add_message_to_history=SimpleNamespace(),
+        system_prompt="system",
+        session_id="chat1",
+        run_usage=Usage(),
+        start_time=1.0,
+        current_steps=1,
+        last_valid_response="previous",
+    )
+
+    assert result.should_return is False
+    assert result.last_valid_response == "previous"
+    assert session_state.messages[-1].role == "user"
+    assert session_state.messages[-1].content == "Response must use XML format."
+
+
+@pytest.mark.asyncio
+async def test_loop_step_returns_max_steps_result():
+    outcome_handler = OutcomeHandler()
+    handler = make_handler(outcome_handler=outcome_handler, max_steps=2)
+    run_usage = Usage()
+    session_state = make_session_state()
+
+    result = await handler.handle(
+        parsed_response=ParsedResponse(action=True, tool_calls=True, data="[]"),
+        response="<tool_calls />",
+        session_state=session_state,
+        add_message_to_history=SimpleNamespace(),
+        system_prompt="system",
+        session_id="chat1",
+        run_usage=run_usage,
+        start_time=1.0,
+        current_steps=2,
+        last_valid_response="partial",
+    )
+
+    assert result.should_return is True
+    assert result.run_result == {"answer": "MAX_STEPS_REACHED", "usage": run_usage}
+    assert result.last_valid_response == "partial"
+    assert session_state.state == AgentState.STUCK
+    assert outcome_handler.max_steps_kwargs == {
+        "max_steps": 2,
+        "last_valid_response": "partial",
+        "run_usage": run_usage,
+    }


### PR DESCRIPTION
## Summary
- move parsed-response dispatch out of BaseReactAgent.run into AgentLoopStepHandler
- keep BaseReactAgent focused on high-level ReAct loop orchestration
- add unit coverage for final answers, tool actions, sub-agent actions, parser errors, and max-step results

## Tests
- uv run ruff check src tests
- uv run pytest -q