### PR TITLE
Centralize workspace storage config

### DIFF
--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -51,6 +51,7 @@ from omnicoreagent.core.agents.xml_parser import (
 
 if TYPE_CHECKING:
     from omnicoreagent.core.guardrails import PromptInjectionGuard
+    from omnicoreagent.core.workspace_config import WorkspaceConfig
 
 class BaseReactAgent:
     """Autonomous agent implementing the ReAct paradigm for task solving through iterative reasoning and tool usage."""
@@ -68,6 +69,7 @@ class BaseReactAgent:
         enable_agent_skills: bool = False,
         context_management_config: dict = None,
         tool_offload_config: dict = None,
+        workspace_config: WorkspaceConfig | dict | None = None,
         guardrail: PromptInjectionGuard | None = None,
     ):
         self.agent_name = agent_name
@@ -109,7 +111,8 @@ class BaseReactAgent:
         )
 
         self.tool_offloader = ToolResponseOffloader(
-            config=OffloadConfig.from_dict(tool_offload_config or {})
+            config=OffloadConfig.from_dict(tool_offload_config or {}),
+            workspace_config=workspace_config,
         )
         self.guardrail = guardrail
         self.tool_observation_handler = ToolObservationHandler(
@@ -142,6 +145,7 @@ class BaseReactAgent:
             enable_workspace_memory=self.enable_workspace_memory,
             enable_agent_skills=self.enable_agent_skills,
             skill_manager=self.skill_manager,
+            workspace_config=workspace_config,
         )
         self.prompt_context_builder = AgentPromptContextBuilder(
             enable_advanced_tool_use=self.enable_advanced_tool_use,

--- a/src/omnicoreagent/core/agents/react_agent.py
+++ b/src/omnicoreagent/core/agents/react_agent.py
@@ -25,5 +25,6 @@ class ReactAgent(BaseReactAgent):
             enable_agent_skills=config.enable_agent_skills,
             context_management_config=config.context_management,
             tool_offload_config=getattr(config, "tool_offload", None),
+            workspace_config=config.workspace_config,
             guardrail=guardrail,
         )

--- a/src/omnicoreagent/core/runtime/config.py
+++ b/src/omnicoreagent/core/runtime/config.py
@@ -5,6 +5,11 @@ from enum import Enum
 from typing import Any
 import uuid
 
+from omnicoreagent.core.workspace_config import (
+    WorkspaceConfig,
+    resolve_workspace_config,
+)
+
 
 SUPPORTED_MODELS_PROVIDERS = {
     "openai": "openai",
@@ -110,6 +115,7 @@ class AgentConfig:
         default_factory=_default_context_management
     )
     tool_offload: dict[str, Any] = field(default_factory=_default_tool_offload)
+    workspace_config: WorkspaceConfig | dict[str, Any] | None = None
 
     def __post_init__(self):
         self.request_limit = 0 if self.request_limit is None else self.request_limit
@@ -122,6 +128,8 @@ class AgentConfig:
             _default_context_management(), self.context_management
         )
         self.tool_offload = _merge_defaults(_default_tool_offload(), self.tool_offload)
+        if self.workspace_config is not None:
+            self.workspace_config = resolve_workspace_config(self.workspace_config)
 
         _validate_range("max_steps", self.max_steps, minimum=1, maximum=1000)
         _validate_range(

--- a/src/omnicoreagent/core/tool_response_offloader.py
+++ b/src/omnicoreagent/core/tool_response_offloader.py
@@ -22,6 +22,7 @@ from omnicoreagent.core.summarizer.tokenizer import count_tokens
 from omnicoreagent.core.utils import logger
 
 if TYPE_CHECKING:
+    from omnicoreagent.core.workspace_config import WorkspaceConfig
     from omnicoreagent.core.workspace_storage import WorkspaceStorage
 
 
@@ -102,12 +103,14 @@ class ToolResponseOffloader:
         config: OffloadConfig | dict = None,
         base_dir: str = None,
         storage: WorkspaceStorage | None = None,
+        workspace_config: WorkspaceConfig | dict | None = None,
     ):
         if isinstance(config, dict):
             config = OffloadConfig.from_dict(config)
         self.config = config or OffloadConfig()
         self._base_dir = base_dir
         self._storage = storage
+        self._workspace_config = workspace_config
 
         if self.config.enabled:
             self._ensure_storage_dir()
@@ -126,6 +129,7 @@ class ToolResponseOffloader:
             self._storage = create_workspace_storage(
                 namespace="artifacts",
                 workspace_dir=self._base_dir,
+                config=self._workspace_config,
             )
         return self._storage
 

--- a/src/omnicoreagent/core/tools/memory_tool/factory.py
+++ b/src/omnicoreagent/core/tools/memory_tool/factory.py
@@ -1,10 +1,13 @@
-import os
 from threading import Lock
 
 from omnicoreagent.core.tools.memory_tool.base import AbstractMemoryBackend
 from omnicoreagent.core.tools.memory_tool.storage import WorkspaceMemoryBackend
 
 from omnicoreagent.core.utils import logger
+from omnicoreagent.core.workspace_config import (
+    WorkspaceConfig,
+    resolve_workspace_config,
+)
 from omnicoreagent.core.workspace_storage import create_workspace_storage
 
 _backend_cache: dict = {}
@@ -14,6 +17,7 @@ _cache_lock = Lock()
 def create_memory_backend(
     *,
     use_cache: bool = True,
+    workspace_config: WorkspaceConfig | dict | None = None,
 ) -> AbstractMemoryBackend:
     """
     Create the workspace memory backend from the active workspace storage.
@@ -24,7 +28,8 @@ def create_memory_backend(
     Returns:
         Configured backend instance.
     """
-    cache_key = _backend_cache_key()
+    config = resolve_workspace_config(workspace_config)
+    cache_key = config.cache_key(namespace="memories")
 
     # Check cache first
     if use_cache:
@@ -34,45 +39,15 @@ def create_memory_backend(
                 return _backend_cache[cache_key]
 
     # Create new backend
-    storage = create_workspace_storage(namespace="memories")
+    storage = create_workspace_storage(namespace="memories", config=config)
     backend = _create_backend_instance(storage)
 
     # Cache it
     if use_cache:
         with _cache_lock:
             _backend_cache[cache_key] = backend
-    
+
     return backend
-
-
-def _backend_cache_key() -> tuple:
-    workspace_backend = os.environ.get("OMNICOREAGENT_WORKSPACE_BACKEND", "local")
-    workspace_backend = workspace_backend.lower().strip()
-    prefix = os.environ.get("OMNICOREAGENT_WORKSPACE_PREFIX", "workspace").strip("/")
-
-    if workspace_backend == "local":
-        from omnicoreagent.core.workspace import get_memories_dir
-
-        return (workspace_backend, get_memories_dir())
-
-    if workspace_backend == "s3":
-        return (
-            workspace_backend,
-            os.environ.get("AWS_S3_BUCKET"),
-            os.environ.get("AWS_REGION"),
-            os.environ.get("AWS_ENDPOINT_URL"),
-            prefix,
-        )
-
-    if workspace_backend == "r2":
-        return (
-            workspace_backend,
-            os.environ.get("R2_BUCKET_NAME"),
-            os.environ.get("R2_ACCOUNT_ID"),
-            prefix,
-        )
-
-    return (workspace_backend,)
 
 
 def _create_backend_instance(storage) -> AbstractMemoryBackend:

--- a/src/omnicoreagent/core/tools/memory_tool/memory_tool.py
+++ b/src/omnicoreagent/core/tools/memory_tool/memory_tool.py
@@ -6,6 +6,7 @@ implementing AbstractMemoryBackend.
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.tools.memory_tool.base import AbstractMemoryBackend
 from omnicoreagent.core.tools.memory_tool.factory import create_memory_backend
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 
 
 class MemoryTool:
@@ -20,18 +21,24 @@ class MemoryTool:
         memory_tool = MemoryTool(backend=my_custom_backend)
     """
 
-    def __init__(self, backend: AbstractMemoryBackend | None = None):
+    def __init__(
+        self,
+        backend: AbstractMemoryBackend | None = None,
+        workspace_config: WorkspaceConfig | dict | None = None,
+    ):
         """
         Initialize MemoryTool with a backend.
         
         Args:
             backend: Optional AbstractMemoryBackend instance for direct injection.
                 None uses the active workspace backend.
+            workspace_config: Explicit workspace storage config used when backend is
+                not provided. None falls back to environment configuration.
         """
         if isinstance(backend, AbstractMemoryBackend):
             self.backend = backend
         else:
-            self.backend = create_memory_backend()
+            self.backend = create_memory_backend(workspace_config=workspace_config)
 
     def view(self, path: str | None = None) -> str:
         """Show directory listing or file contents."""
@@ -65,6 +72,7 @@ class MemoryTool:
 def build_tool_registry_memory_tool(
     backend: AbstractMemoryBackend | None,
     registry: ToolRegistry,
+    workspace_config: WorkspaceConfig | dict | None = None,
 ) -> ToolRegistry:
     """
     Register memory tool commands in a ToolRegistry.
@@ -73,7 +81,7 @@ def build_tool_registry_memory_tool(
         backend: Optional backend instance. None uses workspace storage.
         registry: ToolRegistry to register commands with
     """
-    memory_tool = MemoryTool(backend=backend)
+    memory_tool = MemoryTool(backend=backend, workspace_config=workspace_config)
 
     @registry.register_tool(
         name="memory_view",

--- a/src/omnicoreagent/core/tools/tool_runtime_registry.py
+++ b/src/omnicoreagent/core/tools/tool_runtime_registry.py
@@ -3,6 +3,7 @@ from typing import Any
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.tools.tool_prompt_renderer import ToolPromptRenderer
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 
 
 async def build_tool_registry_advance_tools_use(registry: ToolRegistry):
@@ -13,12 +14,21 @@ async def build_tool_registry_advance_tools_use(registry: ToolRegistry):
     return await build_advanced_tools(registry=registry)
 
 
-def build_tool_registry_memory_tool(*, backend: Any, registry: ToolRegistry):
+def build_tool_registry_memory_tool(
+    *,
+    backend: Any,
+    registry: ToolRegistry,
+    workspace_config: WorkspaceConfig | dict | None = None,
+):
     from omnicoreagent.core.tools.memory_tool.memory_tool import (
         build_tool_registry_memory_tool as build_memory_tools,
     )
 
-    return build_memory_tools(backend=backend, registry=registry)
+    return build_memory_tools(
+        backend=backend,
+        registry=registry,
+        workspace_config=workspace_config,
+    )
 
 
 def build_tool_registry_artifact_tool(
@@ -49,6 +59,7 @@ class ToolRuntimeRegistry:
         enable_workspace_memory: bool = False,
         enable_agent_skills: bool = False,
         skill_manager: Any = None,
+        workspace_config: WorkspaceConfig | dict | None = None,
     ):
         self.register_internal_tool = register_internal_tool
         self.tool_offloader = tool_offloader
@@ -57,6 +68,7 @@ class ToolRuntimeRegistry:
         self.enable_workspace_memory = enable_workspace_memory
         self.enable_agent_skills = enable_agent_skills
         self.skill_manager = skill_manager
+        self.workspace_config = workspace_config
 
     async def prepare_tools(self, local_tools: Any = None):
         registry = local_tools
@@ -81,6 +93,7 @@ class ToolRuntimeRegistry:
             build_tool_registry_memory_tool(
                 backend=None,
                 registry=registry,
+                workspace_config=self.workspace_config,
             )
 
         if self.tool_offloader.config.enabled:

--- a/src/omnicoreagent/core/workspace.py
+++ b/src/omnicoreagent/core/workspace.py
@@ -1,10 +1,9 @@
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnicoreagent.core.workspace_config import DEFAULT_WORKSPACE_DIR, WorkspaceConfig
 
-_DEFAULT_WORKSPACE = "./workspace"
-_WORKSPACE_ENV = "OMNICOREAGENT_WORKSPACE_DIR"
+_DEFAULT_WORKSPACE = DEFAULT_WORKSPACE_DIR
 
 
 @dataclass(frozen=True)
@@ -22,9 +21,9 @@ class WorkspacePaths:
 
 def resolve_workspace_paths(
     *,
-    workspace_dir: str | os.PathLike | None = None,
+    workspace_dir: str | Path | None = None,
 ) -> WorkspacePaths:
-    root = Path(workspace_dir or os.environ.get(_WORKSPACE_ENV, _DEFAULT_WORKSPACE))
+    root = Path(workspace_dir or WorkspaceConfig.from_env().workspace_dir)
     return WorkspacePaths(
         root=root,
         artifacts=root / "artifacts",

--- a/src/omnicoreagent/core/workspace_config.py
+++ b/src/omnicoreagent/core/workspace_config.py
@@ -1,0 +1,117 @@
+import os
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Mapping
+
+
+DEFAULT_WORKSPACE_BACKEND = "local"
+DEFAULT_WORKSPACE_DIR = "./workspace"
+DEFAULT_WORKSPACE_PREFIX = "workspace"
+
+
+@dataclass(frozen=True)
+class WorkspaceConfig:
+    """Explicit workspace storage configuration."""
+
+    backend: str = DEFAULT_WORKSPACE_BACKEND
+    workspace_dir: str | Path | None = DEFAULT_WORKSPACE_DIR
+    prefix: str = DEFAULT_WORKSPACE_PREFIX
+    s3_bucket: str | None = None
+    aws_region: str | None = None
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    aws_endpoint_url: str | None = None
+    r2_bucket_name: str | None = None
+    r2_account_id: str | None = None
+    r2_access_key_id: str | None = None
+    r2_secret_access_key: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "backend", self.backend.lower().strip())
+        object.__setattr__(self, "prefix", self.prefix.strip("/"))
+        if self.workspace_dir is not None:
+            object.__setattr__(self, "workspace_dir", str(self.workspace_dir))
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "WorkspaceConfig":
+        source = env if env is not None else os.environ
+        return cls(
+            backend=source.get(
+                "OMNICOREAGENT_WORKSPACE_BACKEND", DEFAULT_WORKSPACE_BACKEND
+            ),
+            workspace_dir=source.get(
+                "OMNICOREAGENT_WORKSPACE_DIR", DEFAULT_WORKSPACE_DIR
+            ),
+            prefix=source.get(
+                "OMNICOREAGENT_WORKSPACE_PREFIX", DEFAULT_WORKSPACE_PREFIX
+            ),
+            s3_bucket=source.get("AWS_S3_BUCKET"),
+            aws_region=source.get("AWS_REGION"),
+            aws_access_key_id=source.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=source.get("AWS_SECRET_ACCESS_KEY"),
+            aws_endpoint_url=source.get("AWS_ENDPOINT_URL"),
+            r2_bucket_name=source.get("R2_BUCKET_NAME"),
+            r2_account_id=source.get("R2_ACCOUNT_ID"),
+            r2_access_key_id=source.get("R2_ACCESS_KEY_ID"),
+            r2_secret_access_key=source.get("R2_SECRET_ACCESS_KEY"),
+        )
+
+    def with_overrides(
+        self,
+        *,
+        backend: str | None = None,
+        workspace_dir: str | Path | None = None,
+    ) -> "WorkspaceConfig":
+        updates = {}
+        if backend is not None:
+            updates["backend"] = backend
+        if workspace_dir is not None:
+            updates["workspace_dir"] = workspace_dir
+        return replace(self, **updates)
+
+    def namespace_prefix(self, namespace: str | None = None) -> str:
+        clean_namespace = (namespace or "").strip("/")
+        if self.prefix and clean_namespace:
+            return f"{self.prefix}/{clean_namespace}"
+        return clean_namespace or self.prefix
+
+    def local_namespace_path(self, namespace: str | None = None) -> Path:
+        root = Path(self.workspace_dir or DEFAULT_WORKSPACE_DIR)
+        clean_namespace = (namespace or "").strip("/")
+        return root / clean_namespace if clean_namespace else root
+
+    def cache_key(self, namespace: str | None = None) -> tuple:
+        if self.backend == "local":
+            return (
+                self.backend,
+                str(self.local_namespace_path(namespace).expanduser().resolve()),
+            )
+
+        if self.backend == "s3":
+            return (
+                self.backend,
+                self.s3_bucket,
+                self.aws_region,
+                self.aws_endpoint_url,
+                self.namespace_prefix(namespace),
+            )
+
+        if self.backend == "r2":
+            return (
+                self.backend,
+                self.r2_bucket_name,
+                self.r2_account_id,
+                self.namespace_prefix(namespace),
+            )
+
+        return (self.backend,)
+
+
+def resolve_workspace_config(
+    config: WorkspaceConfig | Mapping[str, object] | None = None,
+) -> WorkspaceConfig:
+    if config is None:
+        return WorkspaceConfig.from_env()
+    if isinstance(config, WorkspaceConfig):
+        return config
+    return WorkspaceConfig(**config)

--- a/src/omnicoreagent/core/workspace_storage.py
+++ b/src/omnicoreagent/core/workspace_storage.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import urllib.parse
 from dataclasses import dataclass
@@ -9,6 +8,10 @@ from typing import Any, Iterable, Protocol
 from filelock import FileLock
 
 from omnicoreagent._optional import load_optional
+from omnicoreagent.core.workspace_config import (
+    WorkspaceConfig,
+    resolve_workspace_config,
+)
 
 
 @dataclass(frozen=True)
@@ -451,61 +454,55 @@ def create_workspace_storage(
     backend: str | None = None,
     namespace: str | None = None,
     workspace_dir: str | Path | None = None,
+    config: WorkspaceConfig | dict | None = None,
 ) -> WorkspaceStorage:
-    backend = backend or os.environ.get("OMNICOREAGENT_WORKSPACE_BACKEND", "local")
-    backend = backend.lower().strip()
+    workspace_config = resolve_workspace_config(config)
+    workspace_config = workspace_config.with_overrides(
+        backend=backend,
+        workspace_dir=workspace_dir,
+    )
+    backend = workspace_config.backend
     namespace = (namespace or "").strip("/")
 
     if backend == "local":
         from omnicoreagent.core.workspace import resolve_workspace_paths
 
-        paths = resolve_workspace_paths(workspace_dir=workspace_dir)
+        paths = resolve_workspace_paths(workspace_dir=workspace_config.workspace_dir)
         root = paths.root / namespace if namespace else paths.root
         return LocalWorkspaceStorage(root)
 
     if backend == "s3":
-        bucket_name = os.environ.get("AWS_S3_BUCKET")
+        bucket_name = workspace_config.s3_bucket
         if not bucket_name:
             raise ValueError("S3 workspace backend requires AWS_S3_BUCKET")
-        prefix = os.environ.get("OMNICOREAGENT_WORKSPACE_PREFIX", "workspace").strip(
-            "/"
-        )
-        if namespace:
-            prefix = f"{prefix}/{namespace}"
+        prefix = workspace_config.namespace_prefix(namespace)
         return S3WorkspaceStorage(
             bucket_name=bucket_name,
             prefix=prefix,
-            region=os.environ.get("AWS_REGION"),
-            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
-            endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
+            region=workspace_config.aws_region,
+            aws_access_key_id=workspace_config.aws_access_key_id,
+            aws_secret_access_key=workspace_config.aws_secret_access_key,
+            endpoint_url=workspace_config.aws_endpoint_url,
         )
 
     if backend == "r2":
-        missing = [
-            name
-            for name in (
-                "R2_BUCKET_NAME",
-                "R2_ACCOUNT_ID",
-                "R2_ACCESS_KEY_ID",
-                "R2_SECRET_ACCESS_KEY",
-            )
-            if not os.environ.get(name)
-        ]
+        required_fields = {
+            "R2_BUCKET_NAME": workspace_config.r2_bucket_name,
+            "R2_ACCOUNT_ID": workspace_config.r2_account_id,
+            "R2_ACCESS_KEY_ID": workspace_config.r2_access_key_id,
+            "R2_SECRET_ACCESS_KEY": workspace_config.r2_secret_access_key,
+        }
+        missing = [name for name, value in required_fields.items() if not value]
         if missing:
             raise ValueError(
                 f"R2 workspace backend requires environment variables: {', '.join(missing)}"
             )
-        prefix = os.environ.get("OMNICOREAGENT_WORKSPACE_PREFIX", "workspace").strip(
-            "/"
-        )
-        if namespace:
-            prefix = f"{prefix}/{namespace}"
+        prefix = workspace_config.namespace_prefix(namespace)
         return R2WorkspaceStorage(
-            bucket_name=os.environ["R2_BUCKET_NAME"],
-            account_id=os.environ["R2_ACCOUNT_ID"],
-            access_key_id=os.environ["R2_ACCESS_KEY_ID"],
-            secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+            bucket_name=workspace_config.r2_bucket_name,
+            account_id=workspace_config.r2_account_id,
+            access_key_id=workspace_config.r2_access_key_id,
+            secret_access_key=workspace_config.r2_secret_access_key,
             prefix=prefix,
         )
 

--- a/tests/test_memory_tool_backend.py
+++ b/tests/test_memory_tool_backend.py
@@ -9,6 +9,7 @@ from omnicoreagent.core.tools.memory_tool.factory import (
 )
 from omnicoreagent.core.tools.memory_tool.memory_tool import MemoryTool
 from omnicoreagent.core.tools.memory_tool.storage import WorkspaceMemoryBackend
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage, S3WorkspaceStorage
 
 
@@ -169,6 +170,35 @@ def test_create_memory_backend_local_uses_workspace_memories(monkeypatch, tmp_pa
 
     assert isinstance(backend, WorkspaceMemoryBackend)
     assert backend.base_dir == (tmp_path / "workspace" / "memories").resolve()
+
+    clear_backend_cache()
+
+
+def test_create_memory_backend_accepts_explicit_workspace_config(monkeypatch, tmp_path):
+    clear_backend_cache()
+    monkeypatch.delenv("OMNICOREAGENT_WORKSPACE_DIR", raising=False)
+    workspace = tmp_path / "explicit-workspace"
+
+    backend = create_memory_backend(
+        workspace_config=WorkspaceConfig(workspace_dir=workspace)
+    )
+
+    assert isinstance(backend, WorkspaceMemoryBackend)
+    assert backend.base_dir == (workspace / "memories").resolve()
+
+    clear_backend_cache()
+
+
+def test_memory_tool_accepts_explicit_workspace_config(monkeypatch, tmp_path):
+    clear_backend_cache()
+    monkeypatch.delenv("OMNICOREAGENT_WORKSPACE_DIR", raising=False)
+    workspace = tmp_path / "memory-tool-workspace"
+
+    tool = MemoryTool(workspace_config=WorkspaceConfig(workspace_dir=workspace))
+    result = tool.create_update("note.txt", "hello", mode="create")
+
+    assert "created" in result.lower()
+    assert (workspace / "memories" / "note.txt").read_text() == "hello"
 
     clear_backend_cache()
 

--- a/tests/test_react_agent.py
+++ b/tests/test_react_agent.py
@@ -2,6 +2,7 @@ import pytest
 
 from omnicoreagent.core.agents.react_agent import ReactAgent
 from omnicoreagent.core.runtime.config import AgentConfig
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 
 
 @pytest.fixture
@@ -33,3 +34,28 @@ def test_react_agent_initialization(agent_config):
 
 def test_react_agent_uses_base_run_loop(react_agent):
     assert callable(react_agent.run)
+
+
+def test_agent_config_keeps_workspace_config_lazy_by_default(monkeypatch):
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    config = AgentConfig(agent_name="test_agent")
+
+    assert config.workspace_config is None
+    assert config.model_dump()["workspace_config"] is None
+
+
+def test_react_agent_passes_workspace_config_to_tool_offloader(
+    agent_config, monkeypatch, tmp_path
+):
+    monkeypatch.delenv("OMNICOREAGENT_WORKSPACE_DIR", raising=False)
+    workspace = tmp_path / "runtime-workspace"
+    agent_config.tool_offload["enabled"] = True
+    agent_config.tool_offload["threshold_tokens"] = 10
+    agent_config.workspace_config = WorkspaceConfig(workspace_dir=workspace)
+
+    agent = ReactAgent(config=agent_config)
+    result = agent.tool_offloader.offload("runtime_tool", "Content " * 50)
+
+    assert result.artifact_path.startswith(str((workspace / "artifacts").resolve()))
+    assert (workspace / "artifacts").is_dir()

--- a/tests/test_tool_response_offloader.py
+++ b/tests/test_tool_response_offloader.py
@@ -25,6 +25,7 @@ from omnicoreagent.core.tool_response_offloader import (
     OffloadConfig,
     OffloadedResponse,
 )
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 from omnicoreagent.core.tools.artifact_tool import build_tool_registry_artifact_tool
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.runtime.config import AgentConfig
@@ -387,6 +388,20 @@ class TestOffload:
             config={"enabled": True, "threshold_tokens": 10}
         )
         result = offloader.offload("env_tool", "Content " * 50)
+
+        assert Path(result.artifact_path).is_relative_to(workspace / "artifacts")
+        assert Path(result.artifact_path).read_text() == "Content " * 50
+
+    def test_offload_accepts_explicit_workspace_config(self, monkeypatch, tmp_path):
+        """Test offloader can use explicit workspace config without env coupling."""
+        monkeypatch.delenv("OMNICOREAGENT_WORKSPACE_DIR", raising=False)
+        workspace = tmp_path / "explicit-workspace"
+
+        offloader = ToolResponseOffloader(
+            config={"enabled": True, "threshold_tokens": 10},
+            workspace_config=WorkspaceConfig(workspace_dir=workspace),
+        )
+        result = offloader.offload("explicit_tool", "Content " * 50)
 
         assert Path(result.artifact_path).is_relative_to(workspace / "artifacts")
         assert Path(result.artifact_path).read_text() == "Content " * 50

--- a/tests/test_tool_runtime_registry.py
+++ b/tests/test_tool_runtime_registry.py
@@ -3,8 +3,10 @@ from types import SimpleNamespace
 import pytest
 
 from omnicoreagent.core.tool_response_offloader import ToolResponseOffloader
+from omnicoreagent.core.tools.memory_tool.factory import clear_backend_cache
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.tools.tool_runtime_registry import ToolRuntimeRegistry
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 
 
 @pytest.fixture
@@ -71,6 +73,32 @@ async def test_prepare_tools_uses_internal_registry_when_harness_tools_enabled(
 
     assert prepared is internal_registry
     assert "internal_ping" in [tool.name for tool in prepared.list_tools()]
+
+
+@pytest.mark.asyncio
+async def test_prepare_tools_uses_workspace_config_for_memory_tools(
+    monkeypatch, tmp_path, internal_registry, offloader
+):
+    clear_backend_cache()
+    monkeypatch.delenv("OMNICOREAGENT_WORKSPACE_DIR", raising=False)
+    workspace = tmp_path / "runtime-workspace"
+    runtime = make_runtime(
+        internal_registry,
+        offloader,
+        enable_workspace_memory=True,
+        workspace_config=WorkspaceConfig(workspace_dir=workspace),
+    )
+
+    prepared = await runtime.prepare_tools(local_tools=None)
+    result = await prepared.execute_tool(
+        "memory_create_update",
+        {"path": "note.txt", "file_text": "hello", "mode": "create"},
+    )
+
+    assert "created" in result.lower()
+    assert (workspace / "memories" / "note.txt").read_text() == "hello"
+
+    clear_backend_cache()
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12,6 +12,7 @@ from omnicoreagent.core.workspace import (
     get_memories_dir,
     get_workspace_dir,
 )
+from omnicoreagent.core.workspace_config import WorkspaceConfig
 from omnicoreagent.core.workspace_storage import LocalWorkspaceStorage
 from omnicoreagent.core.workspace_storage import S3WorkspaceStorage
 from omnicoreagent.core.workspace_storage import create_workspace_storage
@@ -38,6 +39,72 @@ def test_workspace_storage_namespaces_share_one_workspace_root(monkeypatch, tmp_
     assert isinstance(memories, LocalWorkspaceStorage)
     assert artifacts.root == (workspace / "artifacts").resolve()
     assert memories.root == (workspace / "memories").resolve()
+
+
+def test_workspace_config_from_env_normalizes_values(monkeypatch, tmp_path):
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_BACKEND", " S3 ")
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_DIR", str(tmp_path / "workspace"))
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_PREFIX", "/agent-workspace/")
+    monkeypatch.setenv("AWS_S3_BUCKET", "bucket")
+
+    config = WorkspaceConfig.from_env()
+
+    assert config.backend == "s3"
+    assert config.workspace_dir == str(tmp_path / "workspace")
+    assert config.namespace_prefix("artifacts") == "agent-workspace/artifacts"
+    assert config.cache_key(namespace="artifacts") == (
+        "s3",
+        "bucket",
+        None,
+        None,
+        "agent-workspace/artifacts",
+    )
+
+
+def test_workspace_storage_accepts_explicit_local_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("OMNICOREAGENT_WORKSPACE_DIR", raising=False)
+    workspace = tmp_path / "explicit-workspace"
+    config = WorkspaceConfig(workspace_dir=workspace)
+
+    storage = create_workspace_storage(namespace="artifacts", config=config)
+
+    assert isinstance(storage, LocalWorkspaceStorage)
+    assert storage.root == (workspace / "artifacts").resolve()
+
+
+def test_workspace_storage_accepts_explicit_s3_config(monkeypatch):
+    monkeypatch.delenv("AWS_S3_BUCKET", raising=False)
+    captured = {}
+
+    class FakeStorage:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "omnicoreagent.core.workspace_storage.S3WorkspaceStorage",
+        FakeStorage,
+    )
+
+    storage = create_workspace_storage(
+        namespace="memories",
+        config=WorkspaceConfig(
+            backend="s3",
+            prefix="agent",
+            s3_bucket="bucket",
+            aws_region="us-east-1",
+            aws_endpoint_url="https://example.test",
+        ),
+    )
+
+    assert isinstance(storage, FakeStorage)
+    assert captured == {
+        "bucket_name": "bucket",
+        "prefix": "agent/memories",
+        "region": "us-east-1",
+        "aws_access_key_id": None,
+        "aws_secret_access_key": None,
+        "endpoint_url": "https://example.test",
+    }
 
 
 def test_ensure_workspace_creates_runtime_directories(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Add explicit WorkspaceConfig as the single workspace storage configuration boundary
- Route artifacts and workspace memory through the runtime workspace config path
- Remove direct env reads from workspace storage and memory backend cache internals
- Add focused tests for explicit local/S3 workspace config, memory tools, offloading, and runtime wiring

## Verification
- uv run ruff check src tests
- uv run pytest -q