### PR TITLE
Split runtime construction boundaries

### DIFF
--- a/src/omnicoreagent/core/runtime/agent_runtime.py
+++ b/src/omnicoreagent/core/runtime/agent_runtime.py
@@ -1,303 +1,59 @@
 from __future__ import annotations
 
-from importlib import import_module
-from typing import Any
+from omnicoreagent.core.runtime.construction import (
+    build_agent_settings,
+    build_guardrail,
+    configure_memory_router,
+    create_llm_runtime,
+    create_react_agent,
+    default_event_router,
+    default_memory_router,
+)
+from omnicoreagent.core.runtime.harness_tools import (
+    available_tools,
+    index_tools_for_advanced_use,
+    prepare_dynamic_subagents,
+)
+from omnicoreagent.core.runtime.imports import (
+    LazyDefaultPromptBuilder,
+    runtime,
+    runtime_logger,
+)
+from omnicoreagent.core.runtime.normalization import (
+    build_agent_config,
+    build_mcp_tools,
+    build_model_config,
+    normalize_local_tools,
+)
+from omnicoreagent.core.runtime.summaries import (
+    extract_summary_text,
+    render_history,
+    summary_instruction,
+)
+
+__all__ = [
+    "LazyDefaultPromptBuilder",
+    "available_tools",
+    "build_agent_config",
+    "build_agent_settings",
+    "build_guardrail",
+    "build_mcp_tools",
+    "build_model_config",
+    "configure_memory_router",
+    "create_llm_runtime",
+    "create_react_agent",
+    "default_event_router",
+    "default_memory_router",
+    "extract_summary_text",
+    "index_tools_for_advanced_use",
+    "normalize_local_tools",
+    "prepare_dynamic_subagents",
+    "render_history",
+    "runtime",
+    "runtime_logger",
+    "summary_instruction",
+]
 
 
-_RUNTIME_EXPORTS = {
-    "AdvanceToolsUse": (
-        "omnicoreagent.core.tools.advance_tools.advanced_tools_use",
-        "AdvanceToolsUse",
-    ),
-    "AgentConfig": ("omnicoreagent.core.runtime.config", "AgentConfig"),
-    "DetectionConfig": ("omnicoreagent.core.guardrails", "DetectionConfig"),
-    "EventRouter": ("omnicoreagent.core.events.event_router", "EventRouter"),
-    "FAST_CONVERSATION_SUMMARY_PROMPT": (
-        "omnicoreagent.core.system_prompts",
-        "FAST_CONVERSATION_SUMMARY_PROMPT",
-    ),
-    "LLMConnection": ("omnicoreagent.core.llm", "LLMConnection"),
-    "MemoryRouter": ("omnicoreagent.core.memory_store.memory_router", "MemoryRouter"),
-    "OmniCoreAgentPromptBuilder": (
-        "omnicoreagent.core.system_prompts",
-        "OmniCoreAgentPromptBuilder",
-    ),
-    "PromptInjectionGuard": ("omnicoreagent.core.guardrails", "PromptInjectionGuard"),
-    "REACT_AGENT_PROMPT": ("omnicoreagent.core.system_prompts", "REACT_AGENT_PROMPT"),
-    "ReactAgent": ("omnicoreagent.core.agents.react_agent", "ReactAgent"),
-    "SubagentFactory": ("omnicoreagent.core.subagents", "SubagentFactory"),
-    "Usage": ("omnicoreagent.core.token_usage", "Usage"),
-    "build_subagent_tools": ("omnicoreagent.core.subagents", "build_subagent_tools"),
-    "logger": ("omnicoreagent.core.utils", "logger"),
-    "normalize_agent_config": (
-        "omnicoreagent.core.runtime.config",
-        "normalize_agent_config",
-    ),
-    "normalize_mcp_tools": (
-        "omnicoreagent.core.runtime.config",
-        "normalize_mcp_tools",
-    ),
-    "normalize_model_config": (
-        "omnicoreagent.core.runtime.config",
-        "normalize_model_config",
-    ),
-}
-
-
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str):
     return runtime(name)
-
-
-def runtime(name: str) -> Any:
-    if name in globals():
-        return globals()[name]
-    if name not in _RUNTIME_EXPORTS:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-    module_name, attr_name = _RUNTIME_EXPORTS[name]
-    value = getattr(import_module(module_name), attr_name)
-    globals()[name] = value
-    return value
-
-
-def runtime_logger() -> Any:
-    return runtime("logger")
-
-
-class LazyDefaultPromptBuilder:
-    def __init__(self):
-        self._builder = None
-
-    def _load(self):
-        if self._builder is None:
-            self._builder = runtime("OmniCoreAgentPromptBuilder")(
-                runtime("REACT_AGENT_PROMPT")
-            )
-        return self._builder
-
-    def build(self, *, system_instruction: str) -> str:
-        return self._load().build(system_instruction=system_instruction)
-
-
-def build_model_config(model_config: Any) -> dict[str, Any]:
-    return runtime("normalize_model_config")(model_config)
-
-
-def build_mcp_tools(mcp_tools: list[Any] | None) -> list[dict[str, Any]]:
-    return runtime("normalize_mcp_tools")(mcp_tools)
-
-
-def build_agent_config(name: str, agent_config: Any = None) -> dict[str, Any]:
-    return runtime("normalize_agent_config")(name, agent_config)
-
-
-def normalize_local_tools(local_tools: Any) -> Any:
-    if not isinstance(local_tools, list):
-        return local_tools
-
-    from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
-
-    registry = ToolRegistry()
-    for tool in local_tools:
-        registry.register(tool)
-    return registry
-
-
-def default_memory_router() -> Any:
-    return runtime("MemoryRouter")(memory_store_type="in_memory")
-
-
-def default_event_router() -> Any:
-    return runtime("EventRouter")(event_store_type="in_memory")
-
-
-def build_guardrail(agent_name: str, agent_config: dict[str, Any]) -> tuple[str, Any]:
-    guardrail_mode = agent_config.get("guardrail_mode", "full")
-    if guardrail_mode == "off":
-        runtime_logger().info(f"Guardrail disabled for agent '{agent_name}'")
-        return guardrail_mode, None
-
-    guardrail_config = agent_config.get("guardrail_config", {})
-    detection_config = runtime("DetectionConfig")(**guardrail_config)
-    guardrail = runtime("PromptInjectionGuard")(detection_config)
-    runtime_logger().info(
-        f"Guardrail enabled for agent '{agent_name}' (mode: {guardrail_mode})"
-    )
-    return guardrail_mode, guardrail
-
-
-def create_llm_runtime(
-    *,
-    mcp_tools: list[dict[str, Any]],
-    model_config: dict[str, Any],
-    debug: bool,
-) -> tuple[Any, Any]:
-    if not mcp_tools:
-        llm_connection = runtime("LLMConnection")(
-            model_config=model_config,
-            api_key=model_config.get("api_key"),
-        )
-        return None, llm_connection
-
-    from omnicoreagent.mcp_clients_connection.client import MCPClient
-
-    mcp_client = MCPClient(
-        servers=mcp_tools,
-        model_config=model_config,
-        api_key=model_config.get("api_key"),
-        debug=debug,
-    )
-    return mcp_client, mcp_client.llm_connection
-
-
-def build_agent_settings(agent_config: dict[str, Any]) -> Any:
-    return runtime("AgentConfig")(**agent_config)
-
-
-def configure_memory_router(
-    *,
-    memory_router: Any,
-    agent_settings: Any,
-    summarize_fn: Any,
-):
-    if not memory_router:
-        return
-
-    summary_config = agent_settings.memory_config.get("summary")
-    memory_router.set_memory_config(
-        mode=agent_settings.memory_config["mode"],
-        value=agent_settings.memory_config["value"],
-        summary_config=summary_config,
-        summarize_fn=summarize_fn
-        if summary_config and summary_config.get("enabled")
-        else None,
-    )
-
-
-def create_react_agent(
-    *,
-    agent_settings: Any,
-    guardrail: Any,
-    guardrail_mode: str,
-) -> Any:
-    tool_guardrail = guardrail if guardrail_mode == "full" else None
-    return runtime("ReactAgent")(config=agent_settings, guardrail=tool_guardrail)
-
-
-def prepare_dynamic_subagents(
-    *,
-    enabled: bool,
-    existing_factory: Any,
-    base_model_config: dict[str, Any],
-    mcp_tools: list[dict[str, Any]],
-    local_tools: Any,
-    agent_config: dict[str, Any],
-    prompt_builder: Any,
-    event_router: Any,
-    memory_router: Any,
-    debug: bool,
-) -> tuple[Any, Any]:
-    if not enabled:
-        return existing_factory, local_tools
-    if existing_factory is not None:
-        return existing_factory, local_tools
-
-    from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
-
-    if local_tools is None:
-        local_tools = ToolRegistry()
-
-    factory = runtime("SubagentFactory")(
-        base_model_config=base_model_config,
-        mcp_tools=mcp_tools,
-        local_tools=local_tools,
-        agent_config=agent_config,
-        prompt_builder=prompt_builder,
-        event_router=event_router,
-        memory_router=memory_router,
-        debug=debug,
-    )
-    runtime("build_subagent_tools")(factory, local_tools)
-    return factory, local_tools
-
-
-def index_tools_for_advanced_use(
-    *,
-    enabled: bool,
-    mcp_tools: dict[str, Any] | None = None,
-    local_tools: Any = None,
-):
-    if not enabled:
-        return
-
-    runtime("AdvanceToolsUse")().load_and_process_tools(
-        mcp_tools=mcp_tools,
-        local_tools=local_tools,
-    )
-
-
-def summary_instruction(max_tokens: int | None = None) -> str:
-    instruction = runtime("FAST_CONVERSATION_SUMMARY_PROMPT")
-    if max_tokens:
-        instruction += f" Keep the summary roughly under {max_tokens} tokens."
-    return instruction
-
-
-def render_history(messages: list[dict[str, Any]]) -> str:
-    return "".join(
-        f"{message.get('role', 'unknown')}: {message.get('content', '')}\n"
-        for message in messages
-    )
-
-
-def extract_summary_text(response: Any) -> str:
-    if not response:
-        return ""
-
-    if hasattr(response, "choices") and response.choices:
-        return response.choices[0].message.content.strip()
-    if hasattr(response, "message"):
-        return response.message.content.strip()
-    if hasattr(response, "text"):
-        return response.text.strip()
-    if hasattr(response, "content"):
-        return response.content.strip()
-    if isinstance(response, dict) and "choices" in response:
-        return response["choices"][0]["message"]["content"].strip()
-    if isinstance(response, str):
-        return response
-
-    runtime_logger().error(
-        f"No valid response content found in LLM response: {type(response)}"
-    )
-    return ""
-
-
-def available_tools(mcp_client: Any, local_tools: Any) -> list[dict[str, Any]]:
-    tools: list[dict[str, Any]] = []
-
-    if mcp_client:
-        for server_tools in mcp_client.available_tools.values():
-            tools.extend(_available_mcp_tool(tool) for tool in server_tools)
-
-    if local_tools:
-        tools.extend(local_tools.get_available_tools())
-
-    return tools
-
-
-def _available_mcp_tool(tool: Any) -> dict[str, Any]:
-    if isinstance(tool, dict):
-        return {
-            "name": tool.get("name", ""),
-            "description": tool.get("description", ""),
-            "inputSchema": tool.get("inputSchema", {}),
-            "type": "mcp",
-        }
-
-    return {
-        "name": tool.name,
-        "description": tool.description,
-        "inputSchema": tool.inputSchema,
-        "type": "mcp",
-    }

--- a/src/omnicoreagent/core/runtime/construction.py
+++ b/src/omnicoreagent/core/runtime/construction.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.core.runtime.imports import runtime, runtime_logger
+
+
+def default_memory_router() -> Any:
+    return runtime("MemoryRouter")(memory_store_type="in_memory")
+
+
+def default_event_router() -> Any:
+    return runtime("EventRouter")(event_store_type="in_memory")
+
+
+def build_guardrail(agent_name: str, agent_config: dict[str, Any]) -> tuple[str, Any]:
+    guardrail_mode = agent_config.get("guardrail_mode", "full")
+    if guardrail_mode == "off":
+        runtime_logger().info(f"Guardrail disabled for agent '{agent_name}'")
+        return guardrail_mode, None
+
+    guardrail_config = agent_config.get("guardrail_config", {})
+    detection_config = runtime("DetectionConfig")(**guardrail_config)
+    guardrail = runtime("PromptInjectionGuard")(detection_config)
+    runtime_logger().info(
+        f"Guardrail enabled for agent '{agent_name}' (mode: {guardrail_mode})"
+    )
+    return guardrail_mode, guardrail
+
+
+def create_llm_runtime(
+    *,
+    mcp_tools: list[dict[str, Any]],
+    model_config: dict[str, Any],
+    debug: bool,
+) -> tuple[Any, Any]:
+    if not mcp_tools:
+        llm_connection = runtime("LLMConnection")(
+            model_config=model_config,
+            api_key=model_config.get("api_key"),
+        )
+        return None, llm_connection
+
+    from omnicoreagent.mcp_clients_connection.client import MCPClient
+
+    mcp_client = MCPClient(
+        servers=mcp_tools,
+        model_config=model_config,
+        api_key=model_config.get("api_key"),
+        debug=debug,
+    )
+    return mcp_client, mcp_client.llm_connection
+
+
+def build_agent_settings(agent_config: dict[str, Any]) -> Any:
+    return runtime("AgentConfig")(**agent_config)
+
+
+def configure_memory_router(
+    *,
+    memory_router: Any,
+    agent_settings: Any,
+    summarize_fn: Any,
+):
+    if not memory_router:
+        return
+
+    summary_config = agent_settings.memory_config.get("summary")
+    memory_router.set_memory_config(
+        mode=agent_settings.memory_config["mode"],
+        value=agent_settings.memory_config["value"],
+        summary_config=summary_config,
+        summarize_fn=summarize_fn
+        if summary_config and summary_config.get("enabled")
+        else None,
+    )
+
+
+def create_react_agent(
+    *,
+    agent_settings: Any,
+    guardrail: Any,
+    guardrail_mode: str,
+) -> Any:
+    tool_guardrail = guardrail if guardrail_mode == "full" else None
+    return runtime("ReactAgent")(config=agent_settings, guardrail=tool_guardrail)

--- a/src/omnicoreagent/core/runtime/harness_tools.py
+++ b/src/omnicoreagent/core/runtime/harness_tools.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.core.runtime.imports import runtime
+
+
+def prepare_dynamic_subagents(
+    *,
+    enabled: bool,
+    existing_factory: Any,
+    base_model_config: dict[str, Any],
+    mcp_tools: list[dict[str, Any]],
+    local_tools: Any,
+    agent_config: dict[str, Any],
+    prompt_builder: Any,
+    event_router: Any,
+    memory_router: Any,
+    debug: bool,
+) -> tuple[Any, Any]:
+    if not enabled:
+        return existing_factory, local_tools
+    if existing_factory is not None:
+        return existing_factory, local_tools
+
+    from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+
+    if local_tools is None:
+        local_tools = ToolRegistry()
+
+    factory = runtime("SubagentFactory")(
+        base_model_config=base_model_config,
+        mcp_tools=mcp_tools,
+        local_tools=local_tools,
+        agent_config=agent_config,
+        prompt_builder=prompt_builder,
+        event_router=event_router,
+        memory_router=memory_router,
+        debug=debug,
+    )
+    runtime("build_subagent_tools")(factory, local_tools)
+    return factory, local_tools
+
+
+def index_tools_for_advanced_use(
+    *,
+    enabled: bool,
+    mcp_tools: dict[str, Any] | None = None,
+    local_tools: Any = None,
+):
+    if not enabled:
+        return
+
+    runtime("AdvanceToolsUse")().load_and_process_tools(
+        mcp_tools=mcp_tools,
+        local_tools=local_tools,
+    )
+
+
+def available_tools(mcp_client: Any, local_tools: Any) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+
+    if mcp_client:
+        for server_tools in mcp_client.available_tools.values():
+            tools.extend(_available_mcp_tool(tool) for tool in server_tools)
+
+    if local_tools:
+        tools.extend(local_tools.get_available_tools())
+
+    return tools
+
+
+def _available_mcp_tool(tool: Any) -> dict[str, Any]:
+    if isinstance(tool, dict):
+        return {
+            "name": tool.get("name", ""),
+            "description": tool.get("description", ""),
+            "inputSchema": tool.get("inputSchema", {}),
+            "type": "mcp",
+        }
+
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "inputSchema": tool.inputSchema,
+        "type": "mcp",
+    }

--- a/src/omnicoreagent/core/runtime/imports.py
+++ b/src/omnicoreagent/core/runtime/imports.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+_RUNTIME_EXPORTS = {
+    "AdvanceToolsUse": (
+        "omnicoreagent.core.tools.advance_tools.advanced_tools_use",
+        "AdvanceToolsUse",
+    ),
+    "AgentConfig": ("omnicoreagent.core.runtime.config", "AgentConfig"),
+    "DetectionConfig": ("omnicoreagent.core.guardrails", "DetectionConfig"),
+    "EventRouter": ("omnicoreagent.core.events.event_router", "EventRouter"),
+    "FAST_CONVERSATION_SUMMARY_PROMPT": (
+        "omnicoreagent.core.system_prompts",
+        "FAST_CONVERSATION_SUMMARY_PROMPT",
+    ),
+    "LLMConnection": ("omnicoreagent.core.llm", "LLMConnection"),
+    "MemoryRouter": ("omnicoreagent.core.memory_store.memory_router", "MemoryRouter"),
+    "OmniCoreAgentPromptBuilder": (
+        "omnicoreagent.core.system_prompts",
+        "OmniCoreAgentPromptBuilder",
+    ),
+    "PromptInjectionGuard": ("omnicoreagent.core.guardrails", "PromptInjectionGuard"),
+    "REACT_AGENT_PROMPT": ("omnicoreagent.core.system_prompts", "REACT_AGENT_PROMPT"),
+    "ReactAgent": ("omnicoreagent.core.agents.react_agent", "ReactAgent"),
+    "SubagentFactory": ("omnicoreagent.core.subagents", "SubagentFactory"),
+    "Usage": ("omnicoreagent.core.token_usage", "Usage"),
+    "build_subagent_tools": ("omnicoreagent.core.subagents", "build_subagent_tools"),
+    "logger": ("omnicoreagent.core.utils", "logger"),
+    "normalize_agent_config": (
+        "omnicoreagent.core.runtime.config",
+        "normalize_agent_config",
+    ),
+    "normalize_mcp_tools": (
+        "omnicoreagent.core.runtime.config",
+        "normalize_mcp_tools",
+    ),
+    "normalize_model_config": (
+        "omnicoreagent.core.runtime.config",
+        "normalize_model_config",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return runtime(name)
+
+
+def runtime(name: str) -> Any:
+    if name in globals():
+        return globals()[name]
+    if name not in _RUNTIME_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attr_name = _RUNTIME_EXPORTS[name]
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value
+
+
+def runtime_logger() -> Any:
+    return runtime("logger")
+
+
+class LazyDefaultPromptBuilder:
+    def __init__(self):
+        self._builder = None
+
+    def _load(self):
+        if self._builder is None:
+            self._builder = runtime("OmniCoreAgentPromptBuilder")(
+                runtime("REACT_AGENT_PROMPT")
+            )
+        return self._builder
+
+    def build(self, *, system_instruction: str) -> str:
+        return self._load().build(system_instruction=system_instruction)

--- a/src/omnicoreagent/core/runtime/normalization.py
+++ b/src/omnicoreagent/core/runtime/normalization.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.core.runtime.imports import runtime
+
+
+def build_model_config(model_config: Any) -> dict[str, Any]:
+    return runtime("normalize_model_config")(model_config)
+
+
+def build_mcp_tools(mcp_tools: list[Any] | None) -> list[dict[str, Any]]:
+    return runtime("normalize_mcp_tools")(mcp_tools)
+
+
+def build_agent_config(name: str, agent_config: Any = None) -> dict[str, Any]:
+    return runtime("normalize_agent_config")(name, agent_config)
+
+
+def normalize_local_tools(local_tools: Any) -> Any:
+    if not isinstance(local_tools, list):
+        return local_tools
+
+    from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    for tool in local_tools:
+        registry.register(tool)
+    return registry

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict, List, Optional
 
-from omnicoreagent.core.runtime import agent_runtime
+from omnicoreagent.core.runtime import construction, harness_tools, normalization, summaries
+from omnicoreagent.core.runtime.imports import (
+    LazyDefaultPromptBuilder,
+    runtime,
+    runtime_logger,
+)
 
 
 class OmniCoreAgent:
@@ -46,12 +51,12 @@ class OmniCoreAgent:
         """
         self.name = name
         self.system_instruction = system_instruction
-        self.model_config = agent_runtime.build_model_config(model_config)
-        self.mcp_tools = agent_runtime.build_mcp_tools(mcp_tools)
-        self.local_tools = agent_runtime.normalize_local_tools(local_tools)
+        self.model_config = normalization.build_model_config(model_config)
+        self.mcp_tools = normalization.build_mcp_tools(mcp_tools)
+        self.local_tools = normalization.normalize_local_tools(local_tools)
 
         self.sub_agents = sub_agents
-        self.agent_config = agent_runtime.build_agent_config(name, agent_config)
+        self.agent_config = normalization.build_agent_config(name, agent_config)
 
         self.debug = debug
         self._cumulative_usage = None
@@ -61,7 +66,7 @@ class OmniCoreAgent:
         if prompt_builder:
             self.prompt_builder = prompt_builder
         else:
-            self.prompt_builder = agent_runtime.LazyDefaultPromptBuilder()
+            self.prompt_builder = LazyDefaultPromptBuilder()
         self.agent = None
         self.mcp_client = None
         self.llm_connection = None
@@ -77,13 +82,13 @@ class OmniCoreAgent:
             return
 
         if not self.memory_router:
-            self.memory_router = agent_runtime.default_memory_router()
+            self.memory_router = construction.default_memory_router()
 
         if not self.event_router:
-            self.event_router = agent_runtime.default_event_router()
+            self.event_router = construction.default_event_router()
 
         agent_cfg = self.agent_config
-        self.guardrail_mode, self.guardrail = agent_runtime.build_guardrail(
+        self.guardrail_mode, self.guardrail = construction.build_guardrail(
             self.name, agent_cfg
         )
 
@@ -92,27 +97,27 @@ class OmniCoreAgent:
 
     def _create_agent(self):
         """Create the appropriate agent based on configuration"""
-        self.mcp_client, self.llm_connection = agent_runtime.create_llm_runtime(
+        self.mcp_client, self.llm_connection = construction.create_llm_runtime(
             mcp_tools=self.mcp_tools,
             model_config=self.model_config,
             debug=self.debug,
         )
 
-        agent_settings = agent_runtime.build_agent_settings(self.agent_config)
-        agent_runtime.configure_memory_router(
+        agent_settings = construction.build_agent_settings(self.agent_config)
+        construction.configure_memory_router(
             memory_router=self.memory_router,
             agent_settings=agent_settings,
             summarize_fn=self._summarize_history,
         )
 
-        self.agent = agent_runtime.create_react_agent(
+        self.agent = construction.create_react_agent(
             agent_settings=agent_settings,
             guardrail=self.guardrail,
             guardrail_mode=self.guardrail_mode,
         )
         self._prepare_dynamic_subagents()
         if self.local_tools:
-            agent_runtime.index_tools_for_advanced_use(
+            harness_tools.index_tools_for_advanced_use(
                 enabled=self.agent.enable_advanced_tool_use,
                 local_tools=self.local_tools,
             )
@@ -120,7 +125,7 @@ class OmniCoreAgent:
     def _prepare_dynamic_subagents(self):
         """Register dynamic subagent spawning tools when enabled."""
         self._subagent_factory, self.local_tools = (
-            agent_runtime.prepare_dynamic_subagents(
+            harness_tools.prepare_dynamic_subagents(
                 enabled=self.agent_config.get("enable_subagents", False),
                 existing_factory=self._subagent_factory,
                 base_model_config=self.model_config,
@@ -148,13 +153,13 @@ class OmniCoreAgent:
             String summary of the messages
         """
         if not self.llm_connection:
-            agent_runtime.runtime_logger().warning(
+            runtime_logger().warning(
                 "No LLM connection available for summarization"
             )
             return ""
 
-        instruction = agent_runtime.summary_instruction(max_tokens)
-        history_text = agent_runtime.render_history(messages)
+        instruction = summaries.summary_instruction(max_tokens)
+        history_text = summaries.render_history(messages)
 
         prompt_messages = [
             {
@@ -169,9 +174,9 @@ class OmniCoreAgent:
 
         try:
             response = await self.llm_connection.llm_call(messages=prompt_messages)
-            return agent_runtime.extract_summary_text(response)
+            return summaries.extract_summary_text(response)
         except Exception as e:
-            agent_runtime.runtime_logger().error(f"Summarization callback failed: {e}")
+            runtime_logger().error(f"Summarization callback failed: {e}")
             return ""
 
     def generate_session_id(self) -> str:
@@ -185,7 +190,7 @@ class OmniCoreAgent:
 
         if self.mcp_client and self.mcp_tools:
             await self.mcp_client.connect_to_servers()
-            agent_runtime.index_tools_for_advanced_use(
+            harness_tools.index_tools_for_advanced_use(
                 enabled=self.agent.enable_advanced_tool_use,
                 mcp_tools=self.mcp_client.available_tools if self.mcp_client else {},
                 local_tools=self.local_tools,
@@ -208,7 +213,7 @@ class OmniCoreAgent:
         if self.guardrail:
             result = self.guardrail.check(query)
             if not result.is_safe:
-                agent_runtime.runtime_logger().warning(
+                runtime_logger().warning(
                     f"Query blocked by guardrail: {result.message}"
                 )
                 return {
@@ -279,7 +284,7 @@ class OmniCoreAgent:
 
     def _usage(self):
         if self._cumulative_usage is None:
-            self._cumulative_usage = agent_runtime.runtime("Usage")()
+            self._cumulative_usage = runtime("Usage")()
         return self._cumulative_usage
 
     async def list_all_available_tools(self):
@@ -287,7 +292,7 @@ class OmniCoreAgent:
         if not self._initialized:
             await self.initialize()
 
-        return agent_runtime.available_tools(self.mcp_client, self.local_tools)
+        return harness_tools.available_tools(self.mcp_client, self.local_tools)
 
     async def get_session_history(self, session_id: str) -> List[Dict[str, Any]]:
         """Get session history for a specific session ID"""

--- a/src/omnicoreagent/core/runtime/summaries.py
+++ b/src/omnicoreagent/core/runtime/summaries.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.core.runtime.imports import runtime, runtime_logger
+
+
+def summary_instruction(max_tokens: int | None = None) -> str:
+    instruction = runtime("FAST_CONVERSATION_SUMMARY_PROMPT")
+    if max_tokens:
+        instruction += f" Keep the summary roughly under {max_tokens} tokens."
+    return instruction
+
+
+def render_history(messages: list[dict[str, Any]]) -> str:
+    return "".join(
+        f"{message.get('role', 'unknown')}: {message.get('content', '')}\n"
+        for message in messages
+    )
+
+
+def extract_summary_text(response: Any) -> str:
+    if not response:
+        return ""
+
+    if hasattr(response, "choices") and response.choices:
+        return response.choices[0].message.content.strip()
+    if hasattr(response, "message"):
+        return response.message.content.strip()
+    if hasattr(response, "text"):
+        return response.text.strip()
+    if hasattr(response, "content"):
+        return response.content.strip()
+    if isinstance(response, dict) and "choices" in response:
+        return response["choices"][0]["message"]["content"].strip()
+    if isinstance(response, str):
+        return response
+
+    runtime_logger().error(
+        f"No valid response content found in LLM response: {type(response)}"
+    )
+    return ""

--- a/tests/test_guardrail_default_mode.py
+++ b/tests/test_guardrail_default_mode.py
@@ -59,8 +59,8 @@ class TestGuardrailModeDefault:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             # Prevent _create_agent from executing real logic while still
             # allowing guardrail assignment to happen beforehand.
@@ -78,8 +78,8 @@ class TestGuardrailModeDefault:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -104,8 +104,8 @@ class TestGuardrailModeFullExplicit:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -121,8 +121,8 @@ class TestGuardrailModeFullExplicit:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -144,13 +144,13 @@ class TestGuardrailModeFullExplicit:
             return m
 
         with (
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
             patch(
-                "omnicoreagent.core.runtime.agent_runtime.LLMConnection", return_value=MagicMock()
+                "omnicoreagent.core.runtime.imports.LLMConnection", return_value=MagicMock()
             ),
             patch(
-                "omnicoreagent.core.runtime.agent_runtime.ReactAgent",
+                "omnicoreagent.core.runtime.imports.ReactAgent",
                 side_effect=capture_react_agent_construction,
             ),
         ):
@@ -177,8 +177,8 @@ class TestGuardrailModeInputOnly:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -194,8 +194,8 @@ class TestGuardrailModeInputOnly:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -219,13 +219,13 @@ class TestGuardrailModeInputOnly:
             return m
 
         with (
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
             patch(
-                "omnicoreagent.core.runtime.agent_runtime.LLMConnection", return_value=MagicMock()
+                "omnicoreagent.core.runtime.imports.LLMConnection", return_value=MagicMock()
             ),
             patch(
-                "omnicoreagent.core.runtime.agent_runtime.ReactAgent",
+                "omnicoreagent.core.runtime.imports.ReactAgent",
                 side_effect=capture_react_agent_construction,
             ),
         ):
@@ -252,8 +252,8 @@ class TestGuardrailModeOff:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -269,8 +269,8 @@ class TestGuardrailModeOff:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
             await agent.initialize()
@@ -292,13 +292,13 @@ class TestGuardrailModeOff:
             return m
 
         with (
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
             patch(
-                "omnicoreagent.core.runtime.agent_runtime.LLMConnection", return_value=MagicMock()
+                "omnicoreagent.core.runtime.imports.LLMConnection", return_value=MagicMock()
             ),
             patch(
-                "omnicoreagent.core.runtime.agent_runtime.ReactAgent",
+                "omnicoreagent.core.runtime.imports.ReactAgent",
                 side_effect=capture_react_agent_construction,
             ),
         ):
@@ -340,8 +340,8 @@ class TestCustomGuardrailConfig:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
             patch.object(DetectionConfig, "__init__", capturing_init),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react)
@@ -374,8 +374,8 @@ class TestCustomGuardrailConfig:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
             patch.object(DetectionConfig, "__init__", capturing_init),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react)
@@ -402,8 +402,8 @@ class TestCustomGuardrailConfig:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
             patch.object(DetectionConfig, "__init__", capturing_init),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react_agent)
@@ -575,8 +575,8 @@ class TestInitializeIdempotency:
 
         with (
             patch.object(agent, "_create_agent") as mock_create,
-            patch("omnicoreagent.core.runtime.agent_runtime.MemoryRouter"),
-            patch("omnicoreagent.core.runtime.agent_runtime.EventRouter"),
+            patch("omnicoreagent.core.runtime.imports.MemoryRouter"),
+            patch("omnicoreagent.core.runtime.imports.EventRouter"),
         ):
             mock_create.side_effect = lambda: setattr(agent, "agent", mock_react)
             await agent.initialize()


### PR DESCRIPTION
## Summary
- split runtime construction helpers out of the old agent_runtime utility module
- keep agent_runtime as a thin facade while OmniCoreAgent uses focused runtime modules directly
- separate lazy imports, config normalization, construction, harness tool wiring, and summary helpers
- update guardrail construction tests to patch the new lazy runtime import seam

## Tests
- uv run ruff check src tests
- uv run pytest -q
- uv run pytest tests/test_agent_runtime.py tests/test_import_startup.py tests/test_guardrail_default_mode.py tests/test_subagents.py tests/test_react_agent.py -q