### PR TITLE
Modernize OmniServe Pydantic config

### DIFF
--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -25,8 +25,8 @@ Priority: Environment variables ALWAYS override code values.
 """
 
 import os
-from typing import List, Optional
-from pydantic import BaseModel, Field, model_validator
+from typing import Optional
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 def _get_env(key: str) -> Optional[str]:
@@ -54,7 +54,7 @@ def _get_env_int(key: str) -> Optional[int]:
         return None
 
 
-def _get_env_list(key: str) -> Optional[List[str]]:
+def _get_env_list(key: str) -> Optional[list[str]]:
     """Get list from comma-separated environment variable. Returns None if not set."""
     val = _get_env(key)
     if val is None:
@@ -82,9 +82,17 @@ class OmniServeConfig(BaseModel):
 
     # CORS settings
     cors_enabled: bool = Field(default=True, description="Enable CORS middleware")
-    cors_origins: List[str] = Field(default=["*"], description="Allowed CORS origins")
-    cors_methods: List[str] = Field(default=["*"], description="Allowed CORS methods")
-    cors_headers: List[str] = Field(default=["*"], description="Allowed CORS headers")
+    model_config = ConfigDict(extra="allow")
+
+    cors_origins: list[str] = Field(
+        default_factory=lambda: ["*"], description="Allowed CORS origins"
+    )
+    cors_methods: list[str] = Field(
+        default_factory=lambda: ["*"], description="Allowed CORS methods"
+    )
+    cors_headers: list[str] = Field(
+        default_factory=lambda: ["*"], description="Allowed CORS headers"
+    )
     cors_credentials: bool = Field(default=True, description="Allow credentials in CORS")
 
     # Authentication
@@ -102,10 +110,6 @@ class OmniServeConfig(BaseModel):
     rate_limit_enabled: bool = Field(default=False, description="Enable rate limiting")
     rate_limit_requests: int = Field(default=100, description="Max requests per time window")
     rate_limit_window: int = Field(default=60, description="Rate limit time window in seconds")
-
-    class Config:
-        """Pydantic config."""
-        extra = "allow"
 
     @model_validator(mode="after")
     def apply_env_overrides(self) -> "OmniServeConfig":

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -4,8 +4,8 @@ OmniServe Request/Response Models.
 Pydantic models for API request/response schemas.
 """
 
-from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field
+from typing import Any, Optional
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # =============================================================================
@@ -41,7 +41,7 @@ class RunResponse(BaseModel):
     response: str = Field(..., description="Agent's response")
     session_id: str = Field(..., description="Session ID for this conversation")
     agent_name: str = Field(..., description="Name of the agent")
-    metric: Optional[Dict[str, Any]] = Field(
+    metric: Optional[dict[str, Any]] = Field(
         None, description="Optional metrics for this run"
     )
 
@@ -71,21 +71,18 @@ class ToolInfo(BaseModel):
 
     name: str = Field(..., description="Tool name")
     description: str = Field(..., description="Tool description")
-    input_schema: Dict[str, Any] = Field(
+    model_config = ConfigDict(populate_by_name=True)
+
+    input_schema: dict[str, Any] = Field(
         default_factory=dict, alias="inputSchema", description="Tool input schema"
     )
     type: str = Field(..., description="Tool type ('mcp' or 'local')")
-
-    class Config:
-        """Pydantic config."""
-
-        populate_by_name = True
 
 
 class ToolsResponse(BaseModel):
     """Response model for tools listing endpoint."""
 
-    tools: List[ToolInfo] = Field(..., description="List of available tools")
+    tools: list[ToolInfo] = Field(..., description="List of available tools")
     total: int = Field(..., description="Total number of tools")
 
 
@@ -104,7 +101,7 @@ class SessionHistoryResponse(BaseModel):
     """Response model for session history endpoint."""
 
     session_id: str = Field(..., description="Session ID")
-    messages: List[Dict[str, Any]] = Field(..., description="Message history")
+    messages: list[dict[str, Any]] = Field(..., description="Message history")
     count: int = Field(..., description="Number of messages")
 
 
@@ -112,7 +109,7 @@ class EventsResponse(BaseModel):
     """Response model for events endpoint."""
 
     session_id: str = Field(..., description="Session ID")
-    events: List[Dict[str, Any]] = Field(..., description="Events list")
+    events: list[dict[str, Any]] = Field(..., description="Events list")
     count: int = Field(..., description="Number of events")
 
 
@@ -120,8 +117,8 @@ class TraceResponse(BaseModel):
     """Response model for session trace endpoint."""
 
     session_id: str = Field(..., description="Session ID")
-    summary: Dict[str, Any] = Field(..., description="Trace summary")
-    steps: List[Dict[str, Any]] = Field(..., description="Ordered trace steps")
+    summary: dict[str, Any] = Field(..., description="Trace summary")
+    steps: list[dict[str, Any]] = Field(..., description="Ordered trace steps")
 
 
 class ErrorResponse(BaseModel):


### PR DESCRIPTION
## Summary
- replace deprecated Pydantic class Config blocks with ConfigDict
- update OmniServe schema typing to modern built-in collection annotations
- avoid mutable list defaults for CORS config
- remove the Pydantic deprecation warnings exposed by the latest dependency upgrade

## Tests
- uv run ruff check src tests
- uv run pytest -q
- uv run pytest tests/test_omniserve_full.py -q
- uv run python -W error::DeprecationWarning - <<'PY'
from omnicoreagent.serve.config import OmniServeConfig
from omnicoreagent.serve.models import ToolInfo
config = OmniServeConfig()
tool = ToolInfo(name='x', description='d', inputSchema={'type': 'object'}, type='local')
print(config.port, tool.input_schema)
PY