### PR TITLE
Extract OmniCoreAgent run execution helpers

### DIFF
--- a/src/omnicoreagent/core/runtime/execution.py
+++ b/src/omnicoreagent/core/runtime/execution.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from omnicoreagent.core.runtime.imports import runtime_logger
+
+
+def blocked_guardrail_response(
+    *,
+    guardrail: Any,
+    query: str,
+    session_id: str | None,
+    agent_name: str,
+) -> dict[str, Any] | None:
+    """Return a blocked response when input guardrails reject the query."""
+    if not guardrail:
+        return None
+
+    result = guardrail.check(query)
+    if result.is_safe:
+        return None
+
+    runtime_logger().warning(f"Query blocked by guardrail: {result.message}")
+    return {
+        "response": (
+            "I'm sorry, but I cannot process this request due to safety concerns: "
+            f"{result.message}"
+        ),
+        "session_id": session_id,
+        "agent_name": agent_name,
+        "guardrail_result": result.to_dict(),
+    }
+
+
+def build_agent_run_kwargs(
+    *,
+    mcp_client: Any,
+    local_tools: Any,
+    session_id: str,
+    sub_agents: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the tool/session kwargs passed into the ReactAgent loop."""
+    return {
+        "sessions": mcp_client.sessions if mcp_client else {},
+        "mcp_tools": mcp_client.available_tools if mcp_client else {},
+        "local_tools": local_tools,
+        "session_id": session_id,
+        "sub_agents": sub_agents,
+    }
+
+
+def format_run_response(
+    *,
+    response: Any,
+    session_id: str,
+    agent_name: str,
+    usage_getter: Callable[[], Any],
+) -> dict[str, Any]:
+    """Normalize ReactAgent output into the public OmniCoreAgent run response."""
+    if isinstance(response, dict) and "usage" in response:
+        usage = response["usage"]
+        usage_getter().incr(usage)
+        return {
+            "response": response["answer"],
+            "session_id": session_id,
+            "agent_name": agent_name,
+            "metric": usage,
+        }
+
+    return {"response": response, "session_id": session_id, "agent_name": agent_name}

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from omnicoreagent.core.runtime import (
     builder,
     construction,
+    execution,
     harness_tools,
     normalization,
     summaries,
@@ -196,18 +197,14 @@ class OmniCoreAgent:
         if not self._initialized:
             await self.initialize()
 
-        if self.guardrail:
-            result = self.guardrail.check(query)
-            if not result.is_safe:
-                runtime_logger().warning(
-                    f"Query blocked by guardrail: {result.message}"
-                )
-                return {
-                    "response": f"I'm sorry, but I cannot process this request due to safety concerns: {result.message}",
-                    "session_id": session_id,
-                    "agent_name": self.name,
-                    "guardrail_result": result.to_dict(),
-                }
+        blocked_response = execution.blocked_guardrail_response(
+            guardrail=self.guardrail,
+            query=query,
+            session_id=session_id,
+            agent_name=self.name,
+        )
+        if blocked_response:
+            return blocked_response
 
         if not session_id:
             session_id = self.generate_session_id()
@@ -215,14 +212,6 @@ class OmniCoreAgent:
         runtime_prompt = self.prompt_builder.build(
             system_instruction=self.system_instruction
         )
-
-        extra_kwargs = {
-            "sessions": self.mcp_client.sessions if self.mcp_client else {},
-            "mcp_tools": self.mcp_client.available_tools if self.mcp_client else {},
-            "local_tools": self.local_tools,
-            "session_id": session_id,
-            "sub_agents": self.sub_agents,
-        }
 
         response = await self.agent.run(
             system_prompt=runtime_prompt,
@@ -232,19 +221,20 @@ class OmniCoreAgent:
             message_history=self.memory_router.get_messages,
             debug=self.debug,
             event_router=self.event_router.append,
-            **extra_kwargs,
+            **execution.build_agent_run_kwargs(
+                mcp_client=self.mcp_client,
+                local_tools=self.local_tools,
+                session_id=session_id,
+                sub_agents=self.sub_agents,
+            ),
         )
 
-        if isinstance(response, dict) and "usage" in response:
-            self._usage().incr(response["usage"])
-            return {
-                "response": response["answer"],
-                "session_id": session_id,
-                "agent_name": self.name,
-                "metric": response["usage"],
-            }
-
-        return {"response": response, "session_id": session_id, "agent_name": self.name}
+        return execution.format_run_response(
+            response=response,
+            session_id=session_id,
+            agent_name=self.name,
+            usage_getter=self._usage,
+        )
 
     async def get_metrics(self) -> Dict[str, Any]:
         """

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -8,7 +8,7 @@ from omnicoreagent.core.runtime.harness_tools import (
     available_tools,
     prepare_dynamic_subagents,
 )
-from omnicoreagent.core.runtime import builder
+from omnicoreagent.core.runtime import builder, execution
 from omnicoreagent.core.runtime.normalization import normalize_local_tools
 from omnicoreagent.core.runtime.summaries import extract_summary_text, render_history
 from omnicoreagent.core.tools.local_tools_registry import Tool
@@ -218,3 +218,125 @@ def test_build_agent_runtime_wires_components(monkeypatch):
         "enabled": True,
         "local_tools": "local-tools",
     }
+
+
+def test_blocked_guardrail_response_returns_none_without_guardrail():
+    assert (
+        execution.blocked_guardrail_response(
+            guardrail=None,
+            query="hello",
+            session_id="session",
+            agent_name="agent",
+        )
+        is None
+    )
+
+
+def test_blocked_guardrail_response_returns_none_for_safe_input():
+    guardrail = SimpleNamespace(
+        check=lambda query: SimpleNamespace(is_safe=True, message="", to_dict=dict)
+    )
+
+    assert (
+        execution.blocked_guardrail_response(
+            guardrail=guardrail,
+            query="hello",
+            session_id="session",
+            agent_name="agent",
+        )
+        is None
+    )
+
+
+def test_blocked_guardrail_response_formats_unsafe_input():
+    result = SimpleNamespace(
+        is_safe=False,
+        message="unsafe",
+        to_dict=lambda: {"is_safe": False, "message": "unsafe"},
+    )
+    guardrail = SimpleNamespace(check=lambda query: result)
+
+    response = execution.blocked_guardrail_response(
+        guardrail=guardrail,
+        query="bad",
+        session_id="session",
+        agent_name="agent",
+    )
+
+    assert response == {
+        "response": (
+            "I'm sorry, but I cannot process this request due to safety concerns: "
+            "unsafe"
+        ),
+        "session_id": "session",
+        "agent_name": "agent",
+        "guardrail_result": {"is_safe": False, "message": "unsafe"},
+    }
+
+
+def test_build_agent_run_kwargs_uses_empty_mcp_state_when_disconnected():
+    assert execution.build_agent_run_kwargs(
+        mcp_client=None,
+        local_tools="local-tools",
+        session_id="session",
+        sub_agents=None,
+    ) == {
+        "sessions": {},
+        "mcp_tools": {},
+        "local_tools": "local-tools",
+        "session_id": "session",
+        "sub_agents": None,
+    }
+
+
+def test_build_agent_run_kwargs_uses_connected_mcp_state():
+    worker = object()
+    mcp_client = SimpleNamespace(
+        sessions={"server": "session"},
+        available_tools={"server": ["tool"]},
+    )
+
+    assert execution.build_agent_run_kwargs(
+        mcp_client=mcp_client,
+        local_tools="local-tools",
+        session_id="session",
+        sub_agents={"worker": worker},
+    ) == {
+        "sessions": {"server": "session"},
+        "mcp_tools": {"server": ["tool"]},
+        "local_tools": "local-tools",
+        "session_id": "session",
+        "sub_agents": {"worker": worker},
+    }
+
+
+def test_format_run_response_keeps_plain_response_without_usage_allocation():
+    def fail_usage_getter():
+        raise AssertionError("usage getter should not be called")
+
+    assert execution.format_run_response(
+        response="done",
+        session_id="session",
+        agent_name="agent",
+        usage_getter=fail_usage_getter,
+    ) == {"response": "done", "session_id": "session", "agent_name": "agent"}
+
+
+def test_format_run_response_increments_usage_for_metric_response():
+    usage = SimpleNamespace()
+    cumulative_usage = SimpleNamespace(incr=lambda value: setattr(value, "seen", True))
+
+    response = execution.format_run_response(
+        response={"answer": "done", "usage": usage},
+        session_id="session",
+        agent_name="agent",
+        usage_getter=lambda: cumulative_usage,
+    )
+
+    assert response == {
+        "response": "done",
+        "session_id": "session",
+        "agent_name": "agent",
+        "metric": usage,
+    }
+    assert getattr(usage, "seen") is True


### PR DESCRIPTION
## Summary
- move input guardrail response handling out of OmniCoreAgent.run
- move ReactAgent run kwargs assembly into a focused runtime execution helper
- move public run response formatting and cumulative usage incrementing into the execution helper
- add focused tests for execution helper behavior

## Verification
- uv run ruff check src tests
- uv run pytest -q tests/test_agent_runtime.py tests/test_import_startup.py tests/test_guardrail_default_mode.py
- uv run pytest -q