### PR TITLE
Refine background agent architecture

### DIFF
--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -1,241 +1,696 @@
 # Background Agents Architecture
 
-This is an internal architecture record under `engineering/architecture`, not
-public product documentation. It is the source of truth for the next
-OmniCoreAgent background-agent design.
+This is an internal architecture record for the OmniCoreAgent background
+execution system. It is not public product documentation.
 
-Keep public docs thin. Keep the full reasoning, ownership boundaries,
-implementation decisions, failure modes, and coding-agent instructions here.
+The document defines the system we are building: durable, inspectable,
+scheduled, triggerable, long-running agent execution on top of `OmniCoreAgent`.
+It is the source of truth for implementation, tests, cookbook examples, and
+OmniServe integration.
 
-This document is not a list of nice-to-have ideas. When background-agent code is
-rebuilt, implementation, tests, public docs, examples, and this architecture
-record must stay aligned.
+Public docs stay concise. This record keeps the full engineering design.
 
 Read this before changing:
 
 - `src/omnicoreagent/background`
-- background-agent exports in `src/omnicoreagent/__init__.py`
-- background events in `src/omnicoreagent/core/events`
-- background cookbook examples
-- OmniServe endpoints that will later manage background agents
-- workspace conventions for scheduled or long-running runs
-
-The design target is a durable background execution system for agents. It is not
-just "run this function every N seconds."
+- `src/omnicoreagent/core/runtime`
+- `src/omnicoreagent/core/workspace`
+- `src/omnicoreagent/core/events`
+- `src/omnicoreagent/core/memory_store`
+- `engineering/specifications/background-agents.md`
 
 ---
 
-## External Design Inputs
+## Design Goal
 
-The design is informed by production systems that separate durable execution,
-scheduling, lifecycle events, and runtime state.
+Background agents turn `OmniCoreAgent` into a durable task runner.
 
-| System | Design lesson |
-|--------|---------------|
-| APScheduler | Schedules, triggers, job stores, and executors are separate concepts. A scheduler should decide when work is due; it should not own all agent state. |
-| Celery | Periodic scheduling, queued execution, retries, and task results are separate operational concerns. |
-| Temporal | Long-running work needs durable run state, retry policies, terminal states, and crash recovery. Fallible I/O should be retryable and observable. |
-| OpenAI background mode | Long-running model work needs stable run IDs, status polling, cancellation, and terminal run states. |
-| Claude Code lifecycle hooks | Agent work has a lifecycle: session start, user prompt, tool calls, tool batches, subagents, compaction, completion, and stop events. Background agents should expose lifecycle events, not hide them. |
-| Google ADK | Sessions, memory, artifacts, tools, and runners are separate services. A background agent should compose these pieces rather than blur them. |
+The system must support:
 
-These systems do not dictate OmniCoreAgent's API. They confirm the architecture
-principle: durable background execution is a runtime layer around the agent
-harness, not a second agent framework.
+- manual background runs
+- interval schedules
+- cron schedules
+- one-shot schedules
+- long-running jobs that run for minutes, hours, or days
+- cancellation
+- retry
+- timeout
+- overlap control
+- restart recovery
+- run inspection
+- workspace output
+- lifecycle events
+- OmniServe control APIs
 
-References reviewed:
-
-- APScheduler user guide: `https://apscheduler.readthedocs.io/en/stable/userguide.html`
-- Celery task guide: `https://docs.celeryq.dev/en/stable/userguide/tasks.html`
-- Temporal durable execution docs: `https://docs.temporal.io/`
-- OpenAI background mode: `https://platform.openai.com/docs/guides/background`
-- OpenAI Codex cloud tasks/environments: `https://developers.openai.com/codex/cloud/environments`
-- Claude Code hooks: `https://code.claude.com/docs/en/hooks`
-- Google ADK sessions/memory: `https://adk.dev/sessions/memory/`
-
----
-
-## Purpose
-
-Background agents exist to run `OmniCoreAgent` under supervision.
-
-They solve these harness problems:
-
-| Problem | Background-agent answer |
-|---------|-------------------------|
-| Agents need to run without a human request in the foreground | Schedule or trigger tasks and execute them in the background |
-| Long-running work must be inspectable | Persist each run, status, attempts, events, and workspace output |
-| Scheduled work must survive process restarts | Store task definitions and run state in a durable task store |
-| Agent runs can fail, time out, or loop | Apply retry, timeout, cancellation, and overlap policies outside the model loop |
-| Operators need control | Support start, pause, resume, cancel, run-now, inspect, and delete operations |
-| Background work must integrate with the harness | Use OmniCoreAgent memory, workspace, tools, guardrails, context management, subagents, and events |
-
-The design rule is:
+The core design rule:
 
 ```text
-Background agents supervise OmniCoreAgent runs.
-They do not replace OmniCoreAgent and they do not fork the agent runtime.
+Background execution supervises OmniCoreAgent.
+OmniCoreAgent remains the only reasoning and tool-execution engine.
 ```
 
+Background agents are not a second agent framework. They are a durable
+execution layer around the agent harness.
+
 ---
 
-## Current Problem
+## Architectural Principles
 
-The current implementation is functional but too small and too tightly coupled.
+| Principle | Requirement |
+|-----------|-------------|
+| Composition over subclassing | Background execution wraps an `OmniCoreAgent` run instead of creating a separate agent type |
+| Durable state first | Task, schedule, run, attempt, cancellation, and lease state live in a task store |
+| Scheduler is not executor | The scheduler emits due work; it never runs the agent |
+| Supervisor owns execution | Retry, timeout, cancellation, heartbeat, leases, and terminal status are handled outside the model loop |
+| Workspace is mandatory | Every background run gets a workspace namespace for durable outputs |
+| Memory is separate | Conversation/session memory stays in `MemoryRouter`; operational state stays in the task store |
+| Events are visibility, not truth | Events describe lifecycle transitions; the task store is the source of truth |
+| Storage is pluggable | `AbstractTaskStore` supports `in_memory`, `sql`, `redis`, and `mongodb` through one interface |
+| Backend choice is explicit | A running manager uses one task store; backend transfer is explicit, not hot-swapped mid-run |
+| Root import stays light | Optional scheduler/storage dependencies load only when background features need them |
 
-Current shape:
+---
+
+## System Context
 
 ```text
+User / OmniServe / Application
+        |
+        v
 BackgroundAgentManager
-  -> TaskRegistry
-  -> APSchedulerBackend
-  -> BackgroundOmniCoreAgent extends OmniCoreAgent
+        |
+        +--> AgentRegistry
+        +--> TaskStoreRouter
+        |       |
+        |       v
+        |   AbstractTaskStore
+        |       |
+        |       +--> in_memory
+        |       +--> sql
+        |       +--> redis
+        |       +--> mongodb
+        |
+        +--> SchedulerBackend
+        +--> Dispatcher
+        +--> RunQueue
+        +--> BackgroundSupervisor
+                |
+                v
+          OmniCoreAgent.run()
+                |
+                +--> MemoryRouter
+                +--> Workspace
+                +--> EventRouter
+                +--> Tools / MCP / Subagents / Guardrails
 ```
 
-Main issues:
-
-- `BackgroundOmniCoreAgent` subclasses `OmniCoreAgent`, making background
-  execution feel like a different agent type instead of a supervised runtime
-  mode.
-- `TaskRegistry` is in-memory only, so schedules and run state are not durable.
-- `create_agent()` mutates the input config by popping `task_config`.
-- task definition, schedule, queue, worker, retry, status, and agent config are
-  represented as mutable dictionaries.
-- scheduler state and task registry state are separate but not reconciled.
-- task updates do not cleanly reschedule from a single source of truth.
-- task runs do not have a durable run record.
-- run output is returned as a result but not standardized into workspace files.
-- lifecycle events exist but are incomplete for operations such as queued,
-  retrying, timeout, cancelled, skipped, paused, resumed, and deleted.
-- tests cover `TaskRegistry` and `APSchedulerBackend`, but not the full durable
-  lifecycle.
-
-The rebuild must move from "background wrapper" to "durable task runtime for
-agents."
+The manager owns orchestration. The store owns operational truth. The scheduler
+owns due-time calculation. The supervisor owns execution lifecycle.
+`OmniCoreAgent` owns reasoning, tool calls, workspace tools, memory, context
+management, guardrails, and final response generation.
 
 ---
 
-## Target Architecture
+## Main Components
 
-Target shape:
+### `BackgroundAgentManager`
+
+The public facade for registering agents, defining tasks, starting scheduling,
+running tasks manually, inspecting runs, cancelling runs, and shutting down the
+background runtime.
+
+It coordinates the internal services but does not directly execute agent logic.
+
+Responsibilities:
+
+- validate public input
+- register agent specs and task specs
+- initialize the selected task store
+- start and stop scheduler, dispatcher, queue, and supervisor
+- expose control operations
+- expose inspection operations
+- enforce background runtime defaults
+
+### `AgentRegistry`
+
+Holds process-local agent objects and serializable agent specs.
+
+Two registration modes exist:
+
+- direct object registration for applications that construct `OmniCoreAgent`
+  themselves
+- serializable spec registration for durable agents that can be reconstructed
+  by workers
+
+### `TaskStoreRouter`
+
+Builds the selected `AbstractTaskStore` implementation from a backend name and
+configuration.
+
+Supported backend names:
 
 ```text
-BackgroundAgentManager
-  -> BackgroundAgentRegistry
-  -> BackgroundTaskStore
-  -> SchedulerBackend
-  -> Dispatcher
-  -> RunQueue
-  -> BackgroundSupervisor
-  -> OmniCoreAgent.run()
-  -> Workspace + Memory + Events
+in_memory
+sql
+redis
+mongodb
 ```
 
-High-level flow:
+The router is a construction boundary only. Runtime code depends on
+`AbstractTaskStore`, not on backend-specific classes.
+
+### `AbstractTaskStore`
+
+The persistence interface for background execution.
+
+It stores:
+
+- agent specs
+- task specs
+- schedule state
+- run records
+- attempt records
+- run leases
+- cancellation flags
+- pause/enabled flags
+- lifecycle checkpoints
+
+It does not store:
+
+- conversation history
+- workspace files
+- tool definitions
+- MCP clients
+- raw event streams
+
+Conversation memory belongs to `MemoryRouter`. Files and artifacts belong to
+workspace storage. Events belong to `EventRouter`. The task store owns
+operational state.
+
+### `SchedulerBackend`
+
+Computes due work from schedule specs.
+
+Responsibilities:
+
+- register enabled scheduled tasks
+- compute next run time
+- handle interval, cron, and once schedules
+- apply misfire policy
+- notify dispatcher when work is due
+- pause, resume, and remove scheduled triggers
+
+Non-responsibilities:
+
+- running agents
+- retrying failed runs
+- persisting result state
+- writing workspace files
+- deciding overlap behavior
+
+The architecture depends on the `SchedulerBackend` contract, not on a specific
+scheduler package. Any scheduler implementation must be replaceable without
+changing the manager, task store, dispatcher, queue, or supervisor.
+
+### `Dispatcher`
+
+Converts due tasks into run records.
+
+Responsibilities:
+
+- load the task from the task store
+- verify the task is enabled
+- apply overlap policy
+- create a run record
+- persist the run as queued
+- enqueue the run
+- emit queued or skipped lifecycle events
+
+### `RunQueue`
+
+Provides the boundary between due work and execution.
+
+Responsibilities:
+
+- accept queued run IDs
+- provide backpressure
+- preserve deterministic ordering
+- support graceful shutdown
+- allow priority/concurrency policy without changing task storage
+
+The initial queue is process-local. The queue contract allows a durable queue
+implementation without changing the manager API.
+
+### `BackgroundSupervisor`
+
+Executes queued runs under operational control.
+
+Responsibilities:
+
+- claim runs with a lease
+- refresh heartbeats for long-running runs
+- resolve agent, task, session, and workspace namespace
+- execute `OmniCoreAgent.run()`
+- enforce timeout
+- honor cancellation
+- apply retry policy
+- preserve partial output
+- write run metadata to workspace
+- mark terminal status exactly once
+- emit lifecycle events
+
+The supervisor design supports workers running in a separate process without
+redesigning the data model.
+
+---
+
+## Task Store Architecture
+
+### Backend Names
+
+The public task-store backend names are:
+
+| Backend | Purpose |
+|---------|---------|
+| `in_memory` | Fast development and tests; state is lost on process exit |
+| `sql` | Durable relational storage for SQLite locally and Postgres in production |
+| `redis` | Durable operational state in Redis for deployments already using Redis |
+| `mongodb` | Durable document storage for MongoDB deployments |
+
+Do not expose separate public routers named after each SQL database. `sql` is
+the relational backend family. Its connection URL decides whether the concrete
+database is SQLite, Postgres, or another supported SQLAlchemy target.
+
+Example:
+
+```python
+manager = BackgroundAgentManager(
+    task_store={
+        "backend": "sql",
+        "url": "sqlite:///.omnicoreagent/background.db",
+    }
+)
+```
+
+Production Postgres uses the same backend:
+
+```python
+manager = BackgroundAgentManager(
+    task_store={
+        "backend": "sql",
+        "url": "postgresql://user:pass@host:5432/omnicoreagent",
+    }
+)
+```
+
+### Backend Selection
+
+The selected task store is part of manager construction.
 
 ```text
-register agent spec
-register task spec
-persist task
-scheduler marks task due
-dispatcher creates run
-queue accepts run
-supervisor claims run
-agent executes with session and workspace namespace
-events stream throughout lifecycle
-workspace captures files/artifacts/output
-task store records terminal run state
-scheduler computes next due time
+BackgroundAgentManager(task_store="in_memory")
+BackgroundAgentManager(task_store="sql")
+BackgroundAgentManager(task_store="redis")
+BackgroundAgentManager(task_store="mongodb")
+BackgroundAgentManager(task_store={...})
 ```
 
-The scheduler only decides when a task is due. It does not own execution.
+The manager must not hot-swap task stores while runs are active. Operational
+state is stateful by design. Moving from one backend to another requires an
+explicit export/import or transfer utility so task definitions, schedule state,
+run records, attempts, leases, and cancellation flags move together.
 
-The supervisor owns execution lifecycle. It does not own model reasoning.
+### Source Of Truth
 
-`OmniCoreAgent` owns reasoning, tools, memory, workspace tools, subagents,
-guardrails, context management, observations, and final response.
+The task store is the source of truth for:
 
----
+- which tasks exist
+- whether a task is enabled
+- when a task last ran
+- when a task is next due
+- which runs exist
+- which runs are active
+- which worker claimed a run
+- whether cancellation was requested
+- final run status
 
-## Terminology
-
-Use these names consistently.
-
-| Term | Meaning |
-|------|---------|
-| Background agent | A registered `OmniCoreAgent` plus supervision metadata |
-| Agent spec | Static definition needed to construct or reference the agent |
-| Task spec | Durable definition of scheduled or manual work |
-| Schedule spec | Interval, cron, once, or manual trigger configuration |
-| Run | One concrete execution attempt created from a task spec |
-| Attempt | One try within a run under the retry policy |
-| Task store | Operational persistence for agents, tasks, schedules, runs, and attempts |
-| Scheduler backend | Adapter that computes due work from schedule specs |
-| Dispatcher | Converts due tasks into queued runs |
-| Run queue | Backpressure and ordering boundary before execution |
-| Supervisor | Claims runs, executes them, handles retries/timeouts/cancel, and records state |
-| Workspace namespace | Durable file area for a task or run |
-
-Do not call the task store a memory store. Memory stores conversation history.
-The task store stores operational state.
-
-Do not call workspace storage a task store. Workspace stores files and artifacts.
-The task store stores metadata, status, and scheduling state.
+The scheduler can keep its own runtime jobs, but those jobs are rebuildable from
+task-store state. On startup, the manager reads enabled tasks from the task
+store and reconstructs scheduler triggers.
 
 ---
 
-## Architecture Invariants
+## Data Model
 
-These invariants are mandatory.
+### Agent Spec
 
-| Invariant | Reason |
-|-----------|--------|
-| `OmniCoreAgent` remains the execution engine | Avoid creating two agent runtimes |
-| Background execution uses composition, not agent subclassing | Keep scheduling/supervision decoupled from reasoning |
-| Task definitions are durable | Scheduled agents must survive restarts |
-| Every run has a durable `run_id` and terminal state | Operators need status, debugging, and reliable automation |
-| Scheduler does not execute agent logic directly | Scheduling and execution have different failure modes |
-| Supervisor owns retries, timeout, cancellation, and overlap policy | These are operational controls, not model reasoning controls |
-| Workspace is the file boundary for run output | Every background run must leave inspectable output |
-| Memory remains conversation/session history | Do not hide scheduled task state in MemoryRouter |
-| Events describe lifecycle transitions | Observability must be reconstructable from events |
-| Public APIs accept typed specs or validated dictionaries | Avoid unvalidated mutable config blobs |
-| In-memory implementations are development/test only | Production behavior needs durable task state |
+`BackgroundAgentSpec` identifies an agent the background system can run.
+
+Fields:
+
+- `agent_id`
+- `name`
+- `system_instruction`
+- `model_config`
+- `agent_config`
+- `mcp_tools`
+- `local_tools_ref`
+- `workspace_config`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+Direct Python tool objects are process-local. Durable agent specs can reference
+tool sets by name, but they do not serialize live Python callables.
+
+### Task Spec
+
+`BackgroundTaskSpec` defines reusable background work.
+
+Fields:
+
+- `task_id`
+- `agent_id`
+- `query`
+- `schedule`
+- `enabled`
+- `timeout_seconds`
+- `retry_policy`
+- `overlap_policy`
+- `session_policy`
+- `workspace_policy`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+The task spec is stable configuration. It is not a run result.
+
+### Schedule Spec
+
+`ScheduleSpec` defines when work becomes due.
+
+Supported schedule types:
+
+- `manual`
+- `interval`
+- `cron`
+- `once`
+
+Schedule state tracks:
+
+- next due time
+- last due time
+- last dispatch time
+- misfire handling
+- timezone
+- jitter
+- enabled/paused state
+
+### Run
+
+`BackgroundRun` is one concrete execution created from a task.
+
+Fields:
+
+- `run_id`
+- `task_id`
+- `agent_id`
+- `status`
+- `attempt`
+- `max_attempts`
+- `trigger`
+- `session_id`
+- `workspace_path`
+- `lease_owner`
+- `lease_expires_at`
+- `heartbeat_at`
+- `queued_at`
+- `claimed_at`
+- `started_at`
+- `finished_at`
+- `cancel_requested_at`
+- `error`
+- `result_preview`
+- `metadata`
+
+### Attempt
+
+`BackgroundAttempt` records each try inside a run.
+
+Fields:
+
+- `attempt_id`
+- `run_id`
+- `attempt_number`
+- `status`
+- `started_at`
+- `finished_at`
+- `error`
+- `retry_delay_seconds`
+- `worker_id`
+
+Attempts make retry behavior inspectable. A multi-day task trajectory must
+show every attempt and every transition that led to the final state.
 
 ---
 
-## Component Ownership
-
-Target module layout:
+## Run Lifecycle
 
 ```text
-background/
-  __init__.py
-  manager.py              # public facade
-  models.py               # typed specs, run records, enums
-  store.py                # TaskStore protocol and in-memory implementation
-  sqlite_store.py         # local durable task store
-  scheduler.py            # SchedulerBackend protocol
-  apscheduler_backend.py  # APScheduler adapter
-  dispatcher.py           # due task -> queued run
-  queue.py                # run queue and backpressure policy
-  supervisor.py           # run claiming, execution, retries, timeout, cancel
-  runner.py               # thin OmniCoreAgent.run adapter
-  workspace.py            # workspace namespace/path helpers
-  events.py               # background event builders
-  errors.py               # typed background errors
+scheduled
+  -> queued
+  -> claimed
+  -> running
+  -> retrying
+  -> running
+  -> completed
+
+running -> failed
+running -> timeout
+queued|claimed|running|retrying -> cancelled
+scheduled|queued -> skipped
 ```
 
-The existing files can be migrated into this shape. Do not keep the old names
-only for compatibility. This code has not been widely exposed enough to justify
-carrying a confusing architecture forward.
+Terminal states:
+
+```text
+completed
+failed
+cancelled
+timeout
+skipped
+```
+
+Terminal states do not transition. A retry creates a new attempt inside the
+same run before terminal status. A replay creates a new run.
+
+---
+
+## Long-Running Execution
+
+Long-running tasks require leases and heartbeats.
+
+When a supervisor claims a run, it writes:
+
+- `lease_owner`
+- `lease_expires_at`
+- `heartbeat_at`
+
+While the run is active, the supervisor refreshes the heartbeat. If the process
+dies, the lease expires and another supervisor can recover the run according to
+the recovery policy.
+
+Recovery policy must distinguish:
+
+- run never started after queue claim
+- run started but heartbeat expired
+- run was retrying when heartbeat expired
+- cancellation was requested before recovery
+- terminal status was already written
+
+The task store must make claim and terminal writes atomic so two supervisors do
+not complete the same run.
+
+---
+
+## Trigger Model
+
+Every run has a trigger record.
+
+Trigger types:
+
+- `manual`
+- `interval`
+- `cron`
+- `once`
+- `retry`
+- `recovery`
+
+Trigger metadata includes:
+
+- `triggered_at`
+- `due_at`
+- `reason`
+- `source`
+- scheduler job ID when available
+
+This gives operators the complete task trajectory: why a run exists, when it
+became due, who claimed it, what happened during execution, and how it ended.
+
+---
+
+## Overlap Policy
+
+Overlap policy is applied by the dispatcher before a run is queued.
+
+Supported policies:
+
+| Policy | Behavior |
+|--------|----------|
+| `skip_if_running` | Do not queue a new run while another active run for the same task exists |
+| `queue_next` | Queue the new run behind active work |
+| `cancel_previous` | Request cancellation for active runs and queue the new run |
+| `allow_parallel` | Allow multiple active runs for the same task |
+
+Default:
+
+```text
+skip_if_running
+```
+
+This protects long-running tasks from accidental runaway schedules.
+
+---
+
+## Retry Policy
+
+Retry policy belongs to the supervisor.
+
+Fields:
+
+- `max_retries`
+- `initial_delay_seconds`
+- `max_delay_seconds`
+- `backoff`
+- `retry_on`
+
+Retries are attempts inside a run. The scheduler is not involved in retrying a
+failed attempt.
+
+---
+
+## Cancellation
+
+Cancellation is a durable flag on the run.
+
+Cancellation can happen:
+
+- before execution starts
+- while waiting in queue
+- while running
+- during retry delay
+
+The supervisor checks cancellation:
+
+- before claiming
+- before starting the agent
+- between attempts
+- during retry sleep
+- after timeout or exception before scheduling another retry
+
+Agent-level hard interruption depends on what the active model/tool call can
+support. The background runtime still records cancellation intent immediately
+and marks the run terminal when execution is safely stopped.
+
+---
+
+## Session Policy
+
+Background tasks use normal OmniCoreAgent memory through `MemoryRouter`.
+
+Supported session policies:
+
+| Policy | Session ID |
+|--------|------------|
+| `task` | `background:{agent_id}:{task_id}` |
+| `run` | `background:{run_id}` |
+| `fixed` | User-provided session ID |
+
+Default:
+
+```text
+task
+```
+
+Use task-level sessions for recurring jobs that carry memory across previous runs.
+Use run-level sessions for isolated batch jobs.
+
+---
+
+## Workspace Contract
+
+Workspace is mandatory for background runs.
+
+Default run namespace:
+
+```text
+background/{agent_id}/{task_id}/{run_id}
+```
+
+Standard files:
+
+```text
+output.md
+run.json
+events.jsonl
+logs/
+artifacts/
+subagents/
+scratchpad/
+```
+
+The supervisor writes `run.json`. The agent writes durable task output through
+workspace tools. Events can also be mirrored to `events.jsonl` for easy
+inspection, while `EventRouter` remains the event service.
+
+The final response returned by `OmniCoreAgent.run()` is stored as
+`result_preview`. The durable result of background work is the workspace output.
+
+Workspace storage can be local, S3, or R2 through the existing workspace
+architecture. Background execution does not create a separate file-storage
+system.
+
+---
+
+## Event Model
+
+Background lifecycle events go through `EventRouter`.
+
+Required events:
+
+- `background_agent_registered`
+- `background_task_registered`
+- `background_task_scheduled`
+- `background_task_paused`
+- `background_task_resumed`
+- `background_task_deleted`
+- `background_run_queued`
+- `background_run_claimed`
+- `background_run_started`
+- `background_run_heartbeat`
+- `background_run_retrying`
+- `background_run_completed`
+- `background_run_failed`
+- `background_run_timeout`
+- `background_run_cancelled`
+- `background_run_skipped`
+- `background_run_recovered`
+
+Events make the run observable. They do not replace the task store.
 
 ---
 
 ## Public API Shape
-
-The public API should feel like scheduling a normal `OmniCoreAgent`, not
-creating a different kind of agent.
 
 ```python
 from omnicoreagent import BackgroundAgentManager, OmniCoreAgent
@@ -246,555 +701,38 @@ agent = OmniCoreAgent(
     model_config={"provider": "openai", "model": "gpt-4o-mini"},
 )
 
-manager = BackgroundAgentManager(task_store="sqlite")
-
-await manager.register_agent(
-    agent_id="system_monitor",
-    agent=agent,
+manager = BackgroundAgentManager(
+    task_store={
+        "backend": "sql",
+        "url": "sqlite:///.omnicoreagent/background.db",
+    }
 )
+
+await manager.register_agent(agent_id="system_monitor", agent=agent)
 
 await manager.register_task(
     task_id="hourly_health_report",
     agent_id="system_monitor",
     query="Check system status and save a report.",
     schedule={"type": "interval", "seconds": 3600},
-    timeout=300,
-    retry_policy={"max_retries": 2, "initial_delay": 30},
+    timeout_seconds=300,
+    retry_policy={"max_retries": 2, "initial_delay_seconds": 30},
 )
 
 await manager.start()
-```
 
-Manual execution:
-
-```python
 run = await manager.run_now("hourly_health_report")
-```
-
-Status and operations:
-
-```python
-await manager.get_task("hourly_health_report")
-await manager.get_run(run.run_id)
-await manager.list_runs(task_id="hourly_health_report")
+status = await manager.get_run(run.run_id)
 await manager.cancel_run(run.run_id)
-await manager.pause_task("hourly_health_report")
-await manager.resume_task("hourly_health_report")
-await manager.delete_task("hourly_health_report")
 ```
-
-The manager may also support one-call registration for convenience:
-
-```python
-await manager.register(
-    agent_id="system_monitor",
-    agent=agent,
-    task_id="hourly_health_report",
-    query="Check system status and save a report.",
-    schedule={"type": "interval", "seconds": 3600},
-)
-```
-
-Convenience must call the same typed core path. It must not create a second
-configuration path.
 
 ---
 
-## Agent Spec
+## OmniServe Integration
 
-`BackgroundAgentSpec` defines what agent is available for background execution.
+OmniServe exposes background execution through the runtime contract.
 
-It supports two registration forms:
-
-1. pass an already-created `OmniCoreAgent`
-2. pass a serializable construction spec
-
-In-process direct registration:
-
-```python
-await manager.register_agent(agent_id="monitor", agent=agent)
-```
-
-Serializable registration:
-
-```python
-await manager.register_agent_spec(
-    {
-        "agent_id": "monitor",
-        "name": "system_monitor",
-        "system_instruction": "Monitor health and report problems.",
-        "model_config": {"provider": "openai", "model": "gpt-4o-mini"},
-        "agent_config": {
-            "context_management": {"enabled": True},
-            "tool_offload": {"enabled": True},
-            "enable_workspace_files": True,
-        },
-        "mcp_tools": [],
-    }
-)
-```
-
-Direct `local_tools` may be in-process only because Python callables are not
-portable across processes. A durable task store may record that an agent has
-non-serializable local tools, but it cannot reconstruct those tools in a new
-process unless the user provides an import path or factory.
-
-This is a key boundary: durable tasks are possible only when the agent can be
-reconstructed or when the process keeps the agent object registered.
-
----
-
-## Task Spec
-
-`BackgroundTaskSpec` defines the scheduled work.
-
-Required fields:
-
-- `task_id`
-- `agent_id`
-- `query`
-- `schedule`
-
-Important optional fields:
-
-- `enabled`
-- `timeout`
-- `retry_policy`
-- `overlap_policy`
-- `session_policy`
-- `workspace_policy`
-- `metadata`
-
-The task spec is durable. It is the source of truth. Scheduler jobs are derived
-from task specs and can be rebuilt.
-
----
-
-## Schedule Spec
-
-Supported schedule types:
-
-| Type | Meaning |
-|------|---------|
-| `interval` | Run every N seconds |
-| `cron` | Run from a cron expression |
-| `once` | Run once at `run_at` |
-| `manual` | Never scheduled automatically; runs only through `run_now()` |
-
-Schedule spec examples:
-
-```python
-{"type": "interval", "seconds": 300}
-{"type": "cron", "expression": "0 * * * *", "timezone": "UTC"}
-{"type": "once", "run_at": "2026-05-09T00:00:00Z"}
-{"type": "manual"}
-```
-
-Scheduling options:
-
-- `timezone`
-- `start_at`
-- `end_at`
-- `jitter_seconds`
-- `misfire_policy`
-
-The default misfire policy should be conservative:
-
-```text
-skip_missed
-```
-
-Do not surprise users by running a backlog of missed jobs after downtime unless
-they explicitly choose that behavior.
-
----
-
-## Run Model
-
-Every execution creates a `BackgroundRun`.
-
-The run is the operational unit that can be inspected, cancelled, retried, and
-linked to workspace output.
-
-```text
-run_id
-task_id
-agent_id
-status
-attempt
-queued_at
-started_at
-finished_at
-cancel_requested_at
-timeout_seconds
-error
-result_preview
-workspace_path
-session_id
-metadata
-```
-
-Run statuses:
-
-```text
-scheduled
-queued
-claimed
-running
-retrying
-completed
-failed
-cancelled
-timeout
-skipped
-```
-
-Terminal statuses:
-
-```text
-completed
-failed
-cancelled
-timeout
-skipped
-```
-
-Once a run reaches a terminal status, it must not transition again except
-through an explicit new retry run or replay run.
-
----
-
-## Task Store
-
-The task store is operational persistence.
-
-It stores:
-
-- agent specs that are serializable
-- task specs
-- schedule state
-- run records
-- attempt records
-- cancellation flags
-- pause/enabled flags
-
-It does not store:
-
-- conversation memory
-- workspace files
-- tool definitions
-- MCP connection objects
-- event stream payloads unless an implementation chooses to denormalize
-
-Initial implementations:
-
-```text
-InMemoryTaskStore
-SQLiteTaskStore
-```
-
-Later implementations:
-
-```text
-RedisTaskStore
-PostgresTaskStore
-```
-
-SQLite should become the local durable default for background agents because a
-background scheduler that forgets all task state on restart is not a production
-background system.
-
----
-
-## Scheduler Backend
-
-The scheduler backend is replaceable.
-
-Initial backend:
-
-```text
-APSchedulerBackend
-```
-
-Responsibilities:
-
-- accept enabled task specs
-- compute due times
-- trigger dispatcher when work is due
-- expose next run time
-- pause/resume/delete scheduler jobs
-- rebuild scheduler jobs from task store on manager startup
-
-Non-responsibilities:
-
-- run the agent
-- retry failed work
-- store result state
-- write workspace files
-- emit all lifecycle events
-
-The scheduler should emit "due task" signals, not call `OmniCoreAgent.run()`
-directly.
-
----
-
-## Dispatcher And Queue
-
-The dispatcher converts due tasks into run records.
-
-Responsibilities:
-
-- load task spec
-- check `enabled`
-- evaluate overlap policy
-- create a durable `BackgroundRun`
-- enqueue the run
-- emit queued/skipped events
-
-The run queue provides backpressure.
-
-Queue policies:
-
-- max queue size
-- enqueue timeout
-- priority later if needed
-- per-task or global concurrency later if needed
-
-The queue can start in memory. The task store keeps run state durable, so a
-future process can recover queued/running runs.
-
----
-
-## Supervisor
-
-The supervisor is the execution heart.
-
-Responsibilities:
-
-- claim queued runs
-- mark runs `running`
-- execute `OmniCoreAgent.run()`
-- enforce timeout
-- handle cancellation
-- apply retry policy
-- record attempts
-- write run result metadata
-- emit lifecycle events
-- mark terminal status
-- release resources
-
-The supervisor should be written so it can later run in a separate process or
-worker. It must not depend on global process state that prevents that future.
-
----
-
-## Retry Policy
-
-Retry belongs to the supervisor, not to the scheduler.
-
-Default:
-
-```text
-max_retries = 0
-```
-
-Users opt into retries. Retrying an agent can be expensive and can repeat side
-effects.
-
-Supported fields:
-
-- `max_retries`
-- `initial_delay`
-- `max_delay`
-- `backoff`
-- `retry_on`
-
-Backoff values:
-
-```text
-fixed
-exponential
-```
-
-Retry must create attempt records. A retry is not invisible.
-
----
-
-## Timeout And Cancellation
-
-Timeout and cancellation are first-class.
-
-Timeout behavior:
-
-- supervisor starts timer when run becomes `running`
-- if timeout is exceeded, cancel the execution task
-- mark run `timeout`
-- emit timeout event
-- preserve workspace files already written
-
-Cancellation behavior:
-
-- `cancel_run(run_id)` sets a cancellation flag in the task store
-- supervisor checks cancellation before starting, between retries, and during
-  long-running execution where possible
-- cancellation marks run `cancelled`
-- cancellation must be idempotent
-
-Hard cancellation of an in-flight Python coroutine is best-effort. The
-architecture must represent that honestly.
-
----
-
-## Overlap Policy
-
-Overlap policy controls what happens when a task is due while a previous run is
-still active.
-
-Supported values:
-
-| Policy | Behavior |
-|--------|----------|
-| `skip_if_running` | Do not enqueue a new run if active run exists |
-| `queue_next` | Queue one or more future runs |
-| `cancel_previous` | Request cancellation of active run before queuing new one |
-| `allow_parallel` | Allow multiple active runs for the same task |
-
-Default:
-
-```text
-skip_if_running
-```
-
-This default prevents runaway schedules and duplicate side effects.
-
----
-
-## Session Policy
-
-Background agents need clear memory behavior.
-
-Supported session policies:
-
-| Policy | Behavior |
-|--------|----------|
-| `task` | Reuse one session per task |
-| `run` | Use one new session per run |
-| `fixed` | Use provided `session_id` |
-
-Default:
-
-```text
-task
-```
-
-For recurring monitoring/reporting, task-level session continuity is useful.
-For independent batch jobs, run-level sessions avoid old context leaking into
-new work.
-
----
-
-## Workspace Policy
-
-Every run must have a workspace namespace.
-
-Default layout:
-
-```text
-/background/{agent_id}/{task_id}/{run_id}/
-  output.md
-  scratchpad.md
-  events.jsonl
-  artifacts/
-  subagents/
-  logs/
-```
-
-Workspace policy fields:
-
-- `namespace`
-- `persist_outputs`
-- `output_file`
-- `event_log_file`
-- `artifact_policy`
-
-The supervisor should inject workspace guidance into the run context so the
-agent knows where to write durable output.
-
-The runtime should never rely only on `result["response"]` for background work.
-A background run must leave inspectable workspace output.
-
----
-
-## Events
-
-Background events must describe lifecycle transitions.
-
-Required event types:
-
-```text
-background_agent_registered
-background_task_registered
-background_task_scheduled
-background_task_paused
-background_task_resumed
-background_task_deleted
-background_run_queued
-background_run_started
-background_run_retrying
-background_run_completed
-background_run_failed
-background_run_timeout
-background_run_cancelled
-background_run_skipped
-```
-
-Existing event types can be migrated or mapped:
-
-```text
-background_task_started      -> background_run_started
-background_task_completed    -> background_run_completed
-background_task_error        -> background_run_failed
-background_agent_status      -> keep as aggregate status event if useful
-```
-
-Events go through `EventRouter`. Run state goes through `TaskStore`.
-
-Do not rely on events as the only source of run state. Event streams are for
-visibility. Task store is the operational source of truth.
-
----
-
-## Integration With OmniCoreAgent Harness
-
-Background execution should enable or encourage harness features that matter for
-long-running work:
-
-- workspace files
-- tool offloading
-- context management
-- event emission
-- memory session continuity
-- subagents where enabled by agent config
-
-The background system should not silently change core agent behavior except
-where required for durability. For example, if `enable_workspace_files` is false,
-the manager can reject the task or force it on by documented policy. The
-recommended policy is:
-
-```text
-background runs require workspace files
-```
-
-Reason: background work must leave durable inspectable output.
-
----
-
-## OmniServe Integration Later
-
-OmniServe should later expose background-agent operations through a dedicated
-router.
-
-Possible endpoints:
+API shape:
 
 ```text
 POST   /background/agents
@@ -805,6 +743,7 @@ DELETE /background/agents/{agent_id}
 POST   /background/tasks
 GET    /background/tasks
 GET    /background/tasks/{task_id}
+PATCH  /background/tasks/{task_id}
 POST   /background/tasks/{task_id}/pause
 POST   /background/tasks/{task_id}/resume
 POST   /background/tasks/{task_id}/run
@@ -814,82 +753,85 @@ GET    /background/runs
 GET    /background/runs/{run_id}
 POST   /background/runs/{run_id}/cancel
 GET    /background/runs/{run_id}/events
+GET    /background/runs/{run_id}/workspace
 ```
 
-This should happen after the internal runtime is clean. Do not build HTTP API
-first.
+The HTTP layer calls the same manager API used by Python applications.
 
 ---
 
-## Migration Strategy
+## Implementation Phases
 
-The rebuild should happen in stages.
+### Phase 1: Models And Task Store
 
-### Stage 1: Typed Models And Store
+- `models.py`
+- `store/base.py`
+- `store/router.py`
+- `store/in_memory.py`
+- `store/sql.py`
+- `store/redis.py`
+- `store/mongodb.py`
+- validation tests
+- store contract tests shared by every backend
 
-- add `models.py`
-- add `TaskStore` protocol
-- add `InMemoryTaskStore`
-- add `SQLiteTaskStore`
-- add tests for model validation and store behavior
+### Phase 2: Scheduler Boundary
 
-### Stage 2: Scheduler Boundary
+- `scheduler.py`
+- scheduler adapter implementation
+- startup schedule reconstruction
+- interval, cron, once, and manual tests
+- misfire tests
 
-- replace direct scheduler ownership with scheduler adapter protocol
-- make APScheduler emit due-task callbacks
-- rebuild schedules from task store at startup
-- test interval, cron, manual, and disabled tasks
+### Phase 3: Dispatcher And Queue
 
-### Stage 3: Dispatcher, Queue, Supervisor
+- dispatcher service
+- queue service
+- overlap policy tests
+- queued/skipped event tests
 
-- create durable run records
-- enqueue runs
-- supervisor claims and executes runs
-- implement retry, timeout, cancellation, and overlap policies
-- test full lifecycle without real LLM by using fake agent runner
+### Phase 4: Supervisor
 
-### Stage 4: Workspace And Events
+- run claiming
+- leases and heartbeat
+- timeout
+- retry
+- cancellation
+- terminal status handling
+- recovery behavior
+- fake-agent end-to-end tests
 
-- assign run workspace namespace
-- inject workspace guidance
-- write standard run output files
-- emit complete lifecycle events
-- test workspace output and event trace
+### Phase 5: Workspace And Events
 
-### Stage 5: Public API And Docs
+- run workspace namespace creation
+- `run.json`
+- `output.md` guidance
+- event stream integration
+- local workspace integration tests
 
-- replace cookbook examples
-- update public background-agent docs
-- add OmniServe design only after runtime stabilizes
+### Phase 6: Public API, Cookbook, OmniServe
 
----
-
-## Open Design Decisions
-
-These decisions must be finalized before implementation.
-
-| Decision | Recommendation |
-|----------|----------------|
-| Default task store | SQLite for durable local behavior; in-memory only when explicitly requested |
-| Default overlap policy | `skip_if_running` |
-| Default retry policy | no retries unless configured |
-| Default session policy | `task` |
-| Workspace required? | yes, background runs require workspace files |
-| Keep `BackgroundOmniCoreAgent`? | no, migrate to composition around `OmniCoreAgent` |
-| Keep old dict API? | accept dicts only through typed validation; do not preserve old shape for compatibility |
-| First HTTP API? | no, internal runtime first |
+- manager API cleanup
+- cookbook examples
+- public docs
+- OmniServe background routes
 
 ---
 
-## Coding-Agent Instructions
+## Acceptance Criteria
 
-Before editing background-agent code:
+The background execution system is ready when:
 
-1. Read this file.
-2. Read `engineering/specifications/background-agents.md`.
-3. Read current files under `src/omnicoreagent/background`.
-4. Do not preserve confusing legacy shapes for compatibility.
-5. Keep `OmniCoreAgent` as the execution engine.
-6. Add tests before or with each behavior change.
-7. Keep public docs honest: if a feature is not implemented, do not describe it
-   as shipped.
+- every task is persisted through `AbstractTaskStore`
+- `in_memory`, `sql`, `redis`, and `mongodb` conform to the same store tests
+- SQL backend supports SQLite locally and Postgres through one `sql` backend
+- enabled schedules survive manager restart on durable stores
+- every run has a durable `run_id`
+- every attempt is inspectable
+- long-running runs heartbeat while active
+- expired leases can be recovered deterministically
+- cancellation, timeout, retry, and overlap policies are tested
+- every background run writes workspace output
+- run status can be inspected without reading event streams
+- lifecycle events can reconstruct the run trajectory
+- optional dependencies do not load during root import
+- public docs describe shipped behavior only

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -189,7 +189,7 @@ operational state.
 
 ### `SchedulerBackend`
 
-Computes due work from schedule specs.
+Computes wakeups from schedule specs.
 
 Responsibilities:
 
@@ -197,7 +197,7 @@ Responsibilities:
 - compute next run time
 - handle interval, cron, and once schedules
 - apply misfire policy
-- notify dispatcher when work is due
+- notify dispatcher that schedule state may have due work
 - pause, resume, and remove scheduled triggers
 
 Non-responsibilities:
@@ -207,10 +207,15 @@ Non-responsibilities:
 - persisting result state
 - writing workspace files
 - deciding overlap behavior
+- claiming due schedule occurrences
 
 The architecture depends on the `SchedulerBackend` contract, not on a specific
 scheduler package. Any scheduler implementation must be replaceable without
 changing the manager, task store, dispatcher, queue, or supervisor.
+
+Scheduler wakeups are advisory. The dispatcher reads due schedule occurrences
+from the task store, then uses one atomic store operation to create the
+scheduled run and advance schedule state.
 
 ### `Dispatcher`
 
@@ -223,7 +228,7 @@ Responsibilities:
 - apply overlap policy
 - create a run record
 - persist the run as queued
-- enqueue the run
+- make the queued run claimable through the task store
 - emit queued or skipped lifecycle events
 
 ### `RunQueue`
@@ -232,14 +237,16 @@ Provides the boundary between due work and execution.
 
 Responsibilities:
 
-- accept queued run IDs
+- expose claimable queued run IDs from the task store
 - provide backpressure
 - preserve deterministic ordering
 - support graceful shutdown
 - allow priority/concurrency policy without changing task storage
 
-The initial queue is process-local. The queue contract allows a durable queue
-implementation without changing the manager API.
+The run queue is store-backed. A queued run is durable before any worker sees
+it, and queued runs remain claimable after process restart. A process-local
+queue can exist only as an optimization over the store-backed queue; it must not
+be the source of truth.
 
 ### `BackgroundSupervisor`
 
@@ -274,7 +281,7 @@ The public task-store backend names are:
 |---------|---------|
 | `in_memory` | Fast development and tests; state is lost on process exit |
 | `sql` | Durable relational storage for SQLite locally and Postgres in production |
-| `redis` | Durable operational state in Redis for deployments already using Redis |
+| `redis` | Operational state in Redis when Redis persistence and no-eviction policy are configured |
 | `mongodb` | Durable document storage for MongoDB deployments |
 
 Do not expose separate public routers named after each SQL database. `sql` is
@@ -310,10 +317,12 @@ The selected task store is part of manager construction.
 ```text
 BackgroundAgentManager(task_store="in_memory")
 BackgroundAgentManager(task_store="sql")
-BackgroundAgentManager(task_store="redis")
-BackgroundAgentManager(task_store="mongodb")
 BackgroundAgentManager(task_store={...})
 ```
+
+Bare string construction is limited to `in_memory` and `sql`. Redis and MongoDB
+use explicit configuration dictionaries so connection and durability settings
+are visible when the manager starts.
 
 The manager must not hot-swap task stores while runs are active. Operational
 state is stateful by design. Moving from one backend to another requires an
@@ -337,6 +346,10 @@ The task store is the source of truth for:
 The scheduler can keep its own runtime jobs, but those jobs are rebuildable from
 task-store state. On startup, the manager reads enabled tasks from the task
 store and reconstructs scheduler triggers.
+
+Scheduler wakeups are not the source of truth. The task store records schedule
+state, exposes due occurrences, and atomically dispatches each scheduled run
+while advancing schedule state.
 
 ---
 
@@ -406,6 +419,29 @@ Schedule state tracks:
 - jitter
 - enabled/paused state
 
+### Schedule State
+
+`BackgroundScheduleState` records mutable scheduling progress for one task.
+
+Fields:
+
+- `task_id`
+- `next_due_at`
+- `last_due_at`
+- `last_dispatched_at`
+- `paused`
+- `schedule_revision`
+- `misfire_cursor`
+- `updated_at`
+
+The schedule spec defines the rule. Schedule state records the runtime progress
+of that rule. The task store owns schedule state so interval, cron, once,
+misfire, and restart behavior remain deterministic.
+
+Each due occurrence gets a stable `occurrence_id`. Dispatch uses that
+occurrence ID when creating a run so the same schedule occurrence cannot create
+duplicate runs after restart or competing dispatchers.
+
 ### Run
 
 `BackgroundRun` is one concrete execution created from a task.
@@ -418,10 +454,17 @@ Fields:
 - `status`
 - `attempt`
 - `max_attempts`
-- `trigger`
+- `query_snapshot`
+- `trigger_type`
+- `triggered_at`
+- `due_at`
+- `occurrence_id`
+- `trigger_metadata`
 - `session_id`
 - `workspace_path`
 - `lease_owner`
+- `lease_token`
+- `lease_generation`
 - `lease_expires_at`
 - `heartbeat_at`
 - `queued_at`
@@ -442,12 +485,14 @@ Fields:
 - `attempt_id`
 - `run_id`
 - `attempt_number`
+- `reason`
 - `status`
 - `started_at`
 - `finished_at`
 - `error`
 - `retry_delay_seconds`
 - `worker_id`
+- `lease_token`
 
 Attempts make retry behavior inspectable. A multi-day task trajectory must
 show every attempt and every transition that led to the final state.
@@ -457,18 +502,19 @@ show every attempt and every transition that led to the final state.
 ## Run Lifecycle
 
 ```text
-scheduled
-  -> queued
+queued
   -> claimed
   -> running
   -> retrying
+  -> queued
+  -> claimed
   -> running
   -> completed
 
 running -> failed
 running -> timeout
 queued|claimed|running|retrying -> cancelled
-scheduled|queued -> skipped
+queued -> skipped
 ```
 
 Terminal states:
@@ -481,8 +527,9 @@ timeout
 skipped
 ```
 
-Terminal states do not transition. A retry creates a new attempt inside the
-same run before terminal status. A replay creates a new run.
+Terminal states do not transition. Schedule state tracks due work before a run
+exists. A retry creates a new attempt inside the same run. A replay creates a
+new run.
 
 ---
 
@@ -500,6 +547,15 @@ While the run is active, the supervisor refreshes the heartbeat. If the process
 dies, the lease expires and another supervisor can recover the run according to
 the recovery policy.
 
+Every claim creates a `lease_token` and increments `lease_generation`. Heartbeat,
+attempt update, terminal status, and workspace metadata writes must carry the
+current lease token. A worker that loses its lease must stop writing and fail
+closed. This fencing rule reduces duplicate side effects during multi-day runs.
+
+Expired-lease recovery steals the lease with a new token before changing run or
+attempt state. The abandoned attempt is closed as `failed` with reason
+`lease_expired` before the recovered run is requeued or marked terminal.
+
 Recovery policy must distinguish:
 
 - run never started after queue claim
@@ -511,20 +567,26 @@ Recovery policy must distinguish:
 The task store must make claim and terminal writes atomic so two supervisors do
 not complete the same run.
 
+Recovery requeues eligible expired runs through the same claim path used by
+normal execution. It does not create a new run. It records recovery as an
+attempt reason and emits `background_run_recovered`.
+
+Generic metadata updates never change execution state. Any execution-state
+transition after claim must include the worker ID and lease token so stale
+workers cannot mutate a recovered run.
+
 ---
 
 ## Trigger Model
 
 Every run has a trigger record.
 
-Trigger types:
+Run trigger types:
 
 - `manual`
 - `interval`
 - `cron`
 - `once`
-- `retry`
-- `recovery`
 
 Trigger metadata includes:
 
@@ -532,10 +594,15 @@ Trigger metadata includes:
 - `due_at`
 - `reason`
 - `source`
+- `occurrence_id`
 - scheduler job ID when available
 
 This gives operators the complete task trajectory: why a run exists, when it
 became due, who claimed it, what happened during execution, and how it ended.
+
+Retry and recovery are attempt reasons and lifecycle events, not initial run
+trigger types. They do not create a new run unless an operator explicitly starts
+a replay.
 
 ---
 
@@ -547,9 +614,9 @@ Supported policies:
 
 | Policy | Behavior |
 |--------|----------|
-| `skip_if_running` | Do not queue a new run while another active run for the same task exists |
+| `skip_if_running` | Persist a terminal `skipped` run instead of queueing a new active run while another active run for the same task exists |
 | `queue_next` | Queue the new run behind active work |
-| `cancel_previous` | Request cancellation for active runs and queue the new run |
+| `cancel_previous` | Request cancellation for active runs and create the successor run in the same store transaction |
 | `allow_parallel` | Allow multiple active runs for the same task |
 
 Default:
@@ -559,6 +626,12 @@ skip_if_running
 ```
 
 This protects long-running tasks from accidental runaway schedules.
+
+Overlap policy must be enforced atomically by the task store when a run is
+created. The dispatcher does not perform a separate "list active runs, then
+create run" sequence because that races under multiple managers. For
+`queue_next`, the run can be persisted as `queued`, but `claim_next_run` must not
+claim it while an earlier active run for the same task is still active.
 
 ---
 
@@ -576,6 +649,12 @@ Fields:
 
 Retries are attempts inside a run. The scheduler is not involved in retrying a
 failed attempt.
+
+When an attempt times out and retries remain, the run transitions to
+`retrying`, records the failed attempt as `timeout`, waits according to the
+retry policy, then returns to `queued` for the next attempt. The run reaches
+terminal `timeout` only after retry policy is exhausted or timeout is not
+retryable.
 
 ---
 
@@ -649,9 +728,10 @@ subagents/
 scratchpad/
 ```
 
-The supervisor writes `run.json`. The agent writes durable task output through
-workspace tools. Events can also be mirrored to `events.jsonl` for easy
-inspection, while `EventRouter` remains the event service.
+The supervisor binds the run workspace before calling the agent and injects a
+short run-context instruction into the request. The agent writes durable task
+output through workspace tools. Events can also be mirrored to `events.jsonl`
+for easy inspection, while `EventRouter` remains the event service.
 
 The final response returned by `OmniCoreAgent.run()` is stored as
 `result_preview`. The durable result of background work is the workspace output.
@@ -760,63 +840,6 @@ The HTTP layer calls the same manager API used by Python applications.
 
 ---
 
-## Implementation Phases
-
-### Phase 1: Models And Task Store
-
-- `models.py`
-- `store/base.py`
-- `store/router.py`
-- `store/in_memory.py`
-- `store/sql.py`
-- `store/redis.py`
-- `store/mongodb.py`
-- validation tests
-- store contract tests shared by every backend
-
-### Phase 2: Scheduler Boundary
-
-- `scheduler.py`
-- scheduler adapter implementation
-- startup schedule reconstruction
-- interval, cron, once, and manual tests
-- misfire tests
-
-### Phase 3: Dispatcher And Queue
-
-- dispatcher service
-- queue service
-- overlap policy tests
-- queued/skipped event tests
-
-### Phase 4: Supervisor
-
-- run claiming
-- leases and heartbeat
-- timeout
-- retry
-- cancellation
-- terminal status handling
-- recovery behavior
-- fake-agent end-to-end tests
-
-### Phase 5: Workspace And Events
-
-- run workspace namespace creation
-- `run.json`
-- `output.md` guidance
-- event stream integration
-- local workspace integration tests
-
-### Phase 6: Public API, Cookbook, OmniServe
-
-- manager API cleanup
-- cookbook examples
-- public docs
-- OmniServe background routes
-
----
-
 ## Acceptance Criteria
 
 The background execution system is ready when:
@@ -825,13 +848,17 @@ The background execution system is ready when:
 - `in_memory`, `sql`, `redis`, and `mongodb` conform to the same store tests
 - SQL backend supports SQLite locally and Postgres through one `sql` backend
 - enabled schedules survive manager restart on durable stores
+- schedule state stores next due, last due, dispatch cursor, and occurrence IDs
 - every run has a durable `run_id`
+- every run stores the exact input snapshot used for execution
 - every attempt is inspectable
 - long-running runs heartbeat while active
+- lease tokens fence stale workers from writing after recovery
 - expired leases can be recovered deterministically
+- queued runs remain claimable after restart
 - cancellation, timeout, retry, and overlap policies are tested
 - every background run writes workspace output
 - run status can be inspected without reading event streams
 - lifecycle events can reconstruct the run trajectory
-- optional dependencies do not load during root import
+- optional dependencies do not load during root or background-package import
 - public docs describe shipped behavior only

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -1,23 +1,18 @@
 # Background Agents Specification
 
-This is the behavior contract for OmniCoreAgent background agents. The
-architecture record explains why the system exists and how it is owned. This
-specification defines what the implementation must do.
+This specification defines the behavior contract for OmniCoreAgent background
+execution.
 
 Read this with:
 
 - `engineering/architecture/background-agents.md`
 - `src/omnicoreagent/background`
-- `src/omnicoreagent/core/runtime/omnicore_agent.py`
+- `src/omnicoreagent/core/runtime`
 - `src/omnicoreagent/core/workspace`
 - `src/omnicoreagent/core/events`
-- `tests/test_background_agent.py`
+- `src/omnicoreagent/core/memory_store`
 
-When this specification changes, implementation and tests must change in the
-same PR.
-
-This specification describes the target rebuild. It is intentionally stricter
-than the current implementation.
+When this specification changes, implementation and tests must change with it.
 
 ---
 
@@ -25,13 +20,13 @@ than the current implementation.
 
 This specification covers:
 
-- public background-agent manager API
+- public background manager API
 - typed specs and state records
-- task store behavior
+- task-store configuration and behavior
 - schedule behavior
 - dispatch and queue behavior
 - supervisor lifecycle behavior
-- retry, timeout, cancellation, and overlap behavior
+- retry, timeout, cancellation, overlap, heartbeat, and recovery behavior
 - workspace behavior
 - event behavior
 - error behavior
@@ -42,37 +37,103 @@ This specification does not cover:
 - OmniCoreAgent reasoning loop internals
 - tool execution internals
 - MCP client internals
-- conversation memory backend implementation
+- memory backend implementation
 - workspace storage driver implementation
-- OmniServe HTTP endpoints for background agents
-- future trace/evaluation/feedback-loop design
+- trace/evaluation/feedback-loop design
 
 ---
 
 ## Public Exports
 
-The public background-agent exports should be:
+The background package exports:
 
 ```python
 BackgroundAgentManager
 BackgroundAgentSpec
 BackgroundTaskSpec
 BackgroundRun
+BackgroundAttempt
 ScheduleSpec
 RetryPolicy
 OverlapPolicy
 SessionPolicy
+WorkspacePolicy
 RunStatus
-TaskStore
+TaskStoreBackend
+TaskStoreConfig
+AbstractTaskStore
+TaskStoreRouter
 InMemoryTaskStore
-SQLiteTaskStore
+SqlTaskStore
+RedisTaskStore
+MongoDBTaskStore
 ```
 
-`APSchedulerBackend` may remain public only if it is documented as a scheduler
-adapter, not the background-agent architecture.
+Scheduler implementations are internal adapters unless explicitly documented as
+extension points.
 
-`BackgroundOmniCoreAgent` should not remain part of the final public API. The
-background system should compose `OmniCoreAgent`.
+---
+
+## Backend Names
+
+Task-store backend names:
+
+```text
+in_memory
+sql
+redis
+mongodb
+```
+
+Rules:
+
+- `in_memory` is ephemeral and intended for tests/development.
+- `sql` covers SQLite and Postgres through one backend family.
+- `redis` stores task state in Redis.
+- `mongodb` stores task state in MongoDB.
+- The manager uses one task store for its lifecycle.
+- Switching task-store backend during active runs is not supported.
+- Moving state between task-store backends requires explicit export/import or
+  transfer tooling.
+
+---
+
+## Construction
+
+```python
+manager = BackgroundAgentManager(
+    task_store=None,
+    scheduler_backend=None,
+    memory_router=None,
+    event_router=None,
+    workspace=None,
+    worker_id=None,
+)
+```
+
+Defaults:
+
+- `task_store`: `{"backend": "sql", "url": "sqlite:///.omnicoreagent/background.db"}`
+- `scheduler_backend`: default scheduler adapter implementing `SchedulerBackend`
+- `memory_router`: normal OmniCoreAgent default memory router
+- `event_router`: normal OmniCoreAgent default event router
+- `workspace`: normal OmniCoreAgent default workspace
+- `worker_id`: generated stable process identifier
+
+Accepted `task_store` forms:
+
+```python
+"in_memory"
+"sql"
+"redis"
+"mongodb"
+{"backend": "sql", "url": "sqlite:///.omnicoreagent/background.db"}
+{"backend": "redis", "url": "redis://localhost:6379/0", "prefix": "oca:bg"}
+{"backend": "mongodb", "uri": "mongodb://localhost:27017", "database": "omnicoreagent"}
+AbstractTaskStore(...)
+```
+
+If an `AbstractTaskStore` instance is passed, the manager uses it directly.
 
 ---
 
@@ -84,24 +145,25 @@ Fields:
 
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
-| `agent_id` | `str` | yes | Stable identifier |
-| `name` | `str | None` | no | Agent name; defaults to `agent_id` |
-| `system_instruction` | `str | None` | when reconstructing | Agent system instruction |
-| `model_config` | `dict | None` | when reconstructing | OmniCoreAgent model config |
+| `agent_id` | `str` | yes | Stable agent identifier |
+| `name` | `str | None` | no | Display/runtime name |
+| `system_instruction` | `str | None` | no | Instruction used when reconstructing an agent |
+| `model_config` | `dict | None` | no | OmniCoreAgent model config |
 | `agent_config` | `dict` | no | OmniCoreAgent runtime config |
-| `mcp_tools` | `list[dict]` | no | MCP server tool configs |
-| `workspace_config` | `dict | None` | no | Workspace config override |
+| `mcp_tools` | `list[dict]` | no | MCP tool server configs |
+| `local_tools_ref` | `str | None` | no | Application-owned local tool set reference |
+| `workspace_config` | `dict | None` | no | Workspace override |
 | `metadata` | `dict` | no | User metadata |
 | `created_at` | `datetime` | generated | Creation timestamp |
 | `updated_at` | `datetime` | generated | Update timestamp |
 
 Validation:
 
-- `agent_id` must be non-empty.
-- `agent_id` must be stable and URL/log safe: letters, numbers, `_`, `-`, `.`.
-- `model_config` must pass OmniCoreAgent model config normalization when present.
-- `agent_config.enable_workspace_files` must be true for background tasks unless
-  the manager explicitly forces it on.
+- `agent_id` is required.
+- `agent_id` contains only letters, numbers, `_`, `-`, and `.`.
+- `model_config` is validated by the same normalization path used by
+  `OmniCoreAgent`.
+- `metadata` defaults to `{}`.
 
 ### `BackgroundTaskSpec`
 
@@ -114,24 +176,26 @@ Fields:
 | `query` | `str` | yes | Prompt passed to `OmniCoreAgent.run()` |
 | `schedule` | `ScheduleSpec` | yes | Scheduling behavior |
 | `enabled` | `bool` | no | Defaults to true |
-| `timeout` | `int | None` | no | Run timeout in seconds |
+| `timeout_seconds` | `int | None` | no | Run timeout |
 | `retry_policy` | `RetryPolicy` | no | Retry behavior |
 | `overlap_policy` | `OverlapPolicy` | no | Active-run behavior |
-| `session_policy` | `SessionPolicy` | no | Session selection |
-| `workspace_policy` | `WorkspacePolicy` | no | Run workspace layout |
+| `session_policy` | `SessionPolicy` | no | Memory session behavior |
+| `workspace_policy` | `WorkspacePolicy` | no | Workspace namespace behavior |
 | `metadata` | `dict` | no | User metadata |
 | `created_at` | `datetime` | generated | Creation timestamp |
 | `updated_at` | `datetime` | generated | Update timestamp |
 
 Validation:
 
-- `task_id` must be non-empty and URL/log safe.
-- `query` must be non-empty.
-- `timeout` must be positive when provided.
+- `task_id` is required.
+- `task_id` contains only letters, numbers, `_`, `-`, and `.`.
+- `query` is required and non-empty.
+- `timeout_seconds` is positive when provided.
 - `enabled` defaults to true.
 - `retry_policy.max_retries` defaults to 0.
 - `overlap_policy` defaults to `skip_if_running`.
 - `session_policy` defaults to `task`.
+- `workspace_policy.required` defaults to true.
 
 ### `ScheduleSpec`
 
@@ -139,23 +203,24 @@ Fields:
 
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
-| `type` | `interval | cron | once | manual` | yes | Schedule type |
-| `seconds` | `int | None` | for interval | Interval in seconds |
+| `type` | `manual | interval | cron | once` | yes | Schedule type |
+| `seconds` | `int | None` | for interval | Interval duration |
 | `expression` | `str | None` | for cron | Cron expression |
 | `run_at` | `datetime | None` | for once | One-shot run time |
 | `timezone` | `str` | no | Defaults to UTC |
-| `start_at` | `datetime | None` | no | Earliest allowed run |
-| `end_at` | `datetime | None` | no | Latest allowed run |
-| `jitter_seconds` | `int | None` | no | Randomized schedule jitter |
-| `misfire_policy` | `str` | no | Defaults to `skip_missed` |
+| `start_at` | `datetime | None` | no | Earliest due time |
+| `end_at` | `datetime | None` | no | Latest due time |
+| `jitter_seconds` | `int | None` | no | Random schedule jitter |
+| `misfire_policy` | `skip_missed | run_once | queue_all` | no | Missed trigger behavior |
 
 Validation:
 
 - `interval` requires `seconds > 0`.
 - `cron` requires a valid cron expression.
 - `once` requires `run_at`.
-- `manual` must not require scheduler fields.
+- `manual` does not require scheduler fields.
 - `end_at` must be after `start_at` when both exist.
+- `jitter_seconds` must be non-negative when provided.
 
 ### `RetryPolicy`
 
@@ -164,16 +229,17 @@ Fields:
 | Field | Type | Default |
 |-------|------|---------|
 | `max_retries` | `int` | `0` |
-| `initial_delay` | `int` | `30` |
-| `max_delay` | `int` | `300` |
+| `initial_delay_seconds` | `int` | `30` |
+| `max_delay_seconds` | `int` | `300` |
 | `backoff` | `fixed | exponential` | `fixed` |
 | `retry_on` | `list[str]` | `["exception", "timeout"]` |
 
 Validation:
 
 - `max_retries >= 0`
-- `initial_delay >= 0`
-- `max_delay >= initial_delay` unless `initial_delay` is 0
+- `initial_delay_seconds >= 0`
+- `max_delay_seconds >= initial_delay_seconds` unless
+  `initial_delay_seconds == 0`
 
 ### `OverlapPolicy`
 
@@ -186,33 +252,34 @@ cancel_previous
 allow_parallel
 ```
 
-Default:
-
-```text
-skip_if_running
-```
-
 ### `SessionPolicy`
 
-Allowed values:
+Fields:
 
-```text
-task
-run
-fixed
-```
+| Field | Type | Default |
+|-------|------|---------|
+| `mode` | `task | run | fixed` | `task` |
+| `session_id` | `str | None` | required for `fixed` |
 
-Default:
+Session ID rules:
 
-```text
-task
-```
+- `task`: `background:{agent_id}:{task_id}`
+- `run`: `background:{run_id}`
+- `fixed`: exact supplied `session_id`
 
-Rules:
+### `WorkspacePolicy`
 
-- `task` session id: `background:{agent_id}:{task_id}`
-- `run` session id: `background:{run_id}`
-- `fixed` requires explicit `session_id`
+Fields:
+
+| Field | Type | Default |
+|-------|------|---------|
+| `required` | `bool` | `true` |
+| `namespace_template` | `str` | `background/{agent_id}/{task_id}/{run_id}` |
+| `write_run_json` | `bool` | `true` |
+| `write_events_jsonl` | `bool` | `true` |
+
+Background runs require workspace output. If no workspace is configured, the
+manager uses the default local workspace.
 
 ### `BackgroundRun`
 
@@ -223,19 +290,45 @@ Fields:
 | `run_id` | `str` | Stable run identifier |
 | `task_id` | `str` | Source task |
 | `agent_id` | `str` | Executing agent |
-| `status` | `RunStatus` | Current run state |
+| `status` | `RunStatus` | Current state |
 | `attempt` | `int` | Current attempt number |
-| `max_attempts` | `int` | Retry limit plus first attempt |
+| `max_attempts` | `int` | First attempt plus retries |
+| `trigger_type` | `str` | manual, interval, cron, once, retry, recovery |
+| `triggered_at` | `datetime` | Trigger timestamp |
+| `due_at` | `datetime | None` | Schedule due timestamp |
 | `session_id` | `str` | Memory session id |
 | `workspace_path` | `str` | Run workspace namespace |
+| `lease_owner` | `str | None` | Worker holding the run |
+| `lease_expires_at` | `datetime | None` | Lease expiry |
+| `heartbeat_at` | `datetime | None` | Last heartbeat |
 | `queued_at` | `datetime | None` | Queue timestamp |
-| `claimed_at` | `datetime | None` | Worker claim timestamp |
-| `started_at` | `datetime | None` | Execution start timestamp |
+| `claimed_at` | `datetime | None` | Claim timestamp |
+| `started_at` | `datetime | None` | Execution start |
 | `finished_at` | `datetime | None` | Terminal timestamp |
-| `cancel_requested_at` | `datetime | None` | Cancellation request timestamp |
+| `cancel_requested_at` | `datetime | None` | Cancellation request |
 | `error` | `str | None` | Final error |
 | `result_preview` | `str | None` | Small response preview |
 | `metadata` | `dict` | User/runtime metadata |
+
+### `BackgroundAttempt`
+
+Fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `attempt_id` | `str` | Stable attempt identifier |
+| `run_id` | `str` | Parent run |
+| `attempt_number` | `int` | Attempt index starting at 1 |
+| `status` | `str` | running, completed, failed, timeout, cancelled |
+| `worker_id` | `str` | Worker executing attempt |
+| `started_at` | `datetime` | Attempt start |
+| `finished_at` | `datetime | None` | Attempt end |
+| `error` | `str | None` | Attempt error |
+| `retry_delay_seconds` | `int | None` | Delay before next attempt |
+
+---
+
+## Run Status
 
 Allowed statuses:
 
@@ -262,7 +355,7 @@ timeout
 skipped
 ```
 
-Transition rules:
+Allowed transitions:
 
 - `scheduled -> queued`
 - `queued -> claimed`
@@ -272,68 +365,56 @@ Transition rules:
 - `running -> completed`
 - `running -> failed`
 - `running -> timeout`
-- `queued|claimed|running|retrying -> cancelled`
-- `scheduled|queued -> skipped`
-- terminal states do not transition
+- `queued -> cancelled`
+- `claimed -> cancelled`
+- `running -> cancelled`
+- `retrying -> cancelled`
+- `scheduled -> skipped`
+- `queued -> skipped`
+
+Terminal runs cannot be mutated except for non-state metadata explicitly allowed
+by the store.
 
 ---
 
-## Manager Contract
+## Manager API
 
-### Construction
-
-```python
-manager = BackgroundAgentManager(
-    task_store=None,
-    scheduler_backend=None,
-    memory_router=None,
-    event_router=None,
-)
-```
-
-Defaults:
-
-- `task_store`: `SQLiteTaskStore` after the rebuild, `InMemoryTaskStore` only
-  when explicitly requested or during tests
-- `scheduler_backend`: APScheduler adapter
-- `memory_router`: `MemoryRouter("in_memory")` unless passed
-- `event_router`: `EventRouter("in_memory")` unless passed
-
-### Agent Registration
+### Agent Operations
 
 ```python
-await manager.register_agent(agent_id: str, agent: OmniCoreAgent)
-await manager.register_agent_spec(spec: BackgroundAgentSpec | dict)
-await manager.unregister_agent(agent_id: str)
+await manager.register_agent(agent_id: str, agent: OmniCoreAgent, replace: bool = False)
+await manager.register_agent_spec(spec: BackgroundAgentSpec | dict, replace: bool = False)
+await manager.unregister_agent(agent_id: str, force: bool = False)
 await manager.get_agent(agent_id: str)
 await manager.list_agents()
 ```
 
 Rules:
 
-- registering the same `agent_id` twice raises unless `replace=True` is passed
-- unregistering an agent with active runs raises unless `force=True` is passed
-- direct agent objects are stored in process; serializable specs are stored in
-  `TaskStore`
+- duplicate agent IDs raise unless `replace=True`.
+- unregistering an agent with active runs raises unless `force=True`.
+- direct agent objects are process-local.
+- serializable agent specs are persisted through the task store.
 
-### Task Registration
+### Task Operations
 
 ```python
-await manager.register_task(spec: BackgroundTaskSpec | dict)
+await manager.register_task(spec: BackgroundTaskSpec | dict, replace: bool = False)
 await manager.update_task(task_id: str, patch: dict)
-await manager.delete_task(task_id: str)
+await manager.delete_task(task_id: str, delete_runs: bool = False)
 await manager.get_task(task_id: str)
 await manager.list_tasks(agent_id: str | None = None)
 ```
 
 Rules:
 
-- registering a task for an unknown `agent_id` raises
-- deleting a task disables schedule and preserves historical runs unless
-  `delete_runs=True`
-- updating schedule must reschedule the task from the task store source of truth
+- registering a task for an unknown `agent_id` raises.
+- duplicate task IDs raise unless `replace=True`.
+- updating schedule state reschedules from task-store truth.
+- deleting a task removes scheduler triggers.
+- historical runs are preserved unless `delete_runs=True`.
 
-### Runtime Control
+### Runtime Operations
 
 ```python
 await manager.start()
@@ -342,21 +423,25 @@ await manager.pause_task(task_id: str)
 await manager.resume_task(task_id: str)
 await manager.run_now(task_id: str, query: str | None = None)
 await manager.cancel_run(run_id: str)
+await manager.recover_expired_runs()
 ```
 
 Rules:
 
-- `start()` loads enabled tasks from task store and schedules them
-- `shutdown()` stops accepting new runs, asks workers to finish or cancel based
-  on shutdown policy, then closes scheduler
-- `run_now()` creates a run even for manual tasks
-- `cancel_run()` is idempotent
+- `start()` initializes store, scheduler, queue, dispatcher, and supervisor.
+- `start()` rebuilds enabled schedules from the task store.
+- `shutdown()` stops accepting new runs and then stops workers by shutdown
+  policy.
+- `run_now()` creates a run for any registered task, including manual tasks.
+- `cancel_run()` is idempotent.
+- `recover_expired_runs()` claims expired leases according to recovery policy.
 
-### Inspection
+### Inspection Operations
 
 ```python
 await manager.get_run(run_id: str)
 await manager.list_runs(task_id: str | None = None, status: str | None = None)
+await manager.list_attempts(run_id: str)
 await manager.get_task_status(task_id: str)
 await manager.get_manager_status()
 await manager.get_run_events(run_id: str)
@@ -366,13 +451,14 @@ Status payloads must be serializable dictionaries.
 
 ---
 
-## Task Store Contract
-
-`TaskStore` is a protocol.
+## `AbstractTaskStore` Protocol
 
 Required methods:
 
 ```python
+async def initialize() -> None: ...
+async def close() -> None: ...
+
 async def save_agent(spec: BackgroundAgentSpec) -> None: ...
 async def get_agent(agent_id: str) -> BackgroundAgentSpec | None: ...
 async def delete_agent(agent_id: str) -> None: ...
@@ -381,12 +467,23 @@ async def list_agents() -> list[BackgroundAgentSpec]: ...
 async def save_task(spec: BackgroundTaskSpec) -> None: ...
 async def get_task(task_id: str) -> BackgroundTaskSpec | None: ...
 async def delete_task(task_id: str) -> None: ...
-async def list_tasks(agent_id: str | None = None) -> list[BackgroundTaskSpec]: ...
+async def list_tasks(agent_id: str | None = None, enabled: bool | None = None) -> list[BackgroundTaskSpec]: ...
 
 async def create_run(run: BackgroundRun) -> None: ...
 async def get_run(run_id: str) -> BackgroundRun | None: ...
 async def update_run(run_id: str, patch: dict) -> BackgroundRun: ...
-async def list_runs(task_id: str | None = None, status: str | None = None) -> list[BackgroundRun]: ...
+async def transition_run(run_id: str, expected: set[RunStatus], next_status: RunStatus, patch: dict | None = None) -> BackgroundRun: ...
+async def list_runs(task_id: str | None = None, status: RunStatus | None = None) -> list[BackgroundRun]: ...
+async def list_active_runs(task_id: str | None = None) -> list[BackgroundRun]: ...
+
+async def create_attempt(attempt: BackgroundAttempt) -> None: ...
+async def update_attempt(attempt_id: str, patch: dict) -> BackgroundAttempt: ...
+async def list_attempts(run_id: str) -> list[BackgroundAttempt]: ...
+
+async def claim_run(run_id: str, worker_id: str, lease_seconds: int) -> BackgroundRun: ...
+async def refresh_lease(run_id: str, worker_id: str, lease_seconds: int) -> None: ...
+async def release_lease(run_id: str, worker_id: str) -> None: ...
+async def list_expired_leases(now: datetime) -> list[BackgroundRun]: ...
 
 async def request_cancel(run_id: str) -> None: ...
 async def is_cancel_requested(run_id: str) -> bool: ...
@@ -394,17 +491,18 @@ async def is_cancel_requested(run_id: str) -> bool: ...
 
 Store requirements:
 
-- all writes are atomic at the record level
-- IDs are unique
-- updates to terminal runs are rejected unless explicitly allowed for metadata
-- list methods return deterministic order by creation time unless specified
-- SQLite store persists across process restart
+- writes are atomic at record level.
+- IDs are unique.
+- state transitions are validated.
+- terminal status is written exactly once.
+- claim operations are atomic.
+- list methods are deterministic.
+- durable backends persist across process restart.
+- every backend passes the shared task-store contract tests.
 
 ---
 
 ## Scheduler Contract
-
-`SchedulerBackend` is a protocol.
 
 Required methods:
 
@@ -421,11 +519,13 @@ async def is_scheduled(task_id: str) -> bool: ...
 
 Scheduler requirements:
 
-- `manual` tasks are not scheduled
-- disabled tasks are not scheduled
-- startup rebuilds schedule from task store
-- schedule callbacks do not execute the agent; they notify the dispatcher
-- invalid schedule specs raise validation errors before reaching scheduler
+- manual tasks are not scheduled.
+- disabled tasks are not scheduled.
+- schedule callbacks notify the dispatcher.
+- schedule callbacks do not call `OmniCoreAgent.run()`.
+- startup schedules are rebuilt from task-store records.
+- invalid schedule specs fail validation before scheduler registration.
+- misfire behavior follows `ScheduleSpec.misfire_policy`.
 
 ---
 
@@ -434,29 +534,30 @@ Scheduler requirements:
 Dispatcher input:
 
 ```python
-task_id
-due_at
-trigger_reason
+task_id: str
+due_at: datetime | None
+trigger_type: str
+trigger_metadata: dict
 ```
 
-Dispatcher behavior:
+Behavior:
 
 1. Load task from task store.
 2. If missing, emit skipped and return.
 3. If disabled, emit skipped and return.
-4. Apply overlap policy.
-5. Create `BackgroundRun`.
-6. Persist run as `queued`.
-7. Enqueue run.
-8. Emit `background_run_queued`.
+4. Load active runs for overlap policy.
+5. Apply overlap policy.
+6. Create `BackgroundRun`.
+7. Persist run as `queued`.
+8. Enqueue run ID.
+9. Emit `background_run_queued`.
 
 Overlap behavior:
 
-- `skip_if_running`: if active run exists for task, create skipped run or emit
-  skipped event without creating a normal run.
-- `queue_next`: create queued run.
-- `cancel_previous`: request cancel for active runs, then queue new run.
-- `allow_parallel`: create queued run without checking active runs.
+- `skip_if_running`: emit skipped or create a skipped run.
+- `queue_next`: queue the new run.
+- `cancel_previous`: request cancel on active runs, then queue the new run.
+- `allow_parallel`: queue the new run.
 
 ---
 
@@ -465,15 +566,17 @@ Overlap behavior:
 Supervisor loop:
 
 ```text
-dequeue run
-claim run
+dequeue run id
+claim run with lease
 resolve agent
 resolve task
 resolve session id
 resolve workspace namespace
 mark running
-execute agent
+execute attempt
+heartbeat while active
 handle retry/timeout/cancel/error
+write workspace metadata
 mark terminal
 emit events
 ```
@@ -484,23 +587,41 @@ Execution call:
 result = await agent.run(query=task.query, session_id=run.session_id)
 ```
 
-Supervisor requirements:
+Requirements:
 
-- do not call agent if cancel is already requested
-- set `started_at` before calling agent
-- enforce timeout with `asyncio.wait_for`
-- preserve partial workspace output on failure
-- update `attempt` before each attempt
-- apply retry policy outside scheduler
-- write `result_preview` from final response
-- emit terminal event exactly once
-- mark run terminal even when event emission fails
+- do not call agent when cancellation is already requested.
+- set `started_at` before agent execution.
+- enforce timeout with async timeout control.
+- refresh heartbeat while active.
+- preserve partial workspace output on failure.
+- create an attempt record before each attempt.
+- update attempt status after each attempt.
+- apply retry policy outside scheduler.
+- write `result_preview` from final response.
+- emit terminal event exactly once.
+- mark terminal state even when event emission fails.
+- release lease after terminal state.
+
+---
+
+## Recovery Contract
+
+Recovery scans expired leases.
+
+For each expired run:
+
+- if terminal, ignore.
+- if cancellation requested, mark cancelled.
+- if attempts remain and retry policy allows recovery, mark retrying and queue.
+- if attempts are exhausted, mark failed.
+- emit `background_run_recovered` when recovery changes state.
+
+Recovery must use atomic store transitions so multiple supervisors do not
+recover the same run.
 
 ---
 
 ## Workspace Contract
-
-Background runs require workspace files.
 
 Default namespace:
 
@@ -517,31 +638,31 @@ events.jsonl
 logs/
 artifacts/
 subagents/
+scratchpad/
 ```
 
-Supervisor must write `run.json` with:
+`run.json` fields:
 
 - `run_id`
 - `task_id`
 - `agent_id`
 - `status`
+- `attempt`
 - `session_id`
+- `workspace_path`
 - `started_at`
 - `finished_at`
 - `error`
 - `result_preview`
 
-The agent prompt/run context should include:
+Run context guidance must include:
 
 ```text
-Write durable outputs for this background run under:
+This is a background run. Write durable outputs under:
 /workspace/background/{agent_id}/{task_id}/{run_id}/
 Use output.md for the final durable result.
-Use scratchpad/progress files when the task is long.
+Use scratchpad files for progress, notes, todos, and resumable work.
 ```
-
-The final response should still be returned and stored as preview, but
-workspace output is the durable artifact of the background run.
 
 ---
 
@@ -557,13 +678,16 @@ background_task_paused
 background_task_resumed
 background_task_deleted
 background_run_queued
+background_run_claimed
 background_run_started
+background_run_heartbeat
 background_run_retrying
 background_run_completed
 background_run_failed
 background_run_timeout
 background_run_cancelled
 background_run_skipped
+background_run_recovered
 ```
 
 Common payload fields:
@@ -573,23 +697,21 @@ Common payload fields:
 | `agent_id` | yes | Agent identifier |
 | `task_id` | when task-related | Task identifier |
 | `run_id` | when run-related | Run identifier |
-| `session_id` | when run-related | Memory/event session id |
+| `session_id` | when run-related | Memory session id |
 | `status` | when status-related | Current status |
 | `attempt` | when run-related | Attempt number |
 | `timestamp` | yes | ISO timestamp |
 | `error` | on failures | Error string |
 | `workspace_path` | on run events | Run workspace namespace |
+| `worker_id` | on worker events | Supervisor worker id |
 
 Events must be emitted through `EventRouter`.
-
-Run state must still be persisted in `TaskStore`; event emission is not the
-source of truth.
 
 ---
 
 ## Error Contract
 
-Use typed background errors:
+Typed errors:
 
 ```text
 BackgroundAgentError
@@ -599,17 +721,17 @@ TaskAlreadyRegisteredError
 TaskNotFoundError
 RunNotFoundError
 InvalidScheduleError
+InvalidTaskStoreError
 TaskStoreError
 SchedulerError
+RunLeaseError
 RunCancelledError
 RunTimeoutError
 RunExecutionError
 ```
 
-Public manager methods should raise typed errors for programming mistakes and
-return serializable state for normal status queries.
-
-Do not hide scheduler/store/execution failures behind `False` returns.
+Public manager methods raise typed errors for programming mistakes and return
+serializable state for normal status queries.
 
 ---
 
@@ -621,100 +743,103 @@ Do not hide scheduler/store/execution failures behind `False` returns.
 - validates schedule types
 - validates retry policy
 - validates timeout
+- validates workspace policy
 - validates default policies
-- rejects unknown status transitions
+- rejects invalid status transitions
 
-### Task Store Tests
+### Task Store Contract Tests
 
-- stores and retrieves agent specs
-- stores and retrieves task specs
-- stores and updates run records
-- rejects terminal run mutation
-- supports cancellation flag
-- SQLite store persists across reconnect
-- list methods are deterministic
+Run the same contract tests against every backend:
+
+- saves and retrieves agent specs
+- saves and retrieves task specs
+- creates and reads run records
+- creates and reads attempt records
+- updates run records
+- rejects invalid transitions
+- rejects terminal state mutation
+- claims runs atomically
+- refreshes leases
+- lists expired leases
+- stores cancellation flags
+- lists active runs
+- returns deterministic lists
+- persists across reconnect for durable stores
 
 ### Scheduler Tests
 
 - schedules interval tasks
 - schedules cron tasks
+- schedules once tasks
 - ignores manual tasks
 - ignores disabled tasks
 - unschedules deleted tasks
 - rebuilds jobs from task store on startup
 - reports next run time
+- applies misfire policy
 
 ### Dispatcher Tests
 
 - due task creates queued run
 - disabled task is skipped
 - missing task is skipped
-- overlap policies work
-- enqueue failure marks run failed or skipped according to policy
+- every overlap policy works
+- enqueue failure records failed/skipped behavior
 
 ### Supervisor Tests
 
+- claims queued run
 - executes agent runner once
 - records completed run
 - records failed run
-- enforces timeout
-- handles cancellation before start
-- handles cancellation during retry wait
+- records timeout
+- records cancellation before start
+- records cancellation during retry wait
 - applies fixed retry
 - applies exponential retry
+- refreshes heartbeat
+- recovers expired lease
 - writes run metadata to workspace
 - emits lifecycle events
 
 ### Manager Tests
 
-- register agent
-- register task
-- start schedules enabled tasks
-- pause/resume task
-- run now
-- cancel run
-- list runs
-- shutdown stops scheduler and workers
-- no direct import of APScheduler on root package import unless background extra is used
+- registers agent
+- registers task
+- starts schedules for enabled tasks
+- pauses task
+- resumes task
+- runs task immediately
+- cancels run
+- lists runs
+- lists attempts
+- shuts down scheduler and workers
+- does not import optional scheduler/storage dependencies during root import
 
 ### Integration Tests
 
 - in-memory end-to-end background run with fake agent
-- SQLite-backed end-to-end restart recovery
+- SQL SQLite end-to-end restart recovery
 - workspace output persists for local workspace
 - event trace can be built for a background run
 - cookbook background example runs with a short schedule and clean shutdown
 
 ---
 
-## Migration Contract
-
-The legacy implementation can be removed rather than preserved.
-
-Migration rules:
-
-- replace `BackgroundOmniCoreAgent` subclassing with supervisor composition
-- replace `TaskRegistry` with `TaskStore`
-- replace mutable dict config flow with typed validation
-- keep APScheduler only as an adapter
-- update public docs only after behavior is implemented
-- update cookbook examples in the same PR as public API changes
-
-Temporary compatibility wrappers are allowed only inside tests or migration
-helpers and must not appear in public docs.
-
----
-
 ## Acceptance Criteria
 
-The background-agent rebuild is acceptable when:
+The implementation satisfies this specification when:
 
-- background runs have durable `run_id` records
-- tasks survive process restart with SQLite task store
-- run status can be inspected without reading event streams
-- scheduled runs, manual runs, cancellation, timeout, and retry are tested
-- background run output is written under workspace
-- lifecycle events are emitted and traceable
-- root import remains lightweight
-- public docs describe only shipped behavior
-- old subclass-centered design is removed
+- `BackgroundAgentManager` uses `AbstractTaskStore` for all operational state.
+- `TaskStoreRouter` supports `in_memory`, `sql`, `redis`, and `mongodb`.
+- `sql` supports SQLite and Postgres through one backend interface.
+- durable stores survive manager restart.
+- every run has a durable `run_id`.
+- every retry creates an attempt record.
+- active runs have leases and heartbeats.
+- expired leases are recoverable.
+- run status is inspectable without event replay.
+- workspace output is written for every background run.
+- cancellation, timeout, retry, overlap, and recovery behavior are tested.
+- root import remains lightweight.
+- public docs and cookbook examples match the implemented API.

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -51,6 +51,7 @@ The background package exports:
 BackgroundAgentManager
 BackgroundAgentSpec
 BackgroundTaskSpec
+BackgroundScheduleState
 BackgroundRun
 BackgroundAttempt
 ScheduleSpec
@@ -63,12 +64,30 @@ TaskStoreBackend
 TaskStoreConfig
 AbstractTaskStore
 TaskStoreRouter
+SchedulerBackend
 InMemoryTaskStore
 SqlTaskStore
 RedisTaskStore
 MongoDBTaskStore
+BackgroundAgentError
+AgentAlreadyRegisteredError
+AgentNotFoundError
+TaskAlreadyRegisteredError
+TaskNotFoundError
+RunNotFoundError
+InvalidScheduleError
+InvalidTaskStoreError
+TaskStoreError
+SchedulerError
+RunLeaseError
+RunCancelledError
+RunTimeoutError
+RunExecutionError
 ```
 
+Concrete optional backend classes must be lazy exports. Importing
+`omnicoreagent` or `omnicoreagent.background` must not import Redis, MongoDB,
+SQLAlchemy, or scheduler packages until the matching backend is selected.
 Scheduler implementations are internal adapters unless explicitly documented as
 extension points.
 
@@ -95,6 +114,37 @@ Rules:
 - Switching task-store backend during active runs is not supported.
 - Moving state between task-store backends requires explicit export/import or
   transfer tooling.
+
+Redis requirements:
+
+- task, schedule, run, and attempt records must not use TTL.
+- Redis deployments used for durable background state must enable AOF or an
+  equivalent managed durability setting with an explicit acknowledged-write loss
+  bound. RDB-only persistence is not sufficient for strict durable task state.
+- eviction policy must not evict task-store keys.
+- atomic claim, transition, overlap, and schedule-advance operations must use
+  transactions or Lua scripts.
+
+SQL requirements:
+
+- scheduled dispatch, overlap checks, `cancel_previous`, run claiming, lease
+  refresh, and terminal transitions must run in database transactions.
+- SQL backends must enforce uniqueness for `(task_id, occurrence_id)` when
+  `occurrence_id` is not null.
+- claim and transition queries must use row-level locking or an equivalent
+  compare-and-set condition.
+- Postgres must use an isolation level that prevents duplicate active runs for
+  guarded overlap policies.
+
+MongoDB requirements:
+
+- task-store writes that must be atomic across schedule/run/attempt records must
+  use MongoDB transactions on deployments that support them.
+- deployments must use majority write concern for durable task state.
+- MongoDB backends must create a unique index for `(task_id, occurrence_id)`
+  when `occurrence_id` is not null.
+- claim and transition updates must include expected status and lease token in
+  the filter.
 
 ---
 
@@ -125,8 +175,6 @@ Accepted `task_store` forms:
 ```python
 "in_memory"
 "sql"
-"redis"
-"mongodb"
 {"backend": "sql", "url": "sqlite:///.omnicoreagent/background.db"}
 {"backend": "redis", "url": "redis://localhost:6379/0", "prefix": "oca:bg"}
 {"backend": "mongodb", "uri": "mongodb://localhost:27017", "database": "omnicoreagent"}
@@ -134,6 +182,43 @@ AbstractTaskStore(...)
 ```
 
 If an `AbstractTaskStore` instance is passed, the manager uses it directly.
+
+### `TaskStoreBackend`
+
+Allowed values:
+
+```text
+in_memory
+sql
+redis
+mongodb
+```
+
+### `TaskStoreConfig`
+
+Common fields:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `backend` | `TaskStoreBackend` | yes | Store backend |
+| `prefix` | `str | None` | no | Key/table/collection prefix |
+| `connect_timeout` | `float | None` | no | Backend connection timeout |
+
+Backend-specific fields:
+
+| Backend | Fields |
+|---------|--------|
+| `in_memory` | no required fields |
+| `sql` | `url`; accepts SQLite and Postgres URLs; defaults to `sqlite:///.omnicoreagent/background.db` when omitted |
+| `redis` | `url`; Redis must use persistence and no eviction for task records |
+| `mongodb` | `uri`, `database`; optional `collection_prefix` |
+
+Unknown fields raise `InvalidTaskStoreError`. `uri` is only accepted for
+MongoDB. `url` is used for SQL and Redis.
+
+Bare string construction is accepted only for `in_memory` and `sql`. Redis and
+MongoDB require explicit config dictionaries so connection and durability choices
+are visible at construction time.
 
 ---
 
@@ -195,7 +280,7 @@ Validation:
 - `retry_policy.max_retries` defaults to 0.
 - `overlap_policy` defaults to `skip_if_running`.
 - `session_policy` defaults to `task`.
-- `workspace_policy.required` defaults to true.
+- `workspace_policy` always creates a run workspace.
 
 ### `ScheduleSpec`
 
@@ -241,6 +326,14 @@ Validation:
 - `max_delay_seconds >= initial_delay_seconds` unless
   `initial_delay_seconds == 0`
 
+Timeout semantics:
+
+- an attempt timeout records the attempt as `timeout`.
+- if timeout is retryable and attempts remain, the run transitions to
+  `retrying`, waits according to policy, then transitions to `queued`.
+- the run transitions to terminal `timeout` only when no retry remains or
+  timeout is not retryable.
+
 ### `OverlapPolicy`
 
 Allowed values:
@@ -273,13 +366,46 @@ Fields:
 
 | Field | Type | Default |
 |-------|------|---------|
-| `required` | `bool` | `true` |
 | `namespace_template` | `str` | `background/{agent_id}/{task_id}/{run_id}` |
 | `write_run_json` | `bool` | `true` |
 | `write_events_jsonl` | `bool` | `true` |
 
-Background runs require workspace output. If no workspace is configured, the
-manager uses the default local workspace.
+Background runs always require workspace output. If no workspace is configured,
+the manager uses the default local workspace.
+
+### `BackgroundScheduleState`
+
+Fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `task_id` | `str` | Source task |
+| `next_due_at` | `datetime | None` | Next due occurrence |
+| `last_due_at` | `datetime | None` | Last due occurrence |
+| `last_dispatched_at` | `datetime | None` | Last successfully dispatched occurrence |
+| `paused` | `bool` | Whether scheduling is paused |
+| `schedule_revision` | `int` | Monotonic revision for compare-and-set updates |
+| `misfire_cursor` | `str | None` | Backend-specific cursor for missed occurrences |
+| `updated_at` | `datetime` | Last schedule-state update |
+
+Each due occurrence has a stable `occurrence_id`. The store uses
+`occurrence_id` to prevent duplicate run creation for the same scheduled
+occurrence.
+
+Occurrence IDs are unique per task. The portable uniqueness key is:
+
+```text
+(task_id, occurrence_id)
+```
+
+`occurrence_id` is derived from the schedule type, schedule revision, and due
+timestamp:
+
+```text
+{schedule_type}:{schedule_revision}:{due_at_iso}
+```
+
+Manual runs do not use occurrence IDs.
 
 ### `BackgroundRun`
 
@@ -293,12 +419,17 @@ Fields:
 | `status` | `RunStatus` | Current state |
 | `attempt` | `int` | Current attempt number |
 | `max_attempts` | `int` | First attempt plus retries |
-| `trigger_type` | `str` | manual, interval, cron, once, retry, recovery |
+| `query_snapshot` | `str` | Run input captured at dispatch time |
+| `trigger_type` | `str` | manual, interval, cron, once |
 | `triggered_at` | `datetime` | Trigger timestamp |
 | `due_at` | `datetime | None` | Schedule due timestamp |
+| `occurrence_id` | `str | None` | Stable schedule occurrence id |
+| `trigger_metadata` | `dict` | Trigger reason/source metadata |
 | `session_id` | `str` | Memory session id |
 | `workspace_path` | `str` | Run workspace namespace |
 | `lease_owner` | `str | None` | Worker holding the run |
+| `lease_token` | `str | None` | Fencing token for the current lease |
+| `lease_generation` | `int` | Monotonic lease generation |
 | `lease_expires_at` | `datetime | None` | Lease expiry |
 | `heartbeat_at` | `datetime | None` | Last heartbeat |
 | `queued_at` | `datetime | None` | Queue timestamp |
@@ -319,8 +450,10 @@ Fields:
 | `attempt_id` | `str` | Stable attempt identifier |
 | `run_id` | `str` | Parent run |
 | `attempt_number` | `int` | Attempt index starting at 1 |
+| `reason` | `str` | initial, retry, recovery, lease_expired |
 | `status` | `str` | running, completed, failed, timeout, cancelled |
 | `worker_id` | `str` | Worker executing attempt |
+| `lease_token` | `str` | Lease token held by the worker |
 | `started_at` | `datetime` | Attempt start |
 | `finished_at` | `datetime | None` | Attempt end |
 | `error` | `str | None` | Attempt error |
@@ -333,7 +466,6 @@ Fields:
 Allowed statuses:
 
 ```text
-scheduled
 queued
 claimed
 running
@@ -357,11 +489,12 @@ skipped
 
 Allowed transitions:
 
-- `scheduled -> queued`
 - `queued -> claimed`
 - `claimed -> running`
 - `running -> retrying`
-- `retrying -> running`
+- `retrying -> queued`
+- `queued -> claimed`
+- `claimed -> running`
 - `running -> completed`
 - `running -> failed`
 - `running -> timeout`
@@ -369,11 +502,11 @@ Allowed transitions:
 - `claimed -> cancelled`
 - `running -> cancelled`
 - `retrying -> cancelled`
-- `scheduled -> skipped`
 - `queued -> skipped`
 
-Terminal runs cannot be mutated except for non-state metadata explicitly allowed
-by the store.
+Schedule state tracks due work before a run exists. A run starts at `queued`
+after the dispatcher creates it. Terminal runs cannot be mutated except for
+non-state metadata explicitly allowed by the store.
 
 ---
 
@@ -399,7 +532,21 @@ Rules:
 ### Task Operations
 
 ```python
-await manager.register_task(spec: BackgroundTaskSpec | dict, replace: bool = False)
+await manager.register_task(
+    spec: BackgroundTaskSpec | dict | None = None,
+    *,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+    query: str | None = None,
+    schedule: ScheduleSpec | dict | None = None,
+    timeout_seconds: int | None = None,
+    retry_policy: RetryPolicy | dict | None = None,
+    overlap_policy: OverlapPolicy | str | None = None,
+    session_policy: SessionPolicy | dict | None = None,
+    workspace_policy: WorkspacePolicy | dict | None = None,
+    metadata: dict | None = None,
+    replace: bool = False,
+)
 await manager.update_task(task_id: str, patch: dict)
 await manager.delete_task(task_id: str, delete_runs: bool = False)
 await manager.get_task(task_id: str)
@@ -410,6 +557,7 @@ Rules:
 
 - registering a task for an unknown `agent_id` raises.
 - duplicate task IDs raise unless `replace=True`.
+- callers pass either `spec` or keyword fields, not both.
 - updating schedule state reschedules from task-store truth.
 - deleting a task removes scheduler triggers.
 - historical runs are preserved unless `delete_runs=True`.
@@ -432,7 +580,8 @@ Rules:
 - `start()` rebuilds enabled schedules from the task store.
 - `shutdown()` stops accepting new runs and then stops workers by shutdown
   policy.
-- `run_now()` creates a run for any registered task, including manual tasks.
+- `run_now()` creates a run for any registered enabled task, including manual
+  tasks.
 - `cancel_run()` is idempotent.
 - `recover_expired_runs()` claims expired leases according to recovery policy.
 
@@ -469,20 +618,28 @@ async def get_task(task_id: str) -> BackgroundTaskSpec | None: ...
 async def delete_task(task_id: str) -> None: ...
 async def list_tasks(agent_id: str | None = None, enabled: bool | None = None) -> list[BackgroundTaskSpec]: ...
 
-async def create_run(run: BackgroundRun) -> None: ...
+async def save_schedule_state(state: BackgroundScheduleState) -> None: ...
+async def get_schedule_state(task_id: str) -> BackgroundScheduleState | None: ...
+async def get_due_schedules(now: datetime, limit: int) -> list[tuple[BackgroundTaskSpec, BackgroundScheduleState, str]]: ...
+async def advance_schedule(task_id: str, expected_revision: int, occurrence_id: str, next_due_at: datetime | None) -> BackgroundScheduleState: ...
+async def dispatch_scheduled_run(run: BackgroundRun, overlap_policy: OverlapPolicy, expected_schedule_revision: int, next_due_at: datetime | None) -> BackgroundRun: ...
+async def create_run_with_overlap_guard(run: BackgroundRun, overlap_policy: OverlapPolicy) -> BackgroundRun: ...
 async def get_run(run_id: str) -> BackgroundRun | None: ...
-async def update_run(run_id: str, patch: dict) -> BackgroundRun: ...
-async def transition_run(run_id: str, expected: set[RunStatus], next_status: RunStatus, patch: dict | None = None) -> BackgroundRun: ...
+async def update_run_metadata(run_id: str, patch: dict, worker_id: str | None = None, lease_token: str | None = None) -> BackgroundRun: ...
+async def transition_run(run_id: str, expected: set[RunStatus], next_status: RunStatus, patch: dict | None = None, worker_id: str | None = None, lease_token: str | None = None) -> BackgroundRun: ...
 async def list_runs(task_id: str | None = None, status: RunStatus | None = None) -> list[BackgroundRun]: ...
 async def list_active_runs(task_id: str | None = None) -> list[BackgroundRun]: ...
+async def list_claimable_runs(limit: int) -> list[BackgroundRun]: ...
+async def claim_next_run(worker_id: str, lease_seconds: int) -> BackgroundRun | None: ...
 
 async def create_attempt(attempt: BackgroundAttempt) -> None: ...
-async def update_attempt(attempt_id: str, patch: dict) -> BackgroundAttempt: ...
+async def update_attempt(attempt_id: str, patch: dict, worker_id: str, lease_token: str) -> BackgroundAttempt: ...
 async def list_attempts(run_id: str) -> list[BackgroundAttempt]: ...
 
 async def claim_run(run_id: str, worker_id: str, lease_seconds: int) -> BackgroundRun: ...
-async def refresh_lease(run_id: str, worker_id: str, lease_seconds: int) -> None: ...
-async def release_lease(run_id: str, worker_id: str) -> None: ...
+async def steal_expired_run(run_id: str, worker_id: str, lease_seconds: int) -> BackgroundRun: ...
+async def refresh_lease(run_id: str, worker_id: str, lease_token: str, lease_seconds: int) -> None: ...
+async def release_lease(run_id: str, worker_id: str, lease_token: str) -> None: ...
 async def list_expired_leases(now: datetime) -> list[BackgroundRun]: ...
 
 async def request_cancel(run_id: str) -> None: ...
@@ -496,6 +653,18 @@ Store requirements:
 - state transitions are validated.
 - terminal status is written exactly once.
 - claim operations are atomic.
+- scheduled dispatch creates the run, applies overlap, handles
+  `cancel_previous`, deduplicates `occurrence_id`, and advances schedule state
+  atomically.
+- manual run creation and overlap guard are atomic.
+- `claim_next_run` enforces `queue_next` per-task serialization.
+- execution-state transitions require `worker_id` and `lease_token` after claim.
+- run metadata writes from an active worker require `worker_id` and
+  `lease_token`; operator metadata writes outside execution must not change
+  execution state.
+- lease writes compare `worker_id` and `lease_token`.
+- expired-lease stealing creates a new `lease_token` and increments
+  `lease_generation` atomically.
 - list methods are deterministic.
 - durable backends persist across process restart.
 - every backend passes the shared task-store contract tests.
@@ -521,11 +690,13 @@ Scheduler requirements:
 
 - manual tasks are not scheduled.
 - disabled tasks are not scheduled.
-- schedule callbacks notify the dispatcher.
+- schedule callbacks are advisory wakeups that tell the dispatcher to read due
+  schedules with `get_due_schedules(now, limit)`.
 - schedule callbacks do not call `OmniCoreAgent.run()`.
 - startup schedules are rebuilt from task-store records.
 - invalid schedule specs fail validation before scheduler registration.
 - misfire behavior follows `ScheduleSpec.misfire_policy`.
+- mutable schedule progress is written through `BackgroundScheduleState`.
 
 ---
 
@@ -538,26 +709,44 @@ task_id: str
 due_at: datetime | None
 trigger_type: str
 trigger_metadata: dict
+occurrence_id: str | None
 ```
 
 Behavior:
 
+Scheduled behavior:
+
+1. A scheduler wakeup or startup scan calls `get_due_schedules(now, limit)`.
+2. For each due occurrence, build a `BackgroundRun` with `query_snapshot`
+   copied from the task.
+3. Persist the run with `dispatch_scheduled_run()`, which atomically applies
+   overlap policy, deduplicates `occurrence_id`, handles `cancel_previous`,
+   and advances schedule state.
+4. Emit `background_run_queued` or `background_run_skipped`.
+
+Manual behavior:
+
 1. Load task from task store.
-2. If missing, emit skipped and return.
-3. If disabled, emit skipped and return.
-4. Load active runs for overlap policy.
-5. Apply overlap policy.
-6. Create `BackgroundRun`.
-7. Persist run as `queued`.
-8. Enqueue run ID.
-9. Emit `background_run_queued`.
+2. If missing, raise `TaskNotFoundError`.
+3. If disabled, raise `TaskNotFoundError`.
+4. Build a `BackgroundRun` with `query_snapshot` copied from the task or manual
+   override.
+5. Persist the run through `create_run_with_overlap_guard()`.
+6. Do not advance schedule state.
+7. Emit `background_run_queued` or `background_run_skipped`.
 
 Overlap behavior:
 
-- `skip_if_running`: emit skipped or create a skipped run.
-- `queue_next`: queue the new run.
-- `cancel_previous`: request cancel on active runs, then queue the new run.
+- `skip_if_running`: create a terminal `skipped` run for a valid scheduled or
+  manual request.
+- `queue_next`: queue the new run; `claim_next_run` holds it until earlier
+  active runs for the same task are terminal.
+- `cancel_previous`: request cancel on active runs and create the successor run
+  in the same store transaction.
 - `allow_parallel`: queue the new run.
+
+The dispatcher does not implement overlap with a separate list-then-create
+sequence. The task store performs the overlap decision atomically.
 
 ---
 
@@ -566,8 +755,7 @@ Overlap behavior:
 Supervisor loop:
 
 ```text
-dequeue run id
-claim run with lease
+claim next run with lease
 resolve agent
 resolve task
 resolve session id
@@ -584,8 +772,17 @@ emit events
 Execution call:
 
 ```python
-result = await agent.run(query=task.query, session_id=run.session_id)
+result = await agent.run(
+    query=run.query_snapshot,
+    session_id=run.session_id,
+)
 ```
+
+Before execution, the supervisor binds the run workspace and injects the
+background run context into the request. The context contains `run_id`,
+`task_id`, `workspace_path`, and output-file guidance. The mechanism can be a
+runtime context object or request augmentation, but it must be explicit in the
+implementation and covered by tests.
 
 Requirements:
 
@@ -593,6 +790,7 @@ Requirements:
 - set `started_at` before agent execution.
 - enforce timeout with async timeout control.
 - refresh heartbeat while active.
+- every heartbeat, attempt update, and terminal write verifies `lease_token`.
 - preserve partial workspace output on failure.
 - create an attempt record before each attempt.
 - update attempt status after each attempt.
@@ -611,9 +809,14 @@ Recovery scans expired leases.
 For each expired run:
 
 - if terminal, ignore.
-- if cancellation requested, mark cancelled.
-- if attempts remain and retry policy allows recovery, mark retrying and queue.
-- if attempts are exhausted, mark failed.
+- steal the expired lease with `steal_expired_run()` to get a new
+  `lease_token`.
+- close the abandoned running attempt as `failed` with reason
+  `lease_expired`.
+- if cancellation requested, mark cancelled with the new lease token.
+- if attempts remain and retry policy allows recovery, mark retrying and then
+  queued for the normal claim path with the new lease token.
+- if attempts are exhausted, mark failed with the new lease token.
 - emit `background_run_recovered` when recovery changes state.
 
 Recovery must use atomic store transitions so multiple supervisors do not
@@ -648,6 +851,9 @@ scratchpad/
 - `agent_id`
 - `status`
 - `attempt`
+- `query_snapshot`
+- `trigger_type`
+- `occurrence_id`
 - `session_id`
 - `workspace_path`
 - `started_at`
@@ -701,11 +907,22 @@ Common payload fields:
 | `status` | when status-related | Current status |
 | `attempt` | when run-related | Attempt number |
 | `timestamp` | yes | ISO timestamp |
+| `sequence` | run events | Monotonic event sequence within the run |
 | `error` | on failures | Error string |
 | `workspace_path` | on run events | Run workspace namespace |
 | `worker_id` | on worker events | Supervisor worker id |
 
 Events must be emitted through `EventRouter`.
+
+Every background event includes `run_id` for run-scoped events. Event backends
+that store task-level streams must filter by `run_id` when returning a run
+trace.
+
+`get_run_events(run_id)` reads events from `EventRouter` when the event backend
+supports replay and run filtering. If the event backend cannot replay, the
+manager reads the run workspace `events.jsonl` mirror. Returned events are
+ordered by `sequence`, then `timestamp`. Missing event history returns an empty
+list; it does not change run state.
 
 ---
 
@@ -741,6 +958,7 @@ serializable state for normal status queries.
 
 - validates agent/task/run IDs
 - validates schedule types
+- validates schedule-state defaults and revisions
 - validates retry policy
 - validates timeout
 - validates workspace policy
@@ -753,13 +971,19 @@ Run the same contract tests against every backend:
 
 - saves and retrieves agent specs
 - saves and retrieves task specs
-- creates and reads run records
+- creates and reads run records through overlap-guarded creation
 - creates and reads attempt records
+- creates and advances schedule state
+- dispatches scheduled run and advances schedule atomically
 - updates run records
 - rejects invalid transitions
 - rejects terminal state mutation
 - claims runs atomically
+- creates manual runs with atomic overlap guard
+- handles `cancel_previous` atomically with successor run creation
+- enforces `queue_next` claim ordering
 - refreshes leases
+- rejects stale lease-token writes
 - lists expired leases
 - stores cancellation flags
 - lists active runs
@@ -781,10 +1005,11 @@ Run the same contract tests against every backend:
 ### Dispatcher Tests
 
 - due task creates queued run
-- disabled task is skipped
-- missing task is skipped
+- manual missing task raises `TaskNotFoundError`
+- manual disabled task raises `TaskNotFoundError`
 - every overlap policy works
-- enqueue failure records failed/skipped behavior
+- duplicate occurrence IDs do not create duplicate runs
+- manual dispatch does not advance schedule state
 
 ### Supervisor Tests
 
@@ -798,9 +1023,16 @@ Run the same contract tests against every backend:
 - applies fixed retry
 - applies exponential retry
 - refreshes heartbeat
+- rejects stale lease-token updates
 - recovers expired lease
+- steals expired lease with a new lease token
+- closes abandoned attempt on recovery
+- requeues recovered runs through the normal claim path
+- executes `query_snapshot`, not mutable task query
+- binds workspace and injects run context before execution
 - writes run metadata to workspace
 - emits lifecycle events
+- mirrors run events to `events.jsonl` when enabled
 
 ### Manager Tests
 
@@ -813,8 +1045,13 @@ Run the same contract tests against every backend:
 - cancels run
 - lists runs
 - lists attempts
+- reads run events from EventRouter or workspace mirror
 - shuts down scheduler and workers
 - does not import optional scheduler/storage dependencies during root import
+- does not import optional scheduler/storage dependencies during
+  `import omnicoreagent.background`
+- lazy optional backend exports fail with clear optional-extra errors when the
+  dependency is absent
 
 ### Integration Tests
 
@@ -835,11 +1072,15 @@ The implementation satisfies this specification when:
 - `sql` supports SQLite and Postgres through one backend interface.
 - durable stores survive manager restart.
 - every run has a durable `run_id`.
+- every run has a durable `query_snapshot`.
+- every scheduled occurrence has a stable `occurrence_id`.
 - every retry creates an attempt record.
 - active runs have leases and heartbeats.
+- lease tokens fence stale workers.
 - expired leases are recoverable.
+- queued runs remain claimable after restart.
 - run status is inspectable without event replay.
 - workspace output is written for every background run.
 - cancellation, timeout, retry, overlap, and recovery behavior are tested.
-- root import remains lightweight.
+- root and background-package imports remain lightweight.
 - public docs and cookbook examples match the implemented API.


### PR DESCRIPTION
## Summary
- rewrites the background-agent architecture as a target durable execution design instead of a legacy comparison
- defines AbstractTaskStore/TaskStoreRouter with in_memory, sql, redis, and mongodb backends
- hardens long-running task semantics: schedule state, occurrence IDs, store-backed queues, atomic dispatch, overlap policies, leases, fencing tokens, recovery, workspace output, and event replay
- updates the specification with concrete API, backend, event, and test contracts

## Review process
- used three independent sub-agent review passes across architecture, durability/runtime, and API/testability
- fixed genuine issues they found around scheduled run state, retry/recovery triggers, queue durability, schedule-state ownership, lease fencing, query snapshots, Redis durability, manual-vs-scheduled behavior, and event replay

## Validation
- git diff --check
- ASCII check for architecture/spec docs
- targeted stale/contradictory wording scans