### PR TITLE
docs: strengthen OmniCoreAgent harness positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="assets/IMG_5292.jpeg" alt="OmniCoreAgent Logo" width="250"/>
 </p>
 
-<h1 align="center">🚀 OmniCoreAgent</h1>
+<h1 align="center">OmniCoreAgent</h1>
 
 <p align="center">
   <strong>The Open Agent Harness Built for Production</strong><br>
-  <em>Run autonomous agents with tools, memory, context management, guardrails, and deployment paths.</em>
+  <em>Parallel tool batches. Structured observations. Loop detection. Memory, workspace files, MCP, subagents, and serving in one runtime.</em>
 </p>
 
 <p align="center">
@@ -17,77 +17,19 @@
 </p>
 
 <p align="center">
-  <a href="#-quick-start">Quick Start</a> •
-  <a href="#-see-it-in-action">See It In Action</a> •
-  <a href="./cookbook">📚 Cookbook</a> •
-  <a href="#-core-features">Features</a> •
+  <a href="#quick-start">Quick Start</a> -
+  <a href="#what-makes-it-different">What Makes It Different</a> -
+  <a href="./cookbook">Cookbook</a> -
+  <a href="#features">Features</a> -
   <a href="https://docs-omnicoreagent.omnirexfloralabs.com/docs">Docs</a>
 </p>
 
 ---
 
-## 🎬 See It In Action
-
-```python
-import asyncio
-from omnicoreagent import OmniCoreAgent, MemoryRouter, ToolRegistry
-
-# Create tools in seconds
-tools = ToolRegistry()
-
-@tools.register_tool("get_weather")
-def get_weather(city: str) -> dict:
-    """Get current weather for a city."""
-    return {"city": city, "temp": "22°C", "condition": "Sunny"}
-
-# Build a production-ready agent
-agent = OmniCoreAgent(
-    name="assistant",
-    system_instruction="You are a helpful assistant with access to weather data.",
-    model_config={"provider": "openai", "model": "gpt-4o"},
-    local_tools=tools,
-    memory_router=MemoryRouter("in_memory"),
-    agent_config={
-        "context_management": {"enabled": True},  # Auto-manage long conversations
-        "guardrail_config": {"strict_mode": True},  # Block prompt injections
-        "enable_subagents": True,  # Optional dynamic worker spawning
-    }
-)
-
-async def main():
-    # Run the agent
-    result = await agent.run("What's the weather in Tokyo?")
-    print(result["response"])
-    
-    # Production memory stores such as Redis, MongoDB, and Postgres are optional extras.
-    # Install only the memory store you use, then switch at runtime when configured.
-
-asyncio.run(main())
-```
-
-**What just happened?**
-- ✅ Registered a custom tool with type hints
-- ✅ Built an agent with memory
-- ✅ Enabled automatic context management
-- ✅ Kept production backends optional until you need them
-
----
-
-## ⚡ Quick Start
+## Quick Start
 
 ```bash
 pip install omnicoreagent
-```
-
-Install production extras only when you need them:
-
-```bash
-pip install "omnicoreagent[redis]"       # Redis memory and event streams
-pip install "omnicoreagent[postgres]"    # PostgreSQL / SQL memory
-pip install "omnicoreagent[mongodb]"     # MongoDB memory
-pip install "omnicoreagent[s3]"          # S3 / R2 workspace files
-pip install "omnicoreagent[serve]"       # OmniServe REST/SSE API server
-pip install "omnicoreagent[all]"         # Everything
 ```
 
 ```bash
@@ -95,205 +37,375 @@ echo "LLM_API_KEY=your_api_key" > .env
 ```
 
 ```python
+import asyncio
 from omnicoreagent import OmniCoreAgent
 
 agent = OmniCoreAgent(
-    name="my_agent",
+    name="assistant",
     system_instruction="You are a helpful assistant.",
-    model_config={"provider": "openai", "model": "gpt-4o"}
+    model_config={"provider": "openai", "model": "gpt-4o"},
 )
 
-result = await agent.run("Hello!")
-print(result["response"])
+async def main():
+    result = await agent.run("Research the top 3 AI frameworks and summarize them.")
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
 ```
 
-**That's it.** You have an AI agent with session management, memory, and error handling.
+That is the smallest path: one agent, one model, the harness loop, session memory,
+guardrails, workspace files, error handling, and metrics around each run.
 
-> 📚 **Want to learn more?** Check out the [Cookbook](./cookbook) — progressive examples from "Hello World" to production deployments.
+Context management, tool output offloading, BM25 tool retrieval, subagents, skills,
+cloud workspace storage, and production backends are opt-in so a small agent stays
+small.
 
----
-
-## 🎯 What Makes OmniCoreAgent Different?
-
-| Feature | What It Means For You |
-|---------|----------------------|
-| **Agent Harness Runtime** | Tool loop, memory, context management, guardrails, skills, sub-agents, and serving in one open package |
-| **Runtime Backend Switching** | Switch Redis ↔ MongoDB ↔ PostgreSQL without restarting |
-| **Cloud Workspace Storage** | Agent files persist in AWS S3 or Cloudflare R2 ⚡ NEW |
-| **Context Engineering** | Session memory + agent loop context + tool offloading = no token exhaustion |
-| **Tool Response Offloading** | Large tool outputs saved to files, 98% token savings |
-| **Built-in Guardrails** | Prompt injection protection out of the box |
-| **MCP Native** | Connect to any MCP server (stdio, SSE, HTTP with OAuth) |
-| **Background Agents** | Schedule autonomous tasks that run on intervals |
-| **Workflow Orchestration** | Sequential, Parallel, and Router agents for complex tasks |
-| **Runtime Visibility** | Metrics, event streams, and compact in-house trace summaries |
+> Ready to go deeper? The [Cookbook](./cookbook) has progressive examples from
+> hello world to production deployments.
 
 ---
 
-## 🎯 Core Features
+## What Makes It Different
 
-> 📖 **Full documentation**: [docs-omnicoreagent.omnirexfloralabs.com/docs](https://docs-omnicoreagent.omnirexfloralabs.com/docs)
+Most agent frameworks stop at "LLM plus tool loop." OmniCoreAgent is built around
+the problems that show up after that: slow sequential tools, noisy observations,
+stuck loops, context exhaustion, MCP server tools, durable workspace files, and
+runtime serving.
 
-| # | Feature | Description | Docs |
-|---|---------|-------------|------|
-| 1 | **OmniCoreAgent** | The heart of the framework — production agent with all features | [Overview →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/overview) |
-| 2 | **Multi-Tier Memory** | 5 backends (Redis, MongoDB, PostgreSQL, SQLite, in-memory) with runtime switching | [Memory →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/memory) |
-| 3 | **Context Engineering** | Dual-layer system: agent loop context management + tool response offloading | [Context →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/context-engineering) |
-| 4 | **Event System** | Real-time event streaming with runtime switching | [Events →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/events) |
-| 5 | **MCP Tools** | Connect external MCP tool servers (stdio, streamable_http, SSE) with OAuth | [MCP →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/mcp) |
-| 6 | **Dynamic Subagents** | Spawn one or many focused workers from OmniCoreAgent with workspace files | [Sub-Agents →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/sub-agents) |
-| 7 | **Local Tools** | Register any Python function as an AI tool via ToolRegistry | [Local Tools →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/local-tools) |
-| 8 | **Agent Skills** | Polyglot packaged capabilities (Python, Bash, Node.js) | [Skills →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/skills) |
-| 9 | **Workspace Files** | Agent-managed files and tool artifacts on local, S3, or R2 workspaces | [Workspace →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/workspace-files) |
-| 10 | **Harness Defaults** | Subagents, workspace files, context management, and tool offloading inside OmniCoreAgent | [Sub-Agents →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/sub-agents) |
-| 11 | **Background Agents** | Schedule autonomous tasks on intervals | [Background →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/background-agents) |
-| 12 | **Workflows** | Sequential, Parallel, and Router agent orchestration | [Workflows →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/workflows) |
-| 13 | **BM25 Tool Retrieval** | Auto-discover relevant tools from 1000+ using BM25 search | [Advanced Tools →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/advanced-tools) |
-| 14 | **Guardrails** | Prompt injection protection with configurable sensitivity | [Guardrails →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/guardrails) |
-| 15 | **Runtime Visibility** | Per-request metrics, event streams, and compact in-house trace summaries | [Observability →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/observability) |
-| 16 | **Universal Models** | 9 providers via LiteLLM (OpenAI, Anthropic, Gemini, Groq, Ollama, etc.) | [Models →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/models) |
-| 17 | **OmniServe** | Turn any agent into a production REST/SSE API with one command | [OmniServe →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/omniserve) |
+### 1. Agents call tools in batches instead of forced sequences
+
+The usual tool loop looks like this:
+
+```text
+LLM -> call tool A -> wait -> result -> LLM -> call tool B -> wait -> result
+```
+
+OmniCoreAgent lets the model request independent tools together:
+
+```text
+LLM -> [tool A + tool B + tool C in parallel] -> one structured observation -> LLM
+```
+
+The model gets one complete view of the batch before it reasons again. A failed
+tool is represented beside the successful tools instead of silently collapsing the
+whole step.
+
+Native function calling alone is not the runtime. OmniCoreAgent uses its own
+tool-call contract, parser, resolver, parallel runner, and result formatter so
+the harness controls the full execution path.
+
+### 2. Tool results become structured observations
+
+Raw tool output is often too noisy for the next reasoning step. Large payloads,
+errors, irrelevant fields, and prompt-injection content can all distort the loop.
+
+OmniCoreAgent routes tool results through an observation pipeline:
+
+```text
+tool output -> parse -> format -> guardrail check -> offload when configured -> observation -> model
+```
+
+The model receives the signal it needs to continue the task, not an unbounded dump
+of every byte returned by a tool. When tool offloading is enabled, large outputs
+are written into the active workspace and the model receives a readable preview
+plus a path it can use later.
+
+### 3. Loop detection uses signatures beyond step counts
+
+`max_steps` is still useful, but it is a blunt instrument. It stops an agent that
+is making progress just as quickly as one that is stuck.
+
+OmniCoreAgent tracks SHA256-backed tool-call signatures across the loop. Each
+signature is based on the tool name, input, and output for the call. The runtime
+detects:
+
+- **Consecutive loops**: the same tool call returns the same result repeatedly.
+- **Pattern loops**: the same tool repeats a small interaction pattern.
+
+When the harness stops a loop, the agent gets a reason. That makes debugging the
+agent behavior much easier than "max iterations reached."
+
+### 4. The harness is already assembled
+
+OmniCoreAgent ships as a working agent harness, not a bag of disconnected pieces:
+
+```text
+model + prompt + loop + tools + memory + context + workspace + guardrails + events
+```
+
+Keep it small for simple agents, then turn on the heavier harness pieces when the
+workload needs them: MCP tools, BM25 tool retrieval, dynamic subagents, skills,
+cloud workspace storage, Redis/Postgres/MongoDB memory, event streams, and
+OmniServe.
+
+### 5. Context is managed before the model call
+
+When context management is enabled, OmniCoreAgent checks the active message
+history before every LLM request. If the configured threshold is crossed, the
+harness automatically applies the selected strategy before calling the model:
+
+```text
+messages -> threshold check -> truncate or summarize+truncate -> LLM
+```
+
+The system prompt is preserved, recent messages are preserved, and older middle
+history is either summarized or removed depending on configuration. If you set
+the budget below your model's real context window, the harness acts before the
+provider rejects the request.
 
 ---
 
-## 📚 Examples & Cookbook
+## Implementation Map
 
-All examples are in the **[Cookbook](./cookbook)** — organized by use case with progressive learning paths.
+OmniCoreAgent's capabilities are backed by concrete runtime modules:
 
-| Category | What You'll Build | Location |
-|----------|-------------------|----------|
-| **Getting Started** | Your first agent, tools, memory, events | [cookbook/getting_started](./cookbook/getting_started) |
-| **Workflows** | Sequential, Parallel, Router agents | [cookbook/workflows](./cookbook/workflows) |
-| **Background Agents** | Scheduled autonomous tasks | [cookbook/background_agents](./cookbook/background_agents) |
-| **Production** | Metrics and guardrails | [cookbook/production](./cookbook/production) |
+| Capability | Where It Lives |
+|-------|----------------|
+| Parallel tool batches | `core/tools/tool_batch_runner.py` |
+| XML tool-call contract | `core/agents/xml_parser.py` |
+| Structured observations | `core/tools/tool_observation.py` |
+| Tool output offloading | `core/workspace/artifacts.py` |
+| Automatic context control | `core/agents/llm_step.py`, `core/context_manager.py` |
+| Workspace files | `core/workspace/tools.py`, `core/workspace/storage.py` |
+| Dynamic subagents | `core/subagents.py` |
+| Loop detection | `core/agents/loop_detection.py` |
+| MCP server tools | `mcp_clients_connection/client.py` |
+| OmniServe | `serve/` |
+
+See the [Agent Harness docs](https://docs-omnicoreagent.omnirexfloralabs.com/docs/core-concepts/agent-harness)
+for the full implementation map.
+
 ---
 
-## ⚙️ Configuration
+## See It In Action
+
+```python
+import asyncio
+from omnicoreagent import MemoryRouter, OmniCoreAgent, ToolRegistry
+
+tools = ToolRegistry()
+
+@tools.register_tool("search_web")
+def search_web(query: str) -> dict:
+    """Search the web for information."""
+    return {"results": [f"Result for: {query}"]}
+
+@tools.register_tool("read_file")
+def read_file(path: str) -> dict:
+    """Read a local project file."""
+    return {"path": path, "content": f"Contents of {path}"}
+
+agent = OmniCoreAgent(
+    name="research-agent",
+    system_instruction=(
+        "You are a research assistant. Use tools in parallel when the calls are "
+        "independent and you can reason over the results together."
+    ),
+    model_config={"provider": "openai", "model": "gpt-4o"},
+    local_tools=tools,
+    memory_router=MemoryRouter("in_memory"),
+    agent_config={
+        "max_steps": 20,
+        "context_management": {"enabled": True},
+        "tool_offload": {"enabled": True},
+        "enable_subagents": True,
+        "enable_advanced_tool_use": True,
+    },
+)
+
+async def main():
+    result = await agent.run(
+        "Search for recent AI agent papers and read notes.md. Do both at once "
+        "if neither depends on the other."
+    )
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
+```
+
+The runtime accepts `search_web` and `read_file` in the same batch, returns both
+results together, and continues from one structured observation.
+
+---
+
+## Install Only What You Need
+
+```bash
+pip install omnicoreagent                    # Core runtime
+pip install "omnicoreagent[redis]"           # Redis memory + event streams
+pip install "omnicoreagent[postgres]"        # PostgreSQL / SQL memory
+pip install "omnicoreagent[mongodb]"         # MongoDB memory
+pip install "omnicoreagent[s3]"              # S3 / R2 workspace storage
+pip install "omnicoreagent[serve]"           # OmniServe REST/SSE API
+pip install "omnicoreagent[all]"             # Everything
+```
+
+Production backends are installable extras. Install only what the agent actually
+uses.
+
+---
+
+## Features
+
+| Feature | What It Does |
+|---------|--------------|
+| **Parallel Batch Tool Execution** | Executes independent tool calls concurrently and returns one combined observation to the model. |
+| **Structured Observation Pipeline** | Parses, formats, guardrail-checks, and offloads tool results when configured before the model sees them. |
+| **Signature-Based Loop Detection** | Detects repeated SHA256-backed tool-call signatures and repeated tool interaction patterns beyond step-count exhaustion. |
+| **MCP Native Tools** | Connects MCP servers over stdio, SSE, and Streamable HTTP, including OAuth-capable remote servers. |
+| **Local Tool Registry** | Registers Python functions as tools with inferred schemas and async/sync execution support. |
+| **Multi-Tier Memory** | Uses in-memory, SQLite, Redis, MongoDB, or SQL-backed session history through the memory router. |
+| **Runtime Backend Switching** | Switches memory and event backends at runtime when configured. |
+| **Workspace Files** | Gives agents a local, S3, or R2-backed file workspace for notes, scratchpads, artifacts, and tool offloads. |
+| **Context Engineering** | Checks context before each model call and automatically truncates or summarizes when the configured budget threshold is crossed. |
+| **Tool Output Offloading** | Writes large tool results to workspace files and gives the model a preview plus a file reference. |
+| **Dynamic Subagents** | Lets the main agent spawn focused workers with isolated context and shared workspace output. |
+| **Agent Skills** | Loads packaged capabilities implemented with Python, Bash, or Node.js. |
+| **BM25 Tool Retrieval** | Selects relevant tools from large tool sets so the prompt stays focused. |
+| **Guardrails** | Adds prompt-injection screening inside the observation path with configurable behavior. |
+| **Event System** | Emits structured runtime events for agent runs, tool calls, and streaming integrations. |
+| **Workflow Orchestration** | Provides sequential, parallel, and router agents for multi-step application workflows. |
+| **Background Agents** | Supports scheduled autonomous tasks for interval-based workloads. |
+| **Universal Models** | Routes through LiteLLM to OpenAI, Anthropic, Gemini, Groq, Ollama, DeepSeek, Mistral, OpenRouter, Azure, and Cencori. |
+| **OmniServe** | Turns an agent into a REST/SSE service with lifecycle management and metrics. |
+
+---
+
+## Cookbook
+
+All examples live in the **[Cookbook](./cookbook)** and are organized by use case.
+
+| Category | What You'll Build |
+|----------|-------------------|
+| [Getting Started](./cookbook/getting_started) | First agent, tools, memory, events |
+| [Workflows](./cookbook/workflows) | Sequential, Parallel, Router agents |
+| [Background Agents](./cookbook/background_agents) | Scheduled autonomous tasks |
+| [Production](./cookbook/production) | Guardrails, serving, and production patterns |
+
+---
+
+## Configuration
 
 ### Environment Variables
 
 ```bash
-# Required
+# Required by most hosted model providers
 LLM_API_KEY=your_api_key
 
-# Optional: workspace backend for artifacts and workspace files
-OMNICOREAGENT_WORKSPACE_BACKEND=local  # local, s3, or r2
+# Workspace storage
+OMNICOREAGENT_WORKSPACE_BACKEND=local   # local | s3 | r2
 OMNICOREAGENT_WORKSPACE_DIR=.omnicoreagent/workspace
-AWS_S3_BUCKET=your-s3-bucket           # when workspace backend=s3
-R2_BUCKET_NAME=your-r2-bucket          # when workspace backend=r2
+AWS_S3_BUCKET=your-s3-bucket            # when backend=s3
+R2_BUCKET_NAME=your-r2-bucket           # when backend=r2
 ```
 
-### Agent Configuration
+### Agent Config Reference
 
 ```python
 agent_config = {
-    "max_steps": 15,                    # Max reasoning steps
-    "tool_call_timeout": 30,            # Tool timeout (seconds)
-    "request_limit": 0,                 # 0 = unlimited
-    "total_tokens_limit": 0,            # 0 = unlimited
-    "memory_config": {"mode": "sliding_window", "value": 10000},
-    "enable_advanced_tool_use": True,   # BM25 tool retrieval
-    "enable_subagents": True,           # Dynamic focused workers
-    "enable_agent_skills": True,        # Specialized packaged skills
-    "enable_workspace_files": True,    # Default: workspace files for notes/logs/scratchpads
+    "max_steps": 15,
+    "tool_call_timeout": 30,
+    "request_limit": 0,                  # 0 = unlimited
+    "total_tokens_limit": 0,             # 0 = unlimited
+    "memory_config": {
+        "mode": "sliding_window",
+        "value": 10000,
+        "summary": {"enabled": False},
+    },
+    "enable_workspace_files": True,      # Default on
+    "guardrail_mode": "full",            # Default guardrail mode
     "context_management": {"enabled": True},
-    "tool_offload": {"enabled": True}
+    "tool_offload": {"enabled": True},
+    "enable_advanced_tool_use": True,
+    "enable_subagents": True,
+    "enable_agent_skills": True,
 }
 ```
 
-> 📖 **Full configuration reference**: [Configuration Guide →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/configuration)
+When `enable_subagents` is true, workspace files are enabled automatically so
+subagents write outputs, notes, todos, and artifacts into the active
+workspace.
+
+> Full reference: [Configuration Guide](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/configuration)
 
 ---
 
-## 🧪 Testing & Development
+## Development
 
 ```bash
-# Clone
 git clone https://github.com/omnirexflora-labs/omnicoreagent.git
 cd omnicoreagent
 
-# Setup
 uv venv && source .venv/bin/activate
 uv sync --dev
 
-# Test
 pytest tests/ -v
 pytest tests/ --cov=src --cov-report=term-missing
 ```
 
 ---
 
-## 🔍 Troubleshooting
+## Troubleshooting
 
 | Error | Fix |
 |-------|-----|
-| `Invalid API key` | Check `.env`: `LLM_API_KEY=your_key` |
-| `ModuleNotFoundError` for Redis/Postgres/Mongo/S3/OmniServe | Install the matching extra, e.g. `pip install "omnicoreagent[redis]"` |
-| `Redis connection failed` | Start Redis or use `MemoryRouter("in_memory")` |
-| `MCP connection refused` | Ensure MCP server is running |
+| `Invalid API key` | Set the right provider key in `.env`, for example `LLM_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`. |
+| `ModuleNotFoundError` for Redis / Postgres / MongoDB / S3 | Install the matching extra, for example `pip install "omnicoreagent[redis]"`. |
+| `Redis connection failed` | Start Redis or use `MemoryRouter("in_memory")`. |
+| `MCP connection refused` | Ensure the MCP server is running before starting the agent. |
 
-> 📖 **More troubleshooting**: [Basic Usage Guide →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/basic-usage)
-
----
-
-## 📝 Changelog
-
-See the full [Changelog →](https://docs-omnicoreagent.omnirexfloralabs.com/docs/changelog) for version history.
+> More help: [Basic Usage Guide](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/basic-usage)
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 ```bash
-# Fork & clone
 git clone https://github.com/omnirexflora-labs/omnicoreagent.git
+cd omnicoreagent
 
-# Setup
 uv venv && source .venv/bin/activate
 uv sync --dev
 pre-commit install
-
-# Submit PR
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. PRs are welcome.
 
 ---
 
-## 📄 License
+## License
 
-MIT License — see [LICENSE](LICENSE)
+MIT - see [LICENSE](LICENSE).
 
 ---
 
-## 👨‍💻 Author & Credits
+## Author
 
-**Created by [Abiola Adeshina](https://github.com/Abiorh001)**
+**Built by [Abiola Adeshina](https://github.com/Abiorh001)**.
 
 - **GitHub**: [@Abiorh001](https://github.com/Abiorh001)
 - **X (Twitter)**: [@abiorhmangana](https://x.com/abiorhmangana)
 - **Email**: abiolaadedayo1993@gmail.com
 
-### 🌟 The OmniRexFlora Ecosystem
+### The OmniRexFlora Ecosystem
 
 | Project | Description |
 |---------|-------------|
-| [🧠 OmniMemory](https://github.com/omnirexflora-labs/omnimemory) | Self-evolving memory for autonomous agents |
-| [🤖 OmniCoreAgent](https://github.com/omnirexflora-labs/omnicoreagent) | Production-ready AI agent framework (this project) |
+| [OmniMemory](https://github.com/omnirexflora-labs/omnimemory) | Self-evolving memory for autonomous agents |
+| [OmniCoreAgent](https://github.com/omnirexflora-labs/omnicoreagent) | Production agent harness (this project) |
+| [OmniDaemon](https://github.com/omnirexflora-labs/OmniDaemon) | Event-driven runtime for running agents as supervised, autonomous infrastructure services |
 
-### 🙏 Acknowledgments
+### Built On
 
-Built on: [LiteLLM](https://github.com/BerriAI/litellm), [FastAPI](https://fastapi.tiangolo.com/), [Redis](https://redis.io/), [Pydantic](https://pydantic-docs.helpmanual.io/), [APScheduler](https://apscheduler.readthedocs.io/)
+[LiteLLM](https://github.com/BerriAI/litellm) - [FastAPI](https://fastapi.tiangolo.com/) - [Redis](https://redis.io/) - [Pydantic](https://docs.pydantic.dev/) - [APScheduler](https://apscheduler.readthedocs.io/)
 
 ---
 
 <p align="center">
-  <strong>Building the future of production-ready AI agent frameworks</strong>
-</p>
-
-<p align="center">
-  <a href="https://github.com/omnirexflora-labs/omnicoreagent">⭐ Star us on GitHub</a> •
-  <a href="https://github.com/omnirexflora-labs/omnicoreagent/issues">🐛 Report Bug</a> •
-  <a href="https://github.com/omnirexflora-labs/omnicoreagent/issues">💡 Request Feature</a> •
-  <a href="https://docs-omnicoreagent.omnirexfloralabs.com/docs">📖 Documentation</a>
+  <a href="https://github.com/omnirexflora-labs/omnicoreagent">Star on GitHub</a> -
+  <a href="https://github.com/omnirexflora-labs/omnicoreagent/issues">Report Bug</a> -
+  <a href="https://github.com/omnirexflora-labs/omnicoreagent/issues">Request Feature</a> -
+  <a href="https://docs-omnicoreagent.omnirexfloralabs.com/docs">Documentation</a>
 </p>

--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
     "$schema": "https://mintlify.com/docs.json",
     "theme": "maple",
     "name": "OmniCoreAgent",
-    "description": "The AI Agent Framework Built for Production",
+    "description": "The Open Agent Harness Built for Production",
     "favicon": "/docs/assets/logo_light.svg",
     "colors": {
         "primary": "#0D9373",
@@ -42,6 +42,7 @@
                         "group": "Core Concepts",
                         "pages": [
                             "docs/core-concepts/overview",
+                            "docs/core-concepts/agent-harness",
                             "docs/core-concepts/architecture",
                             "docs/core-concepts/memory",
                             "docs/core-concepts/context-engineering",
@@ -109,8 +110,12 @@
                         "href": "https://github.com/omnirexflora-labs/omnicoreagent/discussions"
                     },
                     {
+                        "label": "OmniDaemon",
+                        "href": "https://github.com/omnirexflora-labs/OmniDaemon"
+                    },
+                    {
                         "label": "Contribute",
-                        "href": "https://github.com/omnirexflora-labs/omnicoreagent/blob/main/CONTRIBUTING.mdx"
+                        "href": "https://github.com/omnirexflora-labs/omnicoreagent/blob/main/CONTRIBUTING.md"
                     }
                 ]
             }

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -22,6 +22,7 @@ docs/
 │   └── quickstart.mdx
 ├── core-concepts/
 │   ├── overview.mdx
+│   ├── agent-harness.mdx
 │   ├── architecture.mdx
 │   ├── memory.mdx
 │   ├── context-engineering.mdx

--- a/docs/core-concepts/agent-harness.mdx
+++ b/docs/core-concepts/agent-harness.mdx
@@ -1,0 +1,155 @@
+---
+title: Agent Harness
+description: 'What OmniCoreAgent adds around a model to make it useful for long-running autonomous work'
+icon: 'layer-group'
+---
+
+# Agent Harness
+
+An LLM is not an agent by itself. A useful agent needs runtime behavior around
+the model: tools, memory, context control, a workspace, guardrails, events,
+delegation, and a serving boundary.
+
+That runtime is the agent harness.
+
+OmniCoreAgent is built as an open Python agent harness. You still choose the
+model and the tools, but the execution system around them is already assembled.
+
+```text
+model
+  + prompt contract
+  + ReAct loop
+  + local tools
+  + MCP tools
+  + parallel tool batches
+  + structured observations
+  + loop detection
+  + memory
+  + context management
+  + workspace files
+  + tool artifacts
+  + guardrails
+  + events
+  + subagents
+  + serving through OmniServe
+```
+
+---
+
+## Why This Matters
+
+A basic tool-calling agent is easy to build. The hard part starts when the agent
+needs to work for more than one or two steps:
+
+- tool calls become sequential bottlenecks
+- large tool outputs fill the prompt
+- old context pushes the model toward provider limits
+- external tool output carries prompt-injection risk
+- the agent repeats the same failing action
+- workers need to split independent work and report back
+- intermediate files, notes, logs, and artifacts need a durable place to live
+- the app eventually needs a stable HTTP/SSE serving boundary
+
+OmniCoreAgent exists because these are runtime problems, not prompt-only
+problems.
+
+---
+
+## Implementation-Backed Capability Map
+
+Every capability below maps to code in the repository.
+
+| Capability | What The User Gets | Main Implementation |
+|------------|--------------------|---------------------|
+| **Custom tool-call contract** | XML tool calls, final answers, single tool calls, multi-tool calls, and agent calls are parsed consistently. | `src/omnicoreagent/core/agents/xml_parser.py` |
+| **Parallel batch tool execution** | Independent tools from one model step are resolved and executed together with timeout handling. | `src/omnicoreagent/core/tools/tool_batch_runner.py` |
+| **Tool runtime registry** | Local tools, MCP tools, workspace tools, artifact tools, skills, subagent tools, and BM25 retrieval are prepared through one runtime surface. | `src/omnicoreagent/core/tools/tool_runtime_registry.py` |
+| **Structured observations** | Tool outputs are normalized, guarded, formatted, and returned to the model as structured observations. | `src/omnicoreagent/core/tools/tool_observation.py` |
+| **Tool output offloading** | Large tool responses are written to workspace artifacts and replaced with a compact preview/reference. | `src/omnicoreagent/core/workspace/artifacts.py` |
+| **Artifact readback tools** | Agents read, tail, search, and list offloaded tool responses when full content is needed. | `src/omnicoreagent/core/workspace/artifact_tools.py` |
+| **Automatic context control** | Before each model call, active messages are checked and reduced when the configured context threshold is crossed. | `src/omnicoreagent/core/agents/llm_step.py`, `src/omnicoreagent/core/context_manager.py` |
+| **Loop detection** | Repeated SHA256-backed tool-call signatures and repeated interaction patterns are detected. | `src/omnicoreagent/core/agents/loop_detection.py` |
+| **Workspace files** | Agents get file tools for notes, scratchpads, todos, task progress, generated work, and subagent output. | `src/omnicoreagent/core/workspace/tools.py` |
+| **Local/S3/R2 workspace storage** | The same workspace interface runs on local disk, S3, or R2. | `src/omnicoreagent/core/workspace/config.py`, `src/omnicoreagent/core/workspace/storage.py` |
+| **Dynamic subagents** | The lead agent spawns one or many focused workers; workers inherit model/tools/config and write output to workspace files. | `src/omnicoreagent/core/subagents.py` |
+| **MCP tools** | MCP servers are loaded as external tool providers over supported transports. | `src/omnicoreagent/mcp_clients_connection/client.py` |
+| **Guardrails** | User input and tool output are screened according to guardrail mode; full mode passes guardrails into the ReAct agent for output scrubbing. | `src/omnicoreagent/core/guardrails/`, `src/omnicoreagent/core/tools/tool_observation_guardrail.py` |
+| **Events and metrics** | Runs and tool actions emit events and return request metrics. | `src/omnicoreagent/core/events/`, `src/omnicoreagent/core/agents/llm_step.py` |
+| **OmniServe** | The same agent is exposed through REST/SSE with shared server state and lifecycle handling. | `src/omnicoreagent/serve/` |
+
+---
+
+## The Harness Loop
+
+The core loop is a controlled runtime cycle:
+
+```text
+1. Load session memory
+2. Assemble prompt and tool registry
+3. Check context before model call
+4. Call model through LiteLLM
+5. Parse XML response
+6. Resolve tool or agent calls
+7. Execute tool batch in parallel
+8. Normalize, guard, and offload observations
+9. Detect repeated tool-call loops
+10. Continue or return final answer
+```
+
+This loop is why OmniCoreAgent supports simple assistants and deeper long-running
+agents through the same entry point.
+
+---
+
+## Defaults Versus Harness Features
+
+The default agent stays light. Heavier harness behavior is enabled when the
+workload needs it.
+
+| Capability | Default | Reason |
+|------------|---------|--------|
+| ReAct loop | On | This is the core agent runtime. |
+| Session memory | On | Agents need conversation continuity. |
+| Workspace files | On | Agents need a filesystem surface for notes and outputs. |
+| Guardrails | On in `full` mode | Input and tool-output safety should be available without extra wiring. |
+| Context management | Off until enabled | Small agents should not pay summarization/truncation overhead. |
+| Tool offload | Off until enabled | Only needed when tools produce large payloads. |
+| BM25 tool retrieval | Off until enabled | Only needed when the tool list is too large for the prompt. |
+| Dynamic subagents | Off until enabled | Only needed for delegated work. |
+| Agent skills | Off until enabled | Only needed when packaged capabilities are installed. |
+| Redis/Postgres/MongoDB/S3/R2 | Optional extras | Install only the production backends you use. |
+
+---
+
+## OmniCoreAgent, OmniServe, And OmniDaemon
+
+These are separate layers:
+
+| Layer | Purpose |
+|-------|---------|
+| **OmniCoreAgent** | In-process agent harness: model loop, tools, memory, context, workspace, guardrails, events, subagents. |
+| **OmniServe** | HTTP/SSE serving layer for exposing an OmniCoreAgent instance as an API. |
+| **OmniDaemon** | Event-driven runtime for supervised, process-isolated agents running as autonomous services. |
+
+Keeping these boundaries clear matters. OmniCoreAgent should stay focused on the
+agent harness. Serving and event-driven infrastructure should live outside the
+core loop.
+
+---
+
+## Boundaries
+
+OmniCoreAgent stays focused on the in-process agent harness. That boundary keeps
+the core runtime clean:
+
+- MCP brings external MCP server tools into the same runtime surface as local
+  tools, workspace tools, skills, and harness tools.
+- Context management works by acting before the model call against the configured
+  budget.
+- Cloud workspace storage is used when the S3 or R2 backend is installed and
+  configured.
+- Distributed process supervision belongs in OmniDaemon, while HTTP/SSE serving
+  belongs in OmniServe.
+
+The result is a complete, open agent harness whose production pieces are already
+integrated and testable.

--- a/docs/core-concepts/architecture.mdx
+++ b/docs/core-concepts/architecture.mdx
@@ -1,113 +1,251 @@
 ---
 title: Architecture
-description: 'How OmniCoreAgent is built — layers, components, and data flow'
+description: 'How OmniCoreAgent is built: runtime, loop, tools, observations, memory, workspace, events, and serving'
 icon: 'sitemap'
 ---
 
 # Architecture
 
-OmniCoreAgent is built with a modular, extensible architecture designed for production-grade reliability and scalability. It follows a "layered" approach where each component can be swapped or extended without impacting the others.
+OmniCoreAgent is an agent harness: everything added around a model to make it
+usable for real autonomous work. The model is only one part of the system. The
+harness owns prompt assembly, the reasoning loop, tool resolution, parallel tool
+execution, observation formatting, loop detection, memory, workspace files,
+events, and serving integration.
+
+The architecture is intentionally modular so each layer can be tested and changed
+without turning the root agent class into a dump of unrelated behavior.
 
 ---
 
-## High-Level Overview
-
-OmniCoreAgent acts as the central orchestrator between users, Large Language Models (LLMs), and external tools (via MCP or local functions).
+## High-Level Runtime
 
 ```mermaid
-graph TB
-    User[👤 User Application] --> Agent[🤖 OmniCoreAgent]
-    
-    subgraph "Core Components"
-        Agent --> Reasoning[🔄 ReAct Engine]
-        Agent --> Router[🛤️ Router / Workflow]
-        Agent --> MemoryM[💾 Memory Manager]
-        Agent --> EventM[📡 Event Manager]
-    end
-    
-    subgraph "Capabilities"
-        Reasoning --> LLM[🧠 LiteLLM Integration]
-        Reasoning --> Tools[🛠️ Tool Orchestrator]
-        
-        Tools --> MCP[🔌 MCP Client]
-        Tools --> Local[🔧 Local Tools Registry]
-        Tools --> Skills[🎓 Agent Skills]
-    end
-    
-    subgraph "Storage & Streaming"
-        MemoryM --> MStores[📦 Memory Backends <br/> Redis, DB, Mongo]
-        EventM --> EStores[📈 Event Backends <br/> Redis Stream, memory]
-    end
-    
-    LLM --> Providers[☁️ AI Cloud / Local Models]
+graph TD
+    App["User application"] --> Agent["OmniCoreAgent facade"]
+    Agent --> Runtime["Agent runtime construction"]
+    Runtime --> Loop["ReAct loop"]
+    Runtime --> Tools["Tool runtime"]
+    Runtime --> State["State services"]
+    Runtime --> Harness["Harness capabilities"]
+
+    Loop --> Model["LiteLLM model call"]
+    Loop --> Parser["Custom tool-call parser"]
+    Parser --> Batch["Parallel tool batch runner"]
+    Batch --> Observation["Observation pipeline"]
+    Observation --> Loop
+
+    Tools --> Local["Local ToolRegistry"]
+    Tools --> MCP["MCP tools"]
+    Tools --> WorkspaceTools["Workspace file tools"]
+    Tools --> SkillTools["Skill tools"]
+    Tools --> SubagentTools["Subagent tools"]
+    Tools --> Retrieval["BM25 tool retrieval"]
+
+    State --> Memory["Memory router"]
+    State --> Events["Event router"]
+    State --> Workspace["Workspace storage"]
+
+    Harness --> Context["Context management"]
+    Harness --> Offload["Tool output offload"]
+    Harness --> Guardrails["Guardrails"]
+    Harness --> Serve["OmniServe"]
 ```
 
 ---
 
-## Core Layers
-
-### 1. The Reasoning Layer (ReAct)
-The heart of OmniCoreAgent is its implementation of the **ReAct (Reason + Act)** pattern. Instead of a single completion, the agent engages in a loop:
-- **Think**: Analyze context and user intent.
-- **Act**: Call tools or sub-agents to gather info or perform actions.
-- **Observe**: Read tool outputs and update internal state.
-- **Answer**: Provide the terminal response once the goal is achieved.
-
-### 2. The Storage Layer (Memory & Events)
-OmniCoreAgent decouples data persistence from reasoning logic.
-- **Memory Router**: Manages conversation history. It supports multiple backends (Redis, PostgreSQL, etc.) and can switch between them at runtime.
-- **Event Router**: Handles real-time telemetry. Every thought and action is emitted as a structured event.
-
-### 3. The Connectivity Layer (MCP & Local)
-The framework provides a unified interface for all external actions:
-- **MCP Tool Transport**: Connects external MCP tool servers via stdio, SSE, or Streamable HTTP.
-- **Tool Registry**: A decorator-driven system for registering Python functions.
-- **BM25 Retrieval**: A lexical search layer that filters thousands of tools down to a manageable context for the LLM.
-
----
-
-## Data Flow: Processing a Request
+## Request Flow
 
 <Steps>
-  <Step title="Initialization">
-    The agent loads its system instructions and tool indexes.
+  <Step title="Application calls run()">
+    The user application calls `agent.run(query, session_id=...)`. The runtime
+    loads session state and prepares the prompt for the current request.
   </Step>
-  <Step title="User Input">
-    A `run(query, session_id)` call triggers the workflow.
+  <Step title="Prompt and tool context are assembled">
+    OmniCoreAgent builds the system prompt from the base instruction, harness
+    rules, available tools, workspace guidance, memory policy, subagent policy,
+    and BM25 tool retrieval results when enabled.
   </Step>
-  <Step title="Context Retrieval">
-    The Memory Router fetches previous messages for the session.
+  <Step title="The model reasons">
+    Before every LLM call, the runtime checks whether context management should
+    trigger. If enabled and the configured threshold is crossed, it truncates or
+    summarizes the message history before LiteLLM sends the prompt to the
+    provider. The model returns either a final answer or one or more tool calls
+    using OmniCoreAgent's tool-call contract.
   </Step>
-  <Step title="Tool Discovery">
-    If advanced tool use is enabled, BM25 finds the top relevant tools for the current query.
+  <Step title="Tool calls are parsed and resolved">
+    The parser extracts tool calls. The resolver maps each call to the right
+    executor: local Python tool, MCP tool, skill, workspace tool, or harness tool.
   </Step>
-  <Step title="LLM Interaction">
-    The reasoning loop begins. LiteLLM routes prompts to the configured provider.
+  <Step title="Independent tools run as a batch">
+    The batch runner executes the resolved tools concurrently with a per-tool
+    timeout. Successes and failures are collected together.
   </Step>
-  <Step title="Execution">
-    If the LLM requests a tool, the Tool Orchestrator executes it (local or remote).
+  <Step title="Results become one observation">
+    The observation pipeline normalizes the batch result, applies guardrails,
+    offloads large payloads to the active workspace when configured, and creates the
+    observation text that returns to the model.
   </Step>
-  <Step title="Event Emission">
-    Throughout the process, the Event Router streams progress updates.
+  <Step title="Loop detection checks progress">
+    Tool-call signatures are recorded so the runtime can detect repeated calls or
+    repeated tool interaction patterns beyond max step
+    limits.
   </Step>
-  <Step title="Finalization">
-    The agent returns the response and session ID to the application.
+  <Step title="The loop continues or answers">
+    The model receives the structured observation and either continues with more
+    tool work or returns the final response.
   </Step>
 </Steps>
 
 ---
 
-## Enterprise Features
+## Core Layers
 
-| Feature | Architectural Implementation |
-|---------|------------------------------|
-| **Multi-Tenancy** | Session IDs isolate conversation states across different users. |
-| **Observability** | Native event streaming, in-house trace summaries, and Redis Stream event logging. |
-| **Fault Tolerance**| Built-in retries for tool calls and automatic connection recovery for MCP. |
-| **Scalability** | Distributed memory backends allow agents to scale horizontally across servers. |
+### 1. Public Facade
+
+`OmniCoreAgent` is the API application builders use. It owns the user-facing
+constructor, `run()`, MCP connection helpers, history helpers, runtime switching,
+metrics, and cleanup.
+
+The facade should stay thin. Construction and runtime behavior live in dedicated
+modules so the agent entry point remains easy to read.
+
+### 2. Runtime Construction
+
+The runtime construction layer normalizes:
+
+- model configuration
+- MCP tool configuration
+- agent configuration
+- memory and event routers
+- workspace configuration
+- harness capability setup
+
+This is where defaults are resolved. For example, workspace files are enabled by
+default, context management and tool offload are disabled by default, and enabling
+subagents forces workspace files on.
+
+### 3. ReAct Loop
+
+The loop controls the actual agent execution:
+
+```text
+messages -> model -> tool calls -> batch execution -> observation -> model
+```
+
+The loop is also where max steps, request limits, token limits, context
+management, memory updates, and final response handling are enforced. Context
+management runs before the model call, so a configured token budget reduces the
+prompt before the provider context window is hit.
+
+### 4. Tool Runtime
+
+Tools come from several sources but are exposed to the model through one runtime
+view:
+
+| Source | Purpose |
+|--------|---------|
+| Local tools | Application-owned Python functions registered with `ToolRegistry`. |
+| MCP tools | External tool servers over stdio, SSE, or Streamable HTTP. |
+| Workspace tools | File operations for notes, scratchpads, artifacts, and offloads. |
+| Skills | Packaged capabilities implemented in Python, Bash, or Node.js. |
+| Subagent tools | Harness tools that let the lead agent spawn focused workers. |
+| BM25 retrieval | Optional tool filtering when the full tool set is too large for the prompt. |
+
+The model should not need to know where a tool came from. The resolver maps tool
+names to the right executor.
+
+### 5. Parallel Batch Runner
+
+The batch runner is responsible for executing all tool calls from a model step
+together:
+
+- assigns stable tool call IDs
+- emits start/result/error events
+- runs calls concurrently
+- applies the configured timeout
+- preserves individual success and failure results
+- passes the combined result into the observation pipeline
+
+This layer is one of the core differences between OmniCoreAgent and a basic
+sequential tool loop.
+
+### 6. Observation Pipeline
+
+The observation pipeline protects the next reasoning step from raw, noisy tool
+output.
+
+```text
+raw tool results
+  -> normalized tool result objects
+  -> guardrail screening
+  -> workspace offload when configured
+  -> compact observation text
+```
+
+The model gets enough information to continue the task and a workspace reference
+when a large payload was offloaded.
+
+### 7. State Services
+
+State is split by responsibility:
+
+| Service | Responsibility |
+|---------|----------------|
+| Memory router | Conversation/session history. |
+| Event router | Runtime events for runs, tool calls, streaming, and service integrations. |
+| Workspace storage | Files used by agents, subagents, tools, artifacts, scratchpads, and offloaded payloads. |
+
+Workspace storage is separate from memory storage. Memory stores conversation
+state. Workspace stores files. A project can use Redis for memory and local disk,
+S3, or R2 for workspace files.
+
+### 8. Serving Layer
+
+OmniServe wraps an OmniCoreAgent instance with production HTTP/SSE boundaries:
+
+- app lifecycle
+- request serialization
+- streaming route helpers
+- health and metrics routes
+- CORS and error middleware
+- shared server state
+
+The dependency points one way: OmniServe wraps the agent runtime, while the agent
+runtime stays independent of the serving package.
 
 ---
 
-<Tip>
-This modular design allows you to use OmniCoreAgent as a lightweight local library or as the backbone of a high-scale, distributed AI platform.
-</Tip>
+## Design Invariants
+
+These rules keep the architecture clean:
+
+- MCP connects external MCP server tools into OmniCoreAgent's tool runtime.
+  Those MCP tools are resolved and executed beside local tools, workspace tools,
+  skills, and harness tools.
+- Workspace storage is the only filesystem surface for harness files: notes,
+  scratchpads, artifacts, subagent output, and tool offloads.
+- Memory storage and workspace storage are different concepts and should not
+  share naming that makes users confuse them.
+- Tool output should not go straight to the model. It must pass through the
+  observation pipeline.
+- Subagents must write useful output into the workspace so the lead agent can
+  inspect it later.
+- Optional production backends belong behind routers or storage interfaces, not
+  inside the root agent class.
+- Public docs should separate default behavior from opt-in capability.
+
+---
+
+## Runtime Boundaries
+
+OmniCoreAgent is the in-process agent harness. The surrounding production
+boundaries are handled by the layer designed for that job:
+
+- Use **OmniServe** when you need REST/SSE access to an agent.
+- Use **OmniDaemon** when you need event-driven, supervised, process-isolated
+  agents running as autonomous infrastructure services.
+- Use your own application infrastructure when you only need a direct script or a
+  direct function call around one model request.
+
+This separation keeps OmniCoreAgent focused: it builds the agent harness cleanly,
+then integrates with the right outer runtime when the deployment needs it.

--- a/docs/core-concepts/context-engineering.mdx
+++ b/docs/core-concepts/context-engineering.mdx
@@ -1,107 +1,190 @@
 ---
 title: Context Engineering
-description: 'Dual-layer context management — never hit token limits again'
+description: 'Automatic context control and workspace-backed tool output offloading'
 icon: 'brain-circuit'
 ---
 
-# Context Engineering System
+# Context Engineering
 
-OmniCoreAgent implements **state-of-the-art context engineering** inspired by patterns from Anthropic and Cursor. This dual-layer approach ensures your agents never hit token limits — even during marathon coding sessions or multi-step research tasks.
+OmniCoreAgent has three context-control layers that work together:
+
+| Layer | Scope | Purpose | Default |
+|-------|-------|---------|---------|
+| **Session memory** | Across `agent.run()` calls | Controls how much conversation history is loaded for a session. | On through the memory router |
+| **Agent loop context management** | Inside one `agent.run()` loop | Checks active messages before every model call and reduces them before the configured budget is exceeded. | Off until enabled |
+| **Tool output offloading** | Individual tool responses | Moves large tool outputs into workspace artifacts and keeps only a preview in the prompt. | Off until enabled |
+
+When agent loop context management is enabled and configured with a budget below
+your model's real context window, OmniCoreAgent acts before the provider context
+limit is hit. The runtime checks context before the LLM call, not after an error.
+
+```text
+active messages
+  -> context threshold check
+  -> truncate or summarize+truncate when needed
+  -> model call
+```
+
+This is why long tasks can keep moving without waiting for the provider to reject
+an oversized prompt.
 
 ---
 
-## How the Two Layers Work Together
+## Layer 1: Session Memory
 
-| Layer | Scope | What It Manages | When It Triggers |
-|-------|-------|-----------------|------------------|
-| **Context Management** | Agent loop messages | User/Assistant conversation, tool call history | When context exceeds `threshold_percent` of limit |
-| **Tool Offloading** | Individual tool responses | Large API responses, file contents, search results | When response exceeds `threshold_tokens` |
+Session memory decides what historical messages are loaded when a new
+`agent.run()` starts. This is the cross-request layer.
+
+```python
+agent = OmniCoreAgent(
+    name="assistant",
+    system_instruction="You are helpful.",
+    model_config={"provider": "openai", "model": "gpt-4o"},
+    agent_config={
+        "memory_config": {
+            "mode": "sliding_window",
+            "value": 10000,
+            "summary": {"enabled": False},
+        }
+    },
+)
+```
+
+Use persistent memory backends such as Redis, SQL, MongoDB, or SQLite when
+session history must survive process restarts.
 
 ---
 
-## Layer 1: Agent Loop Context Management
+## Layer 2: Agent Loop Context Management
 
-Prevent token exhaustion during long-running tasks with automatic context management. When enabled, the agent monitors context size and applies truncation or summarization when thresholds are exceeded.
+Agent loop context management runs inside the ReAct loop. Before each model call,
+`OmniCoreAgent` asks the context manager whether the current messages crossed the
+configured threshold. If yes, it reduces the message list before the LLM request
+is sent.
 
 ```python
 agent_config = {
     "context_management": {
         "enabled": True,
-        "mode": "token_budget",  # or "sliding_window"
-        "value": 100000,  # Max tokens (token_budget) or max messages (sliding_window)
-        "threshold_percent": 75,  # Trigger at 75% of limit
+        "mode": "token_budget",          # or "sliding_window"
+        "value": 100000,                 # token budget or message count
+        "threshold_percent": 75,
         "strategy": "summarize_and_truncate",  # or "truncate"
-        "preserve_recent": 4,  # Always keep last N messages
+        "preserve_recent": 6,
     }
 }
 ```
+
+With the config above, management triggers around 75,000 tokens. If the selected
+model has a larger context window, the harness reduces context before the model
+request reaches the provider limit.
+
+### What Is Preserved
+
+| Part | Behavior |
+|------|----------|
+| System prompt | Always preserved. |
+| Recent messages | Preserved according to `preserve_recent`. |
+| Middle history | Truncated, or summarized then truncated, depending on strategy. |
+| Summary metadata | Added when `summarize_and_truncate` creates a context summary. |
 
 ### Modes
 
 | Mode | Description | Best For |
 |------|-------------|----------|
-| `token_budget` | Manage by total token count | Cost control, API limits |
-| `sliding_window` | Manage by message count | Predictable context size |
+| `token_budget` | Manage context by estimated token count. | Provider context limits and cost control. |
+| `sliding_window` | Manage context by message count. | Predictable, low-latency history windows. |
 
 ### Strategies
 
-| Strategy | Behavior | Trade-off |
+| Strategy | Behavior | Trade-Off |
 |----------|----------|-----------|
-| `truncate` | Drop oldest messages | Fast, no extra LLM calls |
-| `summarize_and_truncate` | Summarize then drop | Preserves context, adds latency |
+| `truncate` | Drop older middle messages while preserving system and recent messages. | Fast and deterministic. |
+| `summarize_and_truncate` | Summarize older middle history, insert a summary message, then preserve recent messages. | Keeps more intent, adds an LLM call and latency. |
 
 ---
 
-## Layer 2: Tool Response Offloading
+## Layer 3: Tool Output Offloading
 
-Large tool responses are automatically saved to the workspace `artifacts/` area, with only a **preview** in context. The agent can retrieve full content on demand using built-in artifact tools.
+Tool offloading handles large individual tool responses. It keeps the agent from
+burning context on a full payload when a preview and a file reference are enough
+for the next reasoning step.
 
 ```python
 agent_config = {
     "tool_offload": {
         "enabled": True,
-        "threshold_tokens": 500,  # Offload responses > 500 tokens
-        "max_preview_tokens": 150  # Show first 150 tokens in context
+        "threshold_tokens": 500,
+        "threshold_bytes": 2000,
+        "max_preview_tokens": 150,
+        "max_preview_lines": 10,
     }
 }
 ```
 
-### Token Savings
+When a tool result crosses the configured threshold, OmniCoreAgent writes the
+full payload to the active workspace `artifacts/` area. The observation sent to
+the model contains the preview and the artifact reference.
 
-| Tool Response | Without Offloading | With Offloading | Savings |
-|---------------|-------------------|-----------------|---------|
-| Web search (50 results) | ~10,000 tokens | ~200 tokens | **98%** |
-| Large API response | ~5,000 tokens | ~150 tokens | **97%** |
-| File read (1000 lines) | ~8,000 tokens | ~200 tokens | **97%** |
+```text
+large tool result
+  -> workspace artifact
+  -> preview + artifact reference in the observation
+```
 
-### Built-in Artifact Tools
+The artifact uses the same workspace backend as the rest of the agent: local,
+S3, or R2.
 
-Automatically available when offloading is enabled:
+### Built-In Artifact Tools
+
+Artifact tools are available when offloading is enabled:
 
 | Tool | Purpose |
 |------|---------|
-| `read_artifact(artifact_id)` | Read full content when needed |
-| `tail_artifact(artifact_id, lines)` | Read last N lines (great for logs) |
-| `search_artifact(artifact_id, query)` | Search within large responses |
-| `list_artifacts()` | See all offloaded artifacts in current session |
+| `read_artifact` | Read the full offloaded payload. |
+| `tail_artifact` | Read the last lines of an artifact, useful for logs. |
+| `search_artifact` | Search inside an offloaded payload. |
+| `list_artifacts` | List artifacts available in the current workspace/session scope. |
 
 ---
 
-## Combined Power
+## Full Context Configuration
 
-Enable both for maximum efficiency:
+Use all layers together for long-running research, coding, data, and operational
+agents:
 
 ```python
 agent = OmniCoreAgent(
     name="research_agent",
+    system_instruction=(
+        "Use workspace files and artifact references for long tasks. "
+        "Read artifacts only when the full payload is needed."
+    ),
+    model_config={"provider": "openai", "model": "gpt-4o"},
     agent_config={
-        "context_management": {"enabled": True, "strategy": "summarize_and_truncate"},
-        "tool_offload": {"enabled": True, "threshold_tokens": 500}
-    }
+        "memory_config": {
+            "mode": "sliding_window",
+            "value": 10000,
+        },
+        "context_management": {
+            "enabled": True,
+            "mode": "token_budget",
+            "value": 100000,
+            "threshold_percent": 75,
+            "strategy": "summarize_and_truncate",
+            "preserve_recent": 6,
+        },
+        "tool_offload": {
+            "enabled": True,
+            "threshold_tokens": 500,
+            "threshold_bytes": 2000,
+        },
+    },
 )
-# Result: Agents that can run indefinitely without token exhaustion
 ```
 
 <Tip>
-Enable both layers for long-running tasks (research, multi-step workflows) where context or tool responses can grow unbounded.
+Set `context_management.value` to a budget below your model's real context
+window. OmniCoreAgent checks the budget before each model call and reduces the
+prompt when the threshold is crossed.
 </Tip>

--- a/docs/core-concepts/mcp.mdx
+++ b/docs/core-concepts/mcp.mdx
@@ -1,14 +1,16 @@
 ---
-title: MCP Client
-description: 'Built-in Model Context Protocol support — stdio, SSE, and Streamable HTTP'
+title: MCP Tools
+description: 'Connect MCP server tools over stdio, SSE, and Streamable HTTP'
 icon: 'plug'
 ---
 
-# Built-in MCP Client
+# MCP Tools
 
-Connect to MCP-compatible tool servers with support for multiple transport protocols and authentication methods. OmniCoreAgent treats MCP as an external tool connector, matching the same runtime model as local tools.
+MCP connects external MCP server tools into OmniCoreAgent's tool runtime.
 
-OmniCoreAgent intentionally loads MCP tools only. It does not load MCP resources, prompts, or sampling callbacks into the agent runtime.
+Those tools run beside local Python tools, workspace tools, artifact tools,
+skills, subagent tools, and other harness tools. The agent sees one available
+tool surface; the runtime handles where each tool came from.
 
 ---
 
@@ -36,9 +38,9 @@ Process communication with local CLI tools:
     "transport_type": "streamable_http",
     "url": "http://localhost:8080/mcp",
     "headers": {
-        "Authorization": "Bearer your-token"  # optional
+        "Authorization": "Bearer your-token"
     },
-    "timeout": 60  # optional
+    "timeout": 60
 }
 
 # With OAuth 2.0 (auto-starts callback server on localhost:3000)
@@ -60,10 +62,10 @@ Process communication with local CLI tools:
     "transport_type": "sse",
     "url": "http://localhost:3000/sse",
     "headers": {
-        "Authorization": "Bearer token"  # optional
+        "Authorization": "Bearer token"
     },
-    "timeout": 60,  # optional
-    "sse_read_timeout": 120  # optional
+    "timeout": 60,
+    "sse_read_timeout": 120
 }
 ```
 
@@ -119,5 +121,7 @@ result = await agent.run("List all Python files and get latest commits")
 | `sse` | Real-time data, streaming | Bearer token, custom headers |
 
 <Tip>
-Use MCP when you need to connect to external tools and services. Choose `stdio` for local CLI tools, `streamable_http` for REST APIs, and `sse` for real-time streaming data.
+Use MCP when the agent needs tools hosted by an MCP server. Choose `stdio` for
+local CLI servers, `streamable_http` for HTTP MCP servers, and `sse` for
+Server-Sent Events transports.
 </Tip>

--- a/docs/core-concepts/overview.mdx
+++ b/docs/core-concepts/overview.mdx
@@ -1,29 +1,89 @@
 ---
 title: OmniCoreAgent
-description: 'The primary entry point — create and manage AI agents with built-in memory, events, and tool orchestration'
+description: 'The primary agent harness API: model, loop, tools, memory, workspace, guardrails, events, and runtime options'
 icon: 'robot'
 ---
 
 # OmniCoreAgent
 
-The `OmniCoreAgent` class is the primary entry point for the framework. It provides a high-level, user-friendly API for creating and managing AI agents with built-in memory, events, and tool orchestration.
+`OmniCoreAgent` is the main entry point for the harness. It wraps a model with
+the runtime pieces needed to execute real tasks: a reasoning loop, tool routing,
+parallel tool batches, structured observations, memory, workspace files,
+guardrails, events, and production harness extensions.
+
+Use it when you want one agent object that starts small and grows into a
+production runtime without rebuilding the application around a different API.
+
+For the full implementation-backed map of what OmniCoreAgent adds around the
+model, read [Agent Harness](/docs/core-concepts/agent-harness).
 
 ---
 
-## Quick Start
+## Minimal Agent
 
 ```python
+import asyncio
 from omnicoreagent import OmniCoreAgent
 
-agent = OmniCoreAgent(
-    name="my_assistant",
-    system_instruction="You are a helpful assistant.",
-    model_config={"provider": "openai", "model": "gpt-4o"}
-)
+async def main():
+    agent = OmniCoreAgent(
+        name="my_assistant",
+        system_instruction="You are a helpful assistant.",
+        model_config={"provider": "openai", "model": "gpt-4o"},
+    )
 
-result = await agent.run("Hello!")
-print(result["response"])
+    result = await agent.run("Hello!")
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
 ```
+
+This gives you the core harness loop, session memory, workspace files,
+guardrails, events, metrics, and cleanup lifecycle. Heavier capabilities are
+enabled explicitly through `agent_config` or installable extras.
+
+---
+
+## What The Harness Owns
+
+| Area | Responsibility |
+|------|----------------|
+| **Reasoning loop** | Builds the prompt, calls the model, parses tool calls, observes results, and stops with a final response. |
+| **Tool runtime** | Combines local tools, MCP tools, skills, workspace tools, subagent tools, and BM25 retrieval when enabled. |
+| **Parallel execution** | Runs independent tool calls in one batch and returns a single structured observation. |
+| **Observation pipeline** | Normalizes tool outputs, applies guardrails, and offloads large results to workspace files when configured. |
+| **Context management** | Checks message history before each model call and automatically truncates or summarizes when the configured budget threshold is crossed. |
+| **Memory** | Stores and retrieves session history through the configured memory router. |
+| **Workspace** | Provides agent-accessible files for notes, scratchpads, artifacts, subagent output, and tool offloads. |
+| **Events** | Emits runtime events for runs, tool calls, streaming, and server integrations. |
+| **Serving** | Runs the agent through OmniServe when you need REST/SSE endpoints. |
+
+---
+
+## Defaults And Opt-In Capabilities
+
+OmniCoreAgent keeps the default path light. Production features are enabled by
+configuration or installed as extras when the workload needs them.
+
+| Capability | Default | How To Enable |
+|------------|---------|---------------|
+| Harness loop | On | Always part of `OmniCoreAgent`. |
+| Session memory | On | Uses the default memory router unless you pass another one. |
+| Workspace files | On | `enable_workspace_files=True` by default. |
+| Guardrails | On | `guardrail_mode="full"` by default. |
+| Context management | Off | `agent_config={"context_management": {"enabled": True}}` |
+| Tool output offload | Off | `agent_config={"tool_offload": {"enabled": True}}` |
+| BM25 tool retrieval | Off | `agent_config={"enable_advanced_tool_use": True}` |
+| Dynamic subagents | Off | `agent_config={"enable_subagents": True}` |
+| Agent skills | Off | `agent_config={"enable_agent_skills": True}` |
+| Redis/Postgres/MongoDB/S3/R2 | Installable extras | Install the matching package extra and configure the backend. |
+
+<Tip>
+When dynamic subagents are enabled, workspace files are enabled automatically.
+Subagents need a shared file surface for outputs, todos, notes, and task
+artifacts that the lead agent reads back.
+</Tip>
 
 ---
 
@@ -31,46 +91,48 @@ print(result["response"])
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `name` | `str` | Name of the agent (used for session tracking and logging). |
-| `system_instruction` | `str` | The high-level objective or persona for the agent. |
-| `model_config` | `dict` or `ModelConfig` | Configuration for the LLM provider and model. |
-| `mcp_tools` | `list` | (Optional) List of MCP tool configurations. |
-| `local_tools` | `ToolRegistry` or `list` | (Optional) Custom Python functions or application-owned tools. |
-| `sub_agents` | `list` | (Optional) Specialized agents the parent can delegate to. |
-| `agent_config` | `dict` or `AgentConfig` | (Optional) Settings for reasoning steps, timeouts, etc. |
-| `memory_router` | `MemoryRouter` | (Optional) Custom memory backend (defaults to in-memory). |
-| `event_router` | `EventRouter` | (Optional) Custom event backend (defaults to in-memory). |
+| `name` | `str` | Agent name used for session tracking, events, metrics, and logs. |
+| `system_instruction` | `str` | The high-level role, objective, or policy for the agent. |
+| `model_config` | `dict` or `ModelConfig` | LLM provider and model configuration. |
+| `mcp_tools` | `list` | Optional MCP tool server definitions. OmniCoreAgent loads tools from these servers. |
+| `local_tools` | `ToolRegistry` or `list` | Optional Python/application-owned tools. |
+| `sub_agents` | `list` | Optional predefined agents available for delegation. |
+| `agent_config` | `dict` or `AgentConfig` | Runtime behavior: steps, timeouts, context, offload, subagents, skills, workspace. |
+| `memory_router` | `MemoryRouter` | Optional conversation memory backend. Defaults to in-memory. |
+| `event_router` | `EventRouter` | Optional event backend. Defaults to in-memory. |
 
 ---
 
-## Production Agent (Full Configuration)
+## Full Harness Configuration
 
 ```python
-from omnicoreagent import OmniCoreAgent, ToolRegistry, MemoryRouter, EventRouter
+from omnicoreagent import EventRouter, MemoryRouter, OmniCoreAgent, ToolRegistry
+
+tools = ToolRegistry()
 
 agent = OmniCoreAgent(
     name="production_agent",
-    system_instruction="You are a production agent.",
+    system_instruction="You are a production research agent.",
     model_config={"provider": "openai", "model": "gpt-4o"},
-    local_tools=tool_registry,
+    local_tools=tools,
     mcp_tools=[...],
     memory_router=MemoryRouter("redis"),
     event_router=EventRouter("redis_stream"),
     agent_config={
         "max_steps": 20,
+        "tool_call_timeout": 30,
         "enable_advanced_tool_use": True,
         "enable_subagents": True,
         "enable_agent_skills": True,
-        # Conversation memory with summarization
+        "enable_workspace_files": True,
         "memory_config": {
             "mode": "sliding_window",
-            "value": 10,
+            "value": 10000,
             "summary": {
                 "enabled": True,
                 "retention_policy": "summarize",
             },
         },
-        # Context management for long conversations
         "context_management": {
             "enabled": True,
             "mode": "token_budget",
@@ -79,12 +141,12 @@ agent = OmniCoreAgent(
             "strategy": "summarize_and_truncate",
             "preserve_recent": 6,
         },
-        "tool_offload": {"enabled": True},
-        # Prompt injection guardrails
-        "guardrail_config": {
+        "tool_offload": {
             "enabled": True,
-            "strict_mode": True,
+            "threshold_tokens": 500,
+            "threshold_bytes": 2000,
         },
+        "guardrail_config": {"strict_mode": True},
     },
 )
 ```
@@ -95,24 +157,20 @@ agent = OmniCoreAgent(
 
 ### `run()`
 
-Execute a task with the agent. Supports session continuity.
+Execute a task with the agent. Pass a `session_id` when you want continuity
+across calls.
 
 ```python
 result = await agent.run("What is the weather today?", session_id="user_1")
-print(result['response'])
+print(result["response"])
 ```
 
-- **Query**: The user's input string.
-- **Session ID**: (Optional) Provide a unique ID to maintain conversation history.
-- **Returns**: A dictionary containing `response`, `session_id`, `agent_name`, and `metric`.
-
-<Tip>
-Each `agent.run()` call returns a `metric` field containing fine-grained usage (tokens, time) for that specific request.
-</Tip>
+`run()` returns a dictionary with the response, session ID, agent name, and
+request metrics.
 
 ### `connect_mcp_servers()`
 
-Establishes connections to all configured MCP servers.
+Connect all configured MCP tool servers.
 
 ```python
 await agent.connect_mcp_servers()
@@ -120,7 +178,8 @@ await agent.connect_mcp_servers()
 
 ### `list_all_available_tools()`
 
-Returns a list of all tools currently available (both MCP and local).
+Return all currently available tools from MCP, local tools, skills, workspace
+tools, and harness tools.
 
 ```python
 tools = await agent.list_all_available_tools()
@@ -128,7 +187,7 @@ tools = await agent.list_all_available_tools()
 
 ### `cleanup()`
 
-Closes MCP connections and releases agent runtime state.
+Close MCP connections and release runtime state.
 
 ```python
 await agent.cleanup()
@@ -138,84 +197,41 @@ await agent.cleanup()
 
 ## Session Management
 
-### Retrieve History
-
 ```python
 history = await agent.get_session_history("user_1")
-for msg in history:
-    print(f"{msg['role']}: {msg['content']}")
-```
 
-### Clear History
-
-```python
-# Clear specific session
 await agent.clear_session_history("user_1")
-
-# Clear all history for this agent
-await agent.clear_session_history()
+await agent.clear_session_history()  # clear all sessions for this agent
 ```
 
 ---
 
 ## Runtime Switching
 
-Switch memory and event backends at runtime without restarting:
+Switch configured memory and event backends without rebuilding the agent object:
 
 ```python
-# Switch conversation memory stores
 await agent.switch_memory_store("mongodb")
-await agent.switch_memory_store("database")  # PostgreSQL/MySQL/SQLite
+await agent.switch_memory_store("database")
 await agent.switch_memory_store("redis")
 
-# Switch event backends
 await agent.switch_event_store("redis_stream")
 
-# Check current stores
 await agent.get_memory_store_type()
 await agent.get_event_store_type()
 ```
 
 ---
 
-## Complete API Reference
-
-```python
-# Execution
-await agent.run(query)                          # Execute task
-await agent.run(query, session_id="user_1")     # With session context
-
-# MCP
-await agent.connect_mcp_servers()               # Connect MCP tools
-await agent.cleanup_mcp_servers()               # Cleanup MCP without removing agent
-await agent.list_all_available_tools()          # List all tools
-
-# Memory
-await agent.switch_memory_store("mongodb")       # Switch backend at runtime
-await agent.get_session_history(session_id)      # Retrieve conversation history
-await agent.clear_session_history(session_id)    # Clear history
-await agent.get_memory_store_type()              # Get current memory type
-
-# Events
-await agent.switch_event_store("redis_stream")   # Switch event backend
-await agent.get_events(session_id)               # Get event history
-await agent.get_event_store_type()               # Get current event type
-
-# Metrics
-await agent.get_metrics()                        # Cumulative usage stats
-
-# Cleanup
-await agent.cleanup()                            # Full cleanup
-```
-
----
-
 ## Best Practices
 
-1. **Always Cleanup**: Use `await agent.cleanup()` to avoid orphan processes (especially for MCP).
-2. **Session IDs**: Use meaningful session IDs (e.g., user database IDs) to persist context across interactions.
-3. **Model Choice**: Use cheaper models (e.g., `gpt-4o-mini`) for simple tasks and powerful ones (e.g., `gpt-4o`) when complex reasoning is required.
-
-<Tip>
-OmniCoreAgent is your go-to for any AI task — from simple Q&A to complex multi-step workflows. Start here for any agent project.
-</Tip>
+- Use `await agent.cleanup()` when the application shuts down, especially if MCP
+  tools are connected.
+- Use stable `session_id` values, such as your user or task IDs, when you need
+  continuity.
+- Enable context management and tool offloading for long tasks, research agents,
+  coding agents, and agents that call large-output tools.
+- Enable BM25 retrieval when your tool list is too large to place fully in the
+  prompt.
+- Enable subagents when a task naturally splits into focused work units whose
+  outputs belong in the workspace for lead-agent synthesis.

--- a/docs/core-concepts/workspace-files.mdx
+++ b/docs/core-concepts/workspace-files.mdx
@@ -86,16 +86,16 @@ OmniCoreAgent exposes these tools for the `files/` area:
 
 ---
 
-## Production Features
+## Backend Behavior
 
 | Feature | Local | S3 | R2 |
 |---------|-------|----|-----|
-| Persistent across restarts | ✅ | ✅ | ✅ |
-| Multi-server access | ❌ | ✅ | ✅ |
-| Global CDN distribution | ❌ | ✅ | ✅ |
-| Zero egress fees | N/A | ❌ | ✅ |
-| Auto-retry on failure | ❌ | ✅ | ✅ |
-| Concurrent access safety | ✅ | ✅ | ✅ |
+| Persists across process restarts | Yes | Yes | Yes |
+| Works without cloud credentials | Yes | No | No |
+| Shared across multiple machines | No | Yes | Yes |
+| Fits single-server development | Yes | Yes | Yes |
+| Fits distributed deployments | Limited | Yes | Yes |
+| Uses the same workspace tools | Yes | Yes | Yes |
 
 ---
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,48 +1,55 @@
 ---
 title: Quick Start
-description: 'Build your first AI agent in under 30 seconds'
+description: 'Build your first OmniCoreAgent and understand what the harness gives you'
 icon: 'bolt'
 ---
 
 # Quick Start
 
-Get your first AI agent running in under 30 seconds with OmniCoreAgent.
+This guide creates the smallest useful OmniCoreAgent: one model, one harness
+runtime, and one task.
 
-The quick start uses the light core install. Production backends such as Redis, PostgreSQL, MongoDB, S3/R2, OmniServe, and background scheduling are optional extras you add only when needed.
+The core install stays light. Redis, PostgreSQL, MongoDB, S3/R2, OmniServe, and
+background scheduling install as extras when the agent needs them.
 
 <Steps>
+  <Step title="Install">
+    ```bash
+    pip install omnicoreagent
+    ```
+  </Step>
+
   <Step title="Set API Key">
     Create a `.env` file in your project directory:
 
     ```bash
-    echo "LLM_API_KEY=your_openai_api_key_here" > .env
+    echo "LLM_API_KEY=your_api_key_here" > .env
     ```
 
     <Tip>
-    You can use keys from OpenAI, Anthropic, Google Gemini, Groq, DeepSeek, and more. See [Universal Model Support](/docs/how-to-guides/models).
+    Provider-specific keys such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+    `GEMINI_API_KEY`, or `GROQ_API_KEY` are supported. See
+    [Model Support](/docs/how-to-guides/models).
     </Tip>
   </Step>
 
   <Step title="Create Your First Agent">
-    Create a file named `hello_agent.py`:
+    Create `hello_agent.py`:
 
     ```python
     import asyncio
     from omnicoreagent import OmniCoreAgent
 
     async def main():
-        # 1. Initialize the agent
         agent = OmniCoreAgent(
             name="my_agent",
             system_instruction="You are a helpful assistant.",
-            model_config={"provider": "openai", "model": "gpt-4o"}
+            model_config={"provider": "openai", "model": "gpt-4o"},
         )
 
-        # 2. Run a task
         result = await agent.run("Hello, what can you do?")
-        print(f"Agent Response: {result['response']}")
+        print(result["response"])
 
-        # 3. Cleanup
         await agent.cleanup()
 
     if __name__ == "__main__":
@@ -55,61 +62,127 @@ The quick start uses the light core install. Production backends such as Redis, 
     python hello_agent.py
     ```
 
-    **✅ That's it!** You just built an AI agent with session management, memory persistence, and error handling.
+    You now have an agent with the core harness loop, session memory, workspace
+    files, guardrails, events, metrics, and cleanup lifecycle.
   </Step>
 </Steps>
 
 ---
 
-## Adding Tools (MCP)
+## Add Local Tools
 
-OmniCoreAgent can connect to any MCP-compatible service. Here's how to add a filesystem tool:
+Local tools are normal Python functions registered through `ToolRegistry`.
+
+```python
+from omnicoreagent import OmniCoreAgent, ToolRegistry
+
+tools = ToolRegistry()
+
+@tools.register_tool("get_weather")
+def get_weather(city: str) -> dict:
+    """Get current weather for a city."""
+    return {"city": city, "temp": "22C", "condition": "Sunny"}
+
+agent = OmniCoreAgent(
+    name="weather_agent",
+    system_instruction="Use tools when they help answer the user.",
+    model_config={"provider": "openai", "model": "gpt-4o"},
+    local_tools=tools,
+)
+
+result = await agent.run("What's the weather in Tokyo?")
+```
+
+---
+
+## Add MCP Tools
+
+MCP servers are external tool providers. OmniCoreAgent connects to them and loads
+their tools into the same runtime view as local tools.
 
 ```python
 agent = OmniCoreAgent(
     name="fs_agent",
-    system_instruction="You can manage files.",
+    system_instruction="Inspect files when the task needs filesystem context.",
     model_config={"provider": "openai", "model": "gpt-4o"},
     mcp_tools=[
         {
             "name": "filesystem",
             "transport_type": "stdio",
             "command": "npx",
-            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
         }
-    ]
+    ],
 )
 
 await agent.connect_mcp_servers()
 result = await agent.run("List files in /tmp")
 ```
 
+<Note>
+MCP connects external MCP server tools into OmniCoreAgent's tool runtime. Those
+tools run beside local tools, workspace tools, artifact tools, skills, and
+harness tools.
+</Note>
+
 ---
 
-## Persistence with Session IDs
+## Turn On Heavier Harness Features
 
-Agents remember context when you provide a `session_id`:
+For longer tasks, enable the heavier harness features explicitly: automatic
+context control before each model call, tool output offloading into the
+workspace, BM25 tool retrieval, subagents, and skills.
 
 ```python
-# Session 1
-result1 = await agent.run("My name is Abiola.", session_id="user_123")
-
-# Session 2 (Agent remembers the name)
-result2 = await agent.run("What is my name?", session_id="user_123")
+agent = OmniCoreAgent(
+    name="research_agent",
+    system_instruction=(
+        "Use tools in parallel when the calls are independent. Write useful "
+        "notes and outputs to the workspace when the task is long."
+    ),
+    model_config={"provider": "openai", "model": "gpt-4o"},
+    local_tools=tools,
+    agent_config={
+        "max_steps": 20,
+        "context_management": {"enabled": True},
+        "tool_offload": {"enabled": True},
+        "enable_advanced_tool_use": True,
+        "enable_subagents": True,
+        "enable_agent_skills": True,
+    },
+)
 ```
+
+When `enable_subagents` is true, workspace files are enabled automatically so
+workers write outputs that the lead agent reads back.
+
+---
+
+## Persistence With Session IDs
+
+Agents keep continuity when you provide a stable `session_id`:
+
+```python
+await agent.run("My name is Abiola.", session_id="user_123")
+result = await agent.run("What is my name?", session_id="user_123")
+```
+
+The default memory backend is suitable for local development. Use Redis,
+PostgreSQL, MongoDB, or SQLite when the application needs persistence outside
+the current process.
 
 ---
 
 ## Next Steps
 
 <CardGroup cols={3}>
-  <Card title="Core Concepts" icon="brain" href="/docs/core-concepts/overview">
-    Deep dive into memory, events, and the agent API
+  <Card title="Architecture" icon="sitemap" href="/docs/core-concepts/architecture">
+    Understand the runtime layers and request flow.
   </Card>
-  <Card title="Agent Types" icon="users" href="/docs/core-concepts/sub-agents">
-    Build workflows and background agents
+  <Card title="Local Tools" icon="toolbox" href="/docs/core-concepts/local-tools">
+    Register Python functions as tools.
   </Card>
-  <Card title="Advanced Tools" icon="wand-magic-sparkles" href="/docs/how-to-guides/advanced-tools">
-    Scale to 1000+ tools with BM25 retrieval
+  <Card title="Configuration" icon="gear" href="/docs/how-to-guides/configuration">
+    Configure context, tool offload, memory, events, and workspace storage.
   </Card>
 </CardGroup>

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -6,7 +6,8 @@ icon: 'gear'
 
 # Configuration Guide
 
-OmniCoreAgent can be configured through environment variables, Python dictionaries, or specialized configuration objects.
+OmniCoreAgent supports configuration through environment variables, Python
+dictionaries, and specialized configuration objects.
 
 ---
 
@@ -17,17 +18,29 @@ Environment variables are the best way to manage sensitive data like API keys an
 ### LLM API Keys
 | Provider | Variable |
 |----------|----------|
+| Generic | `LLM_API_KEY` |
 | OpenAI | `OPENAI_API_KEY` |
 | Anthropic | `ANTHROPIC_API_KEY` |
 | Google Gemini | `GEMINI_API_KEY` |
 | Groq | `GROQ_API_KEY` |
 
-### Storage Backends
+### Memory Backends
 | Backend | Variable | Example |
 |---------|----------|---------|
 | **Redis** | `REDIS_URL` | `redis://localhost:6379/0` |
 | **SQL Database** | `DATABASE_URL` | `postgresql://user:pass@localhost:5432/db` |
 | **MongoDB** | `MONGODB_URI` | `mongodb://localhost:27017` |
+
+### Workspace Storage
+Workspace storage is separate from memory storage. Memory stores conversation
+history. Workspace storage stores files, scratchpads, artifacts, subagent
+outputs, and tool offloads.
+
+| Backend | Variables |
+|---------|-----------|
+| **Local** | `OMNICOREAGENT_WORKSPACE_BACKEND=local`, `OMNICOREAGENT_WORKSPACE_DIR=.omnicoreagent/workspace` |
+| **S3** | `OMNICOREAGENT_WORKSPACE_BACKEND=s3`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
+| **R2** | `OMNICOREAGENT_WORKSPACE_BACKEND=r2`, `R2_BUCKET_NAME`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` |
 
 ## 2. Agent Configuration
 
@@ -37,12 +50,12 @@ The `AgentConfig` handles the runtime behavior of the agent, such as reasoning s
 agent_config = {
     "tool_call_timeout": 30,         # Max seconds per tool execution
     "max_steps": 15,                 # Max reasoning loops per run()
-    "request_limit": 1000,           # Max LLM requests per session
-    "total_tokens_limit": 100000,    # Max total tokens per session
+    "request_limit": 0,              # 0 = unlimited
+    "total_tokens_limit": 0,         # 0 = unlimited
     "enable_subagents": True,        # Dynamic focused workers
-    "enable_workspace_files": True, # Default: workspace files for notes/logs/scratchpads
+    "enable_workspace_files": True,  # Default: workspace files for notes/logs/scratchpads
     "enable_agent_skills": True,     # Enable local skill discovery
-    "enable_advanced_tool_use": True,# Enable BM25 tool retrieval
+    "enable_advanced_tool_use": True, # Enable BM25 tool retrieval
     "context_management": {"enabled": True},
     "tool_offload": {"enabled": True}
 }
@@ -54,10 +67,11 @@ agent = OmniCoreAgent(
 ```
 
 When `enable_subagents` is true, OmniCoreAgent automatically enables workspace
-memory because spawned workers write output, todos, logs, and scratchpads into
+files because spawned workers write output, todos, logs, and scratchpads into
 the active workspace. For full harness-style workloads, pair dynamic subagents
-with context management and tool offloading so long-running tasks can stay fast
-and durable.
+with context management and tool offloading. Context management checks the prompt
+before each model call; tool offloading keeps large tool payloads in workspace
+artifacts instead of feeding the full payload back into the loop.
 
 ---
 
@@ -73,7 +87,7 @@ model_config = {
     "max_tokens": 4000,
     "top_p": 0.9,
     # Custom endpoint for self-hosted models
-    "api_base": "http://localhost:8000/v1" 
+    "api_base": "http://localhost:8000/v1"
 }
 ```
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,9 +15,14 @@ mode: 'wide'
   alt="OmniCoreAgent Dark"
 />
 
-## The Open Agent Harness for Production AI
+## The Open Agent Harness Built for Production
 
-**OmniCoreAgent** is a production-grade agent harness for building autonomous AI agents that persist, reason, use tools, manage context, and scale. Unlike frameworks that treat memory as an afterthought, OmniCoreAgent puts **State Management** at the center.
+**OmniCoreAgent** is a Python agent harness for building autonomous agents that
+reason, use tools, keep session memory, manage context, write workspace files,
+connect MCP server tools, spawn subagents, and run behind a REST/SSE API.
+
+The goal is direct: give builders the production pieces they otherwise patch
+around an LLM after the first demo starts breaking.
 
 ```bash
 pip install omnicoreagent
@@ -33,7 +38,36 @@ pip install "omnicoreagent[all]"
 
 ---
 
-## Get Started
+## Why It Exists
+
+OmniCoreAgent is built around real agent runtime problems:
+
+<CardGroup cols={2}>
+  <Card title="Parallel tool batches" icon="bolt">
+    The runtime supports independent tool calls in one batch, executes them
+    concurrently, and returns one structured observation.
+  </Card>
+  <Card title="Structured observations" icon="filter">
+    Tool results are parsed, formatted, guardrail-checked, and offloaded when
+    they cross the configured threshold before the model sees them.
+  </Card>
+  <Card title="Signature loop detection" icon="rotate">
+    The harness detects repeated tool signatures and repeated tool interaction
+    patterns beyond max-step exhaustion.
+  </Card>
+  <Card title="Workspace-backed context" icon="folder-tree">
+    Agents, subagents, tool offloads, notes, scratchpads, and artifacts share one
+    local, S3, or R2-backed workspace.
+  </Card>
+  <Card title="Automatic context control" icon="brain-circuit">
+    When enabled, the runtime checks context before each model call and acts
+    before the configured budget is exceeded.
+  </Card>
+</CardGroup>
+
+---
+
+## Start Building
 
 <CardGroup cols={2}>
   <Card
@@ -41,39 +75,27 @@ pip install "omnicoreagent[all]"
     icon="bolt"
     href="/docs/getting-started/quickstart"
   >
-    Build your first agent in under 30 seconds
+    Build your first OmniCoreAgent and run a task.
+  </Card>
+  <Card
+    title="Agent Harness"
+    icon="layer-group"
+    href="/docs/core-concepts/agent-harness"
+  >
+    Understand what OmniCoreAgent adds around the model.
   </Card>
   <Card
     title="Installation"
     icon="download"
     href="/docs/getting-started/installation"
   >
-    Install with pip, uv, or from source
-  </Card>
-</CardGroup>
-
----
-
-## Core Capabilities
-
-<CardGroup cols={3}>
-  <Card title="Multi-Tier Memory" icon="database" href="/docs/core-concepts/memory">
-    5 backends (Redis, PostgreSQL, MongoDB, SQLite, in-memory) with hot-swap at runtime
-  </Card>
-  <Card title="MCP Client" icon="plug" href="/docs/core-concepts/mcp">
-    Built-in Model Context Protocol — stdio, SSE, and Streamable HTTP transports
-  </Card>
-  <Card title="Context Engineering" icon="brain-circuit" href="/docs/core-concepts/context-engineering">
-    Dual-layer context management so agents never hit token limits
-  </Card>
-  <Card title="Agent Harness" icon="layer-group" href="/docs/core-concepts/sub-agents">
-    Dynamic subagents, workspace files, context management, and tool offloading
+    Install the core package or the extras your agent uses.
   </Card>
   <Card title="Local Tools" icon="toolbox" href="/docs/core-concepts/local-tools">
-    Register application-owned Python functions as agent tools
+    Register application-owned Python functions as tools.
   </Card>
-  <Card title="OmniServe" icon="server" href="/docs/how-to-guides/omniserve">
-    Production REST and SSE API server for OmniCoreAgent
+  <Card title="MCP Tools" icon="plug" href="/docs/core-concepts/mcp">
+    Connect external MCP servers over stdio, SSE, or Streamable HTTP.
   </Card>
 </CardGroup>
 
@@ -83,24 +105,39 @@ pip install "omnicoreagent[all]"
 
 ```python
 import asyncio
-from omnicoreagent import OmniCoreAgent
+from omnicoreagent import OmniCoreAgent, ToolRegistry
+
+tools = ToolRegistry()
+
+@tools.register_tool("search_web")
+def search_web(query: str) -> dict:
+    """Search the web for information."""
+    return {"results": [f"Result for: {query}"]}
+
+@tools.register_tool("read_file")
+def read_file(path: str) -> dict:
+    """Read a project file."""
+    return {"path": path, "content": f"Contents of {path}"}
 
 async def main():
     agent = OmniCoreAgent(
-        name="my_agent",
-        system_instruction="You are a helpful assistant.",
+        name="research_agent",
+        system_instruction=(
+            "Use tools in parallel when the calls are independent."
+        ),
         model_config={"provider": "openai", "model": "gpt-4o"},
-        mcp_tools=[{
-            "name": "filesystem",
-            "transport_type": "stdio",
-            "command": "npx",
-            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
-        }]
+        local_tools=tools,
+        agent_config={
+            "context_management": {"enabled": True},
+            "tool_offload": {"enabled": True},
+        },
     )
 
-    result = await agent.run("Summarize all .md files in /tmp", session_id="user_1")
+    result = await agent.run(
+        "Search for current agent papers and read notes.md. Do both at once "
+        "if neither depends on the other."
+    )
     print(result["response"])
-
     await agent.cleanup()
 
 asyncio.run(main())
@@ -108,25 +145,37 @@ asyncio.run(main())
 
 ---
 
-## Explore the Docs
+## Core Documentation
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+  <Card title="OmniCoreAgent" icon="robot" href="/docs/core-concepts/overview">
+    The main agent harness API and runtime capabilities.
+  </Card>
+  <Card title="Agent Harness" icon="layer-group" href="/docs/core-concepts/agent-harness">
+    The implementation-backed map of the runtime pieces around the model.
+  </Card>
   <Card title="Architecture" icon="sitemap" href="/docs/core-concepts/architecture">
-    Layered design — ReAct, Storage, and Connectivity
+    How the loop, tools, observations, memory, workspace, and serving layers fit.
   </Card>
-  <Card title="Event System" icon="signal-stream" href="/docs/core-concepts/events">
-    Real-time streaming for every tool call, thought, and message
+  <Card title="Memory" icon="database" href="/docs/core-concepts/memory">
+    Session history across in-memory, SQLite, Redis, PostgreSQL, and MongoDB.
   </Card>
-  <Card title="Workflows" icon="diagram-project" href="/docs/core-concepts/workflows">
-    Sequential, parallel, and router patterns for multi-agent tasks
+  <Card title="Context Engineering" icon="brain-circuit" href="/docs/core-concepts/context-engineering">
+    Context strategies plus tool-output offloading for long-running tasks.
   </Card>
-  <Card title="Model Support" icon="microchip" href="/docs/how-to-guides/models">
-    9+ providers — OpenAI, Anthropic, Gemini, Groq, DeepSeek, and more
+  <Card title="Workspace Files" icon="folder-tree" href="/docs/core-concepts/workspace-files">
+    Local, S3, or R2 files for notes, scratchpads, artifacts, and offloads.
   </Card>
-  <Card title="Runtime Visibility" icon="chart-line" href="/docs/how-to-guides/observability">
-    In-house agent traces, event streams, and runtime metrics
+  <Card title="Subagents" icon="users" href="/docs/core-concepts/sub-agents">
+    Dynamic focused workers that write outputs back into the workspace.
   </Card>
-  <Card title="Configuration" icon="gear" href="/docs/how-to-guides/configuration">
-    Environment variables, agent settings, and model configuration
+  <Card title="Guardrails" icon="shield" href="/docs/core-concepts/guardrails">
+    Prompt-injection screening inside the observation pipeline.
+  </Card>
+  <Card title="Events" icon="signal-stream" href="/docs/core-concepts/events">
+    Runtime events for runs, tool calls, and streaming integrations.
+  </Card>
+  <Card title="OmniServe" icon="server" href="/docs/how-to-guides/omniserve">
+    Run an OmniCoreAgent behind REST and SSE endpoints.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Rework README around OmniCoreAgent as the open production agent harness
- Update docs landing, overview, architecture, quickstart, context, workspace, and configuration pages so claims match the current runtime
- Add OmniDaemon to the ecosystem/runtime positioning without mixing it into OmniCoreAgent features

## Verification
- uv run pre-commit run --files README.md docs.json docs/index.mdx docs/core-concepts/overview.mdx docs/core-concepts/architecture.mdx docs/core-concepts/context-engineering.mdx docs/core-concepts/workspace-files.mdx docs/getting-started/quickstart.mdx docs/how-to-guides/configuration.mdx
- git diff --check
- python3 -m json.tool docs.json >/dev/null