### PR TITLE
Add OmniServe background task API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install omnicoreagent
 ```
 
 ```bash
-echo "LLM_API_KEY=your_api_key" > .env
+export LLM_API_KEY=your_api_key
 ```
 
 ```python
@@ -307,18 +307,23 @@ All examples live in the **[Cookbook](./cookbook)** and are organized by use cas
 
 ### Environment Variables
 
-```bash
-# Required by most hosted model providers
-LLM_API_KEY=your_api_key
+For the first run, most hosted model providers only need `LLM_API_KEY`.
+OmniCoreAgent defaults memory and events to in-memory storage, workspace files to
+local disk, and optional production integrations stay off until you configure
+them.
 
-# Workspace storage
-OMNICOREAGENT_WORKSPACE_BACKEND=local   # local | s3 | r2
-OMNICOREAGENT_WORKSPACE_DIR=./workspace
-AWS_S3_BUCKET=your-s3-bucket            # when backend=s3
-R2_BUCKET_NAME=your-r2-bucket           # when backend=r2
+```bash
+export LLM_API_KEY=your_api_key
 ```
 
-### Agent Config Reference
+Add backend-specific variables only when you opt into Redis, MongoDB, SQL
+database storage, S3, R2, or OmniServe deployment settings.
+
+### Full Harness Config Example
+
+The defaults keep the first agent small: workspace files and guardrails are on,
+conversation memory is in-memory, and advanced harness pieces stay off until
+you enable them. This example shows the production-style switches together.
 
 ```python
 agent_config = {
@@ -332,12 +337,12 @@ agent_config = {
         "summary": {"enabled": False},
     },
     "enable_workspace_files": True,      # Default on
-    "guardrail_mode": "full",            # Default guardrail mode
-    "context_management": {"enabled": True},
-    "tool_offload": {"enabled": True},
-    "enable_advanced_tool_use": True,
-    "enable_subagents": True,
-    "enable_agent_skills": True,
+    "guardrail_mode": "full",            # Default
+    "context_management": {"enabled": True},  # Default off
+    "tool_offload": {"enabled": True},        # Default off
+    "enable_advanced_tool_use": True,         # Default off
+    "enable_subagents": True,                 # Default off
+    "enable_agent_skills": True,              # Default off
 }
 ```
 
@@ -368,7 +373,7 @@ pytest tests/ --cov=src --cov-report=term-missing
 
 | Error | Fix |
 |-------|-----|
-| `Invalid API key` | Set `LLM_API_KEY` in `.env` to the key for the provider selected in `model_config`. |
+| `Invalid API key` | Export `LLM_API_KEY` with the key for the provider selected in `model_config`. |
 | `ModuleNotFoundError` for Redis / Postgres / MongoDB / S3 | Install the matching extra, for example `pip install "omnicoreagent[redis]"`. |
 | `Redis connection failed` | Start Redis or use `MemoryRouter("in_memory")`. |
 | `MCP connection refused` | Ensure the MCP server is running before starting the agent. |

--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -1,15 +1,21 @@
-# Background Agents: Durable Agent Tasks
+# Background Agents: Tracked Agent Tasks
 
 Background Agents run OmniCoreAgent tasks outside the foreground request path.
-They are built around durable runs, task-store state, retries, cancellation,
-workspace output, and inspectable lifecycle events.
+They are built around tracked runs, task-store state, retries, cancellation,
+workspace output, and inspectable lifecycle events. Use the default in-memory
+store for local development, or `task_store="sql"` when runs must survive
+restarts.
 
 ## Key Concepts
 
 * **BackgroundAgentManager**: Registers agents, tasks, runs, and lifecycle operations.
-* **Task store**: Operational state for agents, tasks, schedule state, runs, attempts, leases, and cancellation flags.
+* **Task store**: Operational state for agents, tasks, schedule state, runs, attempts, leases, retries, and cancellation flags. It defaults to in-memory and is separate from conversation memory.
 * **Run**: One concrete execution of a task. Runs have stable IDs, statuses, attempts, workspace paths, and event history.
-* **Workspace output**: Every background run gets a workspace namespace for durable output.
+* **Workspace output**: Every background run gets a workspace namespace for output.
+
+You can run the background manager without storage configuration. Use
+`BackgroundAgentManager()` for the default zero-config in-memory task store. Use
+`task_store="sql"` when task state must survive process restarts.
 
 ## Quick Start
 
@@ -26,7 +32,7 @@ async def main():
         model_config={"provider": "openai", "model": "gpt-4o-mini"},
     )
 
-    manager = BackgroundAgentManager(task_store="in_memory")
+    manager = BackgroundAgentManager()
     await manager.register_agent(agent_id="system_monitor", agent=agent)
     await manager.register_task(
         task_id="health_report",
@@ -71,7 +77,8 @@ await manager.resume_task("health_report")
 | `overlap_policy` | `skip_if_running`, `queue_next`, `cancel_previous`, or `allow_parallel`. |
 | `session_policy` | `task`, `run`, or `fixed` memory-session behavior. |
 
-The current implementation includes the durable model, in-memory task store,
-SQLite task store, manager lifecycle, manual and scheduled runs, retries with
-delay/backoff, lease fencing, expired-lease recovery, cancellation, workspace
-lifecycle files, and event history.
+The current implementation includes the tracked run model, SQLite task store,
+in-memory task store for local development and tests, manager lifecycle, manual
+and scheduled runs, retries with delay/backoff, lease fencing, expired-lease
+recovery, cancellation, workspace lifecycle files, and event history. State is
+restart-persistent when the task store is SQL.

--- a/cookbook/background_agents/background_agent_example.py
+++ b/cookbook/background_agents/background_agent_example.py
@@ -1,4 +1,4 @@
-"""Run an OmniCoreAgent task through the durable background manager."""
+"""Run an OmniCoreAgent task through the background manager."""
 
 import asyncio
 import os
@@ -13,11 +13,11 @@ async def main():
 
     agent = OmniCoreAgent(
         name="background_researcher",
-        system_instruction="You write short, durable background task reports.",
+        system_instruction="You write short background task reports.",
         model_config={"provider": "openai", "model": "gpt-4o-mini"},
     )
 
-    manager = BackgroundAgentManager(task_store="in_memory")
+    manager = BackgroundAgentManager()
     await manager.register_agent(agent_id="background_researcher", agent=agent)
     await manager.register_task(
         task_id="daily_research_note",

--- a/cookbook/getting_started/README.mdx
+++ b/cookbook/getting_started/README.mdx
@@ -46,17 +46,14 @@ Welcome to the **OmniCoreAgent** learning path. This guide takes you from writin
 ## 🛠️ Prerequisites
 
 ```bash
-# Required
 pip install omnicoreagent
 
-# Create .env file
-LLM_API_KEY=your_key_here
-
-# Optional (for persistence examples)
-REDIS_URL=redis://localhost:6379/0
-DATABASE_URL=postgresql://user:pass@localhost:5432/db
-MONGODB_URI=mongodb://localhost:27017/omnicoreagent
+# Most hosted model providers need only this key. The cookbook loader reads .env.
+echo "LLM_API_KEY=your_key_here" > .env
 ```
+
+The examples start with in-memory defaults. Add `REDIS_URL`, `DATABASE_URL`, or
+`MONGODB_URI` only when you intentionally run the persistence examples.
 
 ---
 

--- a/cookbook/getting_started/agent_with_models.py
+++ b/cookbook/getting_started/agent_with_models.py
@@ -118,8 +118,6 @@ async def demo_ollama():
     print("OLLAMA (LOCAL LLAMA3)")
     print("=" * 50)
 
-    # Ollama doesn't usually need an API key, but the agent framework
-    # expects LLM_API_KEY to be present for initialization checks.
     print("Note: Ensure you have pulled the model first: `ollama pull llama3`")
 
     try:

--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -34,7 +34,7 @@ def create_agent():
 
 ```bash
 # Quickstart with defaults (no agent file needed)
-omniserve quickstart --provider gemini --model gemini-2.0-flash
+omniserve quickstart --provider openai --model gpt-4o-mini
 
 # Run with your agent file
 omniserve run --agent cookbook/omniserve/cli_agent.py --port 8000
@@ -46,6 +46,9 @@ omniserve run --agent cookbook/omniserve/cli_agent.py \
   --rate-limit 100
 ```
 
+Use the provider that matches your `LLM_API_KEY`. For an OpenAI key, run
+`omniserve quickstart --provider openai --model gpt-4o-mini`.
+
 ### Option 2: Python API (Programmatic control)
 
 ```bash
@@ -55,10 +58,10 @@ python cookbook/omniserve/python_api.py
 
 > [!WARNING]
 > **Environment Variable Precedence:**
-> `.env` variables **ALWAYS override** values set in `OmniServeConfig`.
+> Environment variables **ALWAYS override** values set in `OmniServeConfig`.
 > ```python
 > # In code: port=8000
-> # In .env: OMNISERVE_PORT=9000
+> # In environment: OMNICOREAGENT_SERVE_PORT=9000
 > # Result: Server runs on port 9000 (env wins!)
 > ```
 
@@ -66,33 +69,43 @@ python cookbook/omniserve/python_api.py
 
 ## Environment Variables
 
-All config via `OMNISERVE_*` prefix.
+Server settings use the `OMNICOREAGENT_SERVE_*` prefix. Background task settings
+use the `OMNICOREAGENT_BACKGROUND_*` prefix. You can start without either prefix;
+defaults use port `8000`, in-memory background task state, and no auth/rate
+limiting until you opt in.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OMNISERVE_HOST` | `0.0.0.0` | Server host |
-| `OMNISERVE_PORT` | `8000` | Server port |
-| `OMNISERVE_WORKERS` | `1` | Worker processes |
-| `OMNISERVE_API_PREFIX` | `""` | API path prefix |
-| `OMNISERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
-| `OMNISERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
-| `OMNISERVE_CORS_ENABLED` | `true` | Enable CORS |
-| `OMNISERVE_CORS_ORIGINS` | `*` | Allowed origins |
-| `OMNISERVE_CORS_METHODS` | `*` | Allowed methods |
-| `OMNISERVE_CORS_HEADERS` | `*` | Allowed headers |
-| `OMNISERVE_CORS_CREDENTIALS` | `true` | Allow credentials |
-| `OMNISERVE_AUTH_ENABLED` | `false` | Enable Bearer auth |
-| `OMNISERVE_AUTH_TOKEN` | — | Bearer token value |
-| `OMNISERVE_RATE_LIMIT_ENABLED` | `false` | Rate limiting |
-| `OMNISERVE_RATE_LIMIT_REQUESTS` | `100` | Requests/window |
-| `OMNISERVE_RATE_LIMIT_WINDOW` | `60` | Window seconds |
-| `OMNISERVE_REQUEST_LOGGING` | `true` | Log requests |
-| `OMNISERVE_LOG_LEVEL` | `INFO` | Log level |
-| `OMNISERVE_REQUEST_TIMEOUT` | `300` | Timeout seconds |
+| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host |
+| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix |
+| `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
+| `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
+| `OMNICOREAGENT_SERVE_CORS_ENABLED` | `true` | Enable CORS |
+| `OMNICOREAGENT_SERVE_CORS_ORIGINS` | `*` | Allowed origins |
+| `OMNICOREAGENT_SERVE_CORS_METHODS` | `*` | Allowed methods |
+| `OMNICOREAGENT_SERVE_CORS_HEADERS` | `*` | Allowed headers |
+| `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `true` | Allow credentials |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer auth |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Rate limiting |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests/window |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window seconds |
+| `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log requests |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level |
+| `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Timeout seconds |
+| `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints |
+| `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id for the served agent in background tasks |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background task store backend |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | — | SQL task store URL; setting it selects the SQL task store |
+| `OMNICOREAGENT_BACKGROUND_START_WORKER` | `true` | Start scheduler and worker loop |
 
 ---
 
 ## API Endpoints
+
+### Core Endpoints
 
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
@@ -106,7 +119,30 @@ All config via `OMNISERVE_*` prefix.
 | GET | `/docs` | No | Swagger UI |
 | GET | `/redoc` | No | ReDoc UI |
 
-*Auth required only if `OMNISERVE_AUTH_ENABLED=true` or `--auth-token` is set.
+### Background Task Endpoints
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/background/agents` | Yes* | Register a background agent |
+| GET | `/background/agents` | Yes* | List background agents |
+| GET | `/background/agents/{agent_id}` | Yes* | Inspect a background agent |
+| DELETE | `/background/agents/{agent_id}` | Yes* | Delete a background agent |
+| POST | `/background/tasks` | Yes* | Create a background task |
+| GET | `/background/tasks` | Yes* | List background tasks |
+| GET | `/background/tasks/{task_id}` | Yes* | Inspect a task |
+| PATCH | `/background/tasks/{task_id}` | Yes* | Patch a task |
+| POST | `/background/tasks/{task_id}/run` | Yes* | Queue a manual run |
+| POST | `/background/tasks/{task_id}/pause` | Yes* | Pause scheduled dispatch |
+| POST | `/background/tasks/{task_id}/resume` | Yes* | Resume scheduled dispatch |
+| DELETE | `/background/tasks/{task_id}` | Yes* | Delete a task |
+| POST | `/background/runs/{run_id}/cancel` | Yes* | Cancel a queued or running run |
+| GET | `/background/runs` | Yes* | List runs |
+| GET | `/background/runs/{run_id}` | Yes* | Inspect run state |
+| GET | `/background/runs/{run_id}/attempts` | Yes* | List run attempts |
+| GET | `/background/runs/{run_id}/events` | Yes* | Replay lifecycle events |
+| GET | `/background/runs/{run_id}/workspace` | Yes* | Inspect run workspace files |
+
+*Auth required only if `OMNICOREAGENT_SERVE_AUTH_ENABLED=true` or `--auth-token` is set.
 
 ---
 

--- a/cookbook/omniserve/python_api.py
+++ b/cookbook/omniserve/python_api.py
@@ -144,43 +144,43 @@ config = OmniServeConfig(
     # -------------------------------------------------------------------------
     # SERVER
     # -------------------------------------------------------------------------
-    host="0.0.0.0",  # OMNISERVE_HOST
-    port=8000,  # OMNISERVE_PORT
-    workers=1,  # OMNISERVE_WORKERS
-    api_prefix="",  # OMNISERVE_API_PREFIX (e.g., "/api/v1")
+    host="0.0.0.0",  # OMNICOREAGENT_SERVE_HOST
+    port=8000,  # OMNICOREAGENT_SERVE_PORT
+    workers=1,  # OMNICOREAGENT_SERVE_WORKERS
+    api_prefix="",  # OMNICOREAGENT_SERVE_API_PREFIX (e.g., "/api/v1")
     # -------------------------------------------------------------------------
     # DOCUMENTATION
     # -------------------------------------------------------------------------
-    enable_docs=True,  # OMNISERVE_ENABLE_DOCS - Swagger UI at /docs
-    enable_redoc=True,  # OMNISERVE_ENABLE_REDOC - ReDoc at /redoc
+    enable_docs=True,  # OMNICOREAGENT_SERVE_ENABLE_DOCS - Swagger UI at /docs
+    enable_redoc=True,  # OMNICOREAGENT_SERVE_ENABLE_REDOC - ReDoc at /redoc
     # -------------------------------------------------------------------------
     # CORS (Cross-Origin Resource Sharing)
     # -------------------------------------------------------------------------
-    cors_enabled=True,  # OMNISERVE_CORS_ENABLED
-    cors_origins=["*"],  # OMNISERVE_CORS_ORIGINS - comma-separated
-    cors_credentials=True,  # OMNISERVE_CORS_CREDENTIALS
-    cors_methods=["*"],  # OMNISERVE_CORS_METHODS
-    cors_headers=["*"],  # OMNISERVE_CORS_HEADERS
+    cors_enabled=True,  # OMNICOREAGENT_SERVE_CORS_ENABLED
+    cors_origins=["*"],  # OMNICOREAGENT_SERVE_CORS_ORIGINS - comma-separated
+    cors_credentials=True,  # OMNICOREAGENT_SERVE_CORS_CREDENTIALS
+    cors_methods=["*"],  # OMNICOREAGENT_SERVE_CORS_METHODS
+    cors_headers=["*"],  # OMNICOREAGENT_SERVE_CORS_HEADERS
     # -------------------------------------------------------------------------
     # AUTHENTICATION
     # -------------------------------------------------------------------------
-    auth_enabled=True,  # OMNISERVE_AUTH_ENABLED
-    auth_token="my-secret-token",  # OMNISERVE_AUTH_TOKEN
+    auth_enabled=True,  # OMNICOREAGENT_SERVE_AUTH_ENABLED
+    auth_token="my-secret-token",  # OMNICOREAGENT_SERVE_AUTH_TOKEN
     # -------------------------------------------------------------------------
     # RATE LIMITING
     # -------------------------------------------------------------------------
-    rate_limit_enabled=True,  # OMNISERVE_RATE_LIMIT_ENABLED
-    rate_limit_requests=100,  # OMNISERVE_RATE_LIMIT_REQUESTS
-    rate_limit_window=60,  # OMNISERVE_RATE_LIMIT_WINDOW (seconds)
+    rate_limit_enabled=True,  # OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED
+    rate_limit_requests=100,  # OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS
+    rate_limit_window=60,  # OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW (seconds)
     # -------------------------------------------------------------------------
     # LOGGING
     # -------------------------------------------------------------------------
-    request_logging=True,  # OMNISERVE_REQUEST_LOGGING
-    log_level="INFO",  # OMNISERVE_LOG_LEVEL (DEBUG/INFO/WARNING/ERROR)
+    request_logging=True,  # OMNICOREAGENT_SERVE_REQUEST_LOGGING
+    log_level="INFO",  # OMNICOREAGENT_SERVE_LOG_LEVEL (DEBUG/INFO/WARNING/ERROR)
     # -------------------------------------------------------------------------
     # TIMEOUTS
     # -------------------------------------------------------------------------
-    request_timeout=300,  # OMNISERVE_REQUEST_TIMEOUT (seconds)
+    request_timeout=300,  # OMNICOREAGENT_SERVE_REQUEST_TIMEOUT (seconds)
 )
 
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,46 +10,46 @@ LLM_API_KEY=your-api-key-here
 # =============================================================================
 # Server Configuration
 # =============================================================================
-OMNISERVE_HOST=0.0.0.0
-OMNISERVE_PORT=8000
-OMNISERVE_WORKERS=1
+OMNICOREAGENT_SERVE_HOST=0.0.0.0
+OMNICOREAGENT_SERVE_PORT=8000
+OMNICOREAGENT_SERVE_WORKERS=1
 
 # =============================================================================
 # API Documentation
 # =============================================================================
-OMNISERVE_ENABLE_DOCS=true
-OMNISERVE_ENABLE_REDOC=true
-OMNISERVE_API_PREFIX=
+OMNICOREAGENT_SERVE_ENABLE_DOCS=true
+OMNICOREAGENT_SERVE_ENABLE_REDOC=true
+OMNICOREAGENT_SERVE_API_PREFIX=
 
 # =============================================================================
 # CORS (Cross-Origin Resource Sharing)
 # =============================================================================
-OMNISERVE_CORS_ENABLED=true
+OMNICOREAGENT_SERVE_CORS_ENABLED=true
 # Comma-separated list of origins, or * for all
-OMNISERVE_CORS_ORIGINS=*
-OMNISERVE_CORS_CREDENTIALS=true
+OMNICOREAGENT_SERVE_CORS_ORIGINS=*
+OMNICOREAGENT_SERVE_CORS_CREDENTIALS=true
 
 # =============================================================================
 # Authentication
 # =============================================================================
-OMNISERVE_AUTH_ENABLED=false
+OMNICOREAGENT_SERVE_AUTH_ENABLED=false
 # Set a strong token if auth is enabled
-OMNISERVE_AUTH_TOKEN=
+OMNICOREAGENT_SERVE_AUTH_TOKEN=
 
 # =============================================================================
 # Rate Limiting
 # =============================================================================
-OMNISERVE_RATE_LIMIT_ENABLED=false
-OMNISERVE_RATE_LIMIT_REQUESTS=100
-OMNISERVE_RATE_LIMIT_WINDOW=60
+OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED=false
+OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS=100
+OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW=60
 
 # =============================================================================
 # Logging
 # =============================================================================
-OMNISERVE_REQUEST_LOGGING=true
-OMNISERVE_LOG_LEVEL=INFO
+OMNICOREAGENT_SERVE_REQUEST_LOGGING=true
+OMNICOREAGENT_SERVE_LOG_LEVEL=INFO
 
 # =============================================================================
 # Timeouts
 # =============================================================================
-OMNISERVE_REQUEST_TIMEOUT=300
+OMNICOREAGENT_SERVE_REQUEST_TIMEOUT=300

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Multi-stage build for smaller production image
 #
 # Build:  docker build -t omniserver:latest -f docker/Dockerfile .
-# Run:    docker run -p 8000:8000 -e OPENAI_API_KEY=xxx omniserver:latest
+# Run:    docker run -p 8000:8000 -e LLM_API_KEY=xxx omniserver:latest
 
 FROM python:3.12-slim AS builder
 
@@ -26,7 +26,7 @@ COPY LICENSE .
 COPY src/ src/
 
 # Install dependencies
-RUN uv pip install --system --no-cache .
+RUN uv pip install --system --no-cache ".[serve]"
 
 # ======================================================================
 # Production image
@@ -69,11 +69,11 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 # Default environment variables
-ENV OMNISERVER_HOST=0.0.0.0
-ENV OMNISERVER_PORT=8000
-ENV OMNISERVER_ENABLE_DOCS=true
-ENV OMNISERVER_CORS_ENABLED=true
-ENV OMNISERVER_REQUEST_LOGGING=true
+ENV OMNICOREAGENT_SERVE_HOST=0.0.0.0
+ENV OMNICOREAGENT_SERVE_PORT=8000
+ENV OMNICOREAGENT_SERVE_ENABLE_DOCS=true
+ENV OMNICOREAGENT_SERVE_CORS_ENABLED=true
+ENV OMNICOREAGENT_SERVE_REQUEST_LOGGING=true
 
-# Default command: quickstart with gemini
-CMD ["omniserve", "quickstart", "--provider", "gemini", "--model", "gemini-2.0-flash"]
+# Default command: quickstart with OpenAI
+CMD ["omniserve", "quickstart", "--provider", "openai", "--model", "gpt-4o-mini"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       dockerfile: docker/Dockerfile
     container_name: omniserver
     ports:
-      - "${OMNISERVE_PORT:-8000}:8000"
+      - "${OMNICOREAGENT_SERVE_PORT:-8000}:8000"
     environment:
       # =======================================================================
       # LLM API Key (Required)
@@ -29,42 +29,42 @@ services:
       # =======================================================================
       # Server Configuration
       # =======================================================================
-      - OMNISERVE_HOST=${OMNISERVE_HOST:-0.0.0.0}
-      - OMNISERVE_PORT=${OMNISERVE_PORT:-8000}
-      - OMNISERVE_WORKERS=${OMNISERVE_WORKERS:-1}
-      - OMNISERVE_API_PREFIX=${OMNISERVE_API_PREFIX:-}
+      - OMNICOREAGENT_SERVE_HOST=${OMNICOREAGENT_SERVE_HOST:-0.0.0.0}
+      - OMNICOREAGENT_SERVE_PORT=${OMNICOREAGENT_SERVE_PORT:-8000}
+      - OMNICOREAGENT_SERVE_WORKERS=${OMNICOREAGENT_SERVE_WORKERS:-1}
+      - OMNICOREAGENT_SERVE_API_PREFIX=${OMNICOREAGENT_SERVE_API_PREFIX:-}
       
       # =======================================================================
       # Documentation
       # =======================================================================
-      - OMNISERVE_ENABLE_DOCS=${OMNISERVE_ENABLE_DOCS:-true}
-      - OMNISERVE_ENABLE_REDOC=${OMNISERVE_ENABLE_REDOC:-true}
+      - OMNICOREAGENT_SERVE_ENABLE_DOCS=${OMNICOREAGENT_SERVE_ENABLE_DOCS:-true}
+      - OMNICOREAGENT_SERVE_ENABLE_REDOC=${OMNICOREAGENT_SERVE_ENABLE_REDOC:-true}
       
       # =======================================================================
       # CORS Configuration
       # =======================================================================
-      - OMNISERVE_CORS_ENABLED=${OMNISERVE_CORS_ENABLED:-true}
-      - OMNISERVE_CORS_ORIGINS=${OMNISERVE_CORS_ORIGINS:-*}
-      - OMNISERVE_CORS_CREDENTIALS=${OMNISERVE_CORS_CREDENTIALS:-true}
+      - OMNICOREAGENT_SERVE_CORS_ENABLED=${OMNICOREAGENT_SERVE_CORS_ENABLED:-true}
+      - OMNICOREAGENT_SERVE_CORS_ORIGINS=${OMNICOREAGENT_SERVE_CORS_ORIGINS:-*}
+      - OMNICOREAGENT_SERVE_CORS_CREDENTIALS=${OMNICOREAGENT_SERVE_CORS_CREDENTIALS:-true}
       
       # =======================================================================
       # Authentication
       # =======================================================================
-      - OMNISERVE_AUTH_ENABLED=${OMNISERVE_AUTH_ENABLED:-false}
-      - OMNISERVE_AUTH_TOKEN=${OMNISERVE_AUTH_TOKEN:-}
+      - OMNICOREAGENT_SERVE_AUTH_ENABLED=${OMNICOREAGENT_SERVE_AUTH_ENABLED:-false}
+      - OMNICOREAGENT_SERVE_AUTH_TOKEN=${OMNICOREAGENT_SERVE_AUTH_TOKEN:-}
       
       # =======================================================================
       # Logging
       # =======================================================================
-      - OMNISERVE_REQUEST_LOGGING=${OMNISERVE_REQUEST_LOGGING:-true}
-      - OMNISERVE_LOG_LEVEL=${OMNISERVE_LOG_LEVEL:-INFO}
+      - OMNICOREAGENT_SERVE_REQUEST_LOGGING=${OMNICOREAGENT_SERVE_REQUEST_LOGGING:-true}
+      - OMNICOREAGENT_SERVE_LOG_LEVEL=${OMNICOREAGENT_SERVE_LOG_LEVEL:-INFO}
       
       # =======================================================================
       # Rate Limiting
       # =======================================================================
-      - OMNISERVE_RATE_LIMIT_ENABLED=${OMNISERVE_RATE_LIMIT_ENABLED:-false}
-      - OMNISERVE_RATE_LIMIT_REQUESTS=${OMNISERVE_RATE_LIMIT_REQUESTS:-100}
-      - OMNISERVE_RATE_LIMIT_WINDOW=${OMNISERVE_RATE_LIMIT_WINDOW:-60}
+      - OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED=${OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED:-false}
+      - OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS=${OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS:-100}
+      - OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW=${OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW:-60}
       
       # =======================================================================
       # Timeouts
@@ -88,7 +88,7 @@ services:
       # =======================================================================
       # Timeouts
       # =======================================================================
-      - OMNISERVE_REQUEST_TIMEOUT=${OMNISERVE_REQUEST_TIMEOUT:-300}
+      - OMNICOREAGENT_SERVE_REQUEST_TIMEOUT=${OMNICOREAGENT_SERVE_REQUEST_TIMEOUT:-300}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s

--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -1,15 +1,17 @@
 ---
 title: Background Agents
-description: 'Run durable OmniCoreAgent tasks outside the foreground request path'
+description: 'Run tracked OmniCoreAgent tasks outside the foreground request path'
 icon: 'clock'
 ---
 
 # Background Agents
 
-Background agents turn an OmniCoreAgent into a durable task runner. A task can
-run manually, once at a fixed time, on an interval, or from a five-field cron
-expression. Each run is tracked through queued, claimed, running, retrying, and
-terminal states so long-running work can be inspected and recovered.
+Background agents run tracked OmniCoreAgent tasks outside the foreground request
+path. Use the default in-memory store for local development, or `task_store="sql"`
+when tasks, runs, attempts, leases, retries, and cancellation state must survive
+process restarts. A task can run manually, once at a fixed time, on an interval,
+or from a five-field cron expression. Each run is tracked through queued,
+claimed, running, retrying, and terminal states.
 
 Background execution is part of the core package:
 
@@ -17,7 +19,19 @@ Background execution is part of the core package:
 pip install omnicoreagent
 ```
 
+No storage configuration is required to start. `BackgroundAgentManager()` uses an
+in-memory task store by default so the first run has no database requirement.
+Use `task_store="sql"` when tasks, runs, attempts, leases, retries, and
+cancellation state must survive process restarts.
+
+The task store is separate from agent memory. `MemoryRouter` stores
+conversation/session history. The task store stores operational background
+state and owns the atomic claim, lease, retry, and schedule-cursor guarantees.
+
 ## Quick Start
+
+Set `LLM_API_KEY` first, then run the example; no task-store configuration is
+required.
 
 ```python
 import asyncio
@@ -85,6 +99,30 @@ await manager.resume_task("hourly_report")
 await manager.delete_task("hourly_report", delete_runs=True)
 ```
 
+## OmniServe API
+
+When an agent is served through OmniServe, the server registers that agent with
+the background manager during startup and exposes task control over HTTP:
+
+```bash
+curl -X POST http://localhost:8000/background/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task_id": "health_report",
+    "query": "Check system health and write the report.",
+    "schedule": {"type": "manual"},
+    "timeout_seconds": 60
+  }'
+
+curl -X POST http://localhost:8000/background/tasks/health_report/run \
+  -H "Content-Type: application/json" \
+  -d '{"wait": false}'
+```
+
+The background API includes task creation, task listing, pause, resume, delete,
+manual run, cancellation, run status, attempt history, event replay, and
+workspace inspection.
+
 ## Task Configuration
 
 | Field | Purpose |
@@ -99,7 +137,7 @@ await manager.delete_task("hourly_report", delete_runs=True)
 | `session_policy` | `task`, `run`, or `fixed` memory-session behavior. |
 | `workspace_policy` | Workspace namespace used for run output. |
 
-## What Is Durable
+## Persistent State
 
 The task store is the source of truth for:
 
@@ -109,7 +147,7 @@ The task store is the source of truth for:
 - runs and attempts
 - leases, heartbeats, and cancellation flags
 
-The current runtime includes the durable model, SQLite and in-memory task stores,
-schedule dispatch, manual runs, retries with delay/backoff, lease fencing,
-expired-lease recovery, cancellation, workspace lifecycle files, and run event
-history.
+The current runtime includes the tracked run model, SQLite and in-memory task
+stores, schedule dispatch, manual runs, retries with delay/backoff, lease
+fencing, expired-lease recovery, cancellation, workspace lifecycle files, and run
+event history. State is restart-persistent when the task store is SQL.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -20,10 +20,10 @@ background scheduling install as extras when the agent needs them.
   </Step>
 
   <Step title="Set API Key">
-    Create a `.env` file in your project directory:
+    Export the model key for the provider you choose:
 
     ```bash
-    echo "LLM_API_KEY=your_api_key_here" > .env
+    export LLM_API_KEY=your_api_key_here
     ```
 
     <Tip>

--- a/docs/how-to-guides/basic-usage.mdx
+++ b/docs/how-to-guides/basic-usage.mdx
@@ -28,8 +28,8 @@ async def main():
     result = await agent.run("What is the capital of France?")
 
     print(result["response"])       # The agent's text reply
-    print(result["usage"])          # Token usage stats
-    print(result["tool_calls"])     # Tools the agent invoked (if any)
+    print(result["session_id"])     # Session used for this run
+    print(result.get("metric"))     # Token/timing metric when provider usage is available
 
     await agent.cleanup()
 
@@ -191,7 +191,7 @@ except Exception as e:
 
 | Error | Fix |
 |-------|-----|
-| `Invalid API key` | Check `.env`: `LLM_API_KEY=your_key` |
+| `Invalid API key` | Export `LLM_API_KEY` with the key for the provider selected in `model_config`. |
 | `ModuleNotFoundError` for an optional backend | Install the matching extra, e.g. `pip install "omnicoreagent[redis]"` |
 | `Redis connection failed` | Start Redis or use `MemoryRouter("in_memory")` |
 | `MCP connection refused` | Ensure MCP server is running and path is correct |

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -15,19 +15,28 @@ dictionaries, and specialized configuration objects.
 
 Environment variables are the best way to manage sensitive data like API keys and connection strings.
 
+For the first working agent, set only `LLM_API_KEY`. Memory and events default
+to in-memory storage, workspace files default to local disk, and OmniServe
+settings have server-side defaults. Add backend variables only when you are
+intentionally moving from local defaults to persistent or cloud infrastructure.
+
 ### LLM API Key
 
 OmniCoreAgent uses one public environment variable for hosted model credentials:
 
 ```bash
-LLM_API_KEY=your_provider_key
+export LLM_API_KEY=your_provider_key
 ```
 
 Set `model_config["provider"]` to choose the provider. The runtime reads
 `LLM_API_KEY` and internally passes it to LiteLLM for the selected provider.
 Do not configure provider-specific key names in OmniCoreAgent examples.
 
-### Memory Backends
+### Optional Memory Backends
+
+The default memory backend is in-memory and needs no environment variables.
+Set these only when conversation history must live outside the current process.
+
 | Backend | Variable | Example |
 |---------|----------|---------|
 | **Redis** | `REDIS_URL` | `redis://localhost:6379/0` |
@@ -65,27 +74,42 @@ Optional workspace variables:
 OmniServe reads these variables through `OmniServeConfig`. Environment variables
 override values passed in code.
 
+You do not need any OmniServe environment variables to start. Defaults bind the
+server to port `8000`, enable the background API, start the background worker,
+and use an in-memory task store. Set only the values you want to override.
+
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `OMNISERVE_HOST` | `0.0.0.0` | Server bind host. |
-| `OMNISERVE_PORT` | `8000` | Server port. |
-| `OMNISERVE_WORKERS` | `1` | Uvicorn worker count. |
-| `OMNISERVE_API_PREFIX` | `""` | API route prefix, such as `/api/v1`. |
-| `OMNISERVE_ENABLE_DOCS` | `true` | Enable Swagger UI. |
-| `OMNISERVE_ENABLE_REDOC` | `true` | Enable ReDoc. |
-| `OMNISERVE_CORS_ENABLED` | `true` | Enable CORS middleware. |
-| `OMNISERVE_CORS_ORIGINS` | `*` | Comma-separated allowed origins. |
-| `OMNISERVE_CORS_METHODS` | `*` | Comma-separated allowed methods. |
-| `OMNISERVE_CORS_HEADERS` | `*` | Comma-separated allowed headers. |
-| `OMNISERVE_CORS_CREDENTIALS` | `true` | Allow CORS credentials. |
-| `OMNISERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. |
-| `OMNISERVE_AUTH_TOKEN` | unset | Bearer token value. |
-| `OMNISERVE_REQUEST_LOGGING` | `true` | Log incoming requests. |
-| `OMNISERVE_LOG_LEVEL` | `INFO` | Server log level. |
-| `OMNISERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds. Set `0` to disable timeout middleware. |
-| `OMNISERVE_RATE_LIMIT_ENABLED` | `false` | Enable in-process rate limiting. |
-| `OMNISERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per rate-limit window. |
-| `OMNISERVE_RATE_LIMIT_WINDOW` | `60` | Rate-limit window in seconds. |
+| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server bind host. |
+| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Uvicorn worker count. |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API route prefix, such as `/api/v1`. |
+| `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Enable Swagger UI. |
+| `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | Enable ReDoc. |
+| `OMNICOREAGENT_SERVE_CORS_ENABLED` | `true` | Enable CORS middleware. |
+| `OMNICOREAGENT_SERVE_CORS_ORIGINS` | `*` | Comma-separated allowed origins. |
+| `OMNICOREAGENT_SERVE_CORS_METHODS` | `*` | Comma-separated allowed methods. |
+| `OMNICOREAGENT_SERVE_CORS_HEADERS` | `*` | Comma-separated allowed headers. |
+| `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `true` | Allow CORS credentials. |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | unset | Bearer token value. |
+| `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log incoming requests. |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Server log level. |
+| `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds. Set `0` to disable timeout middleware. |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Enable in-process rate limiting. |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per rate-limit window. |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Rate-limit window in seconds. |
+| `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints. |
+| `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id used when OmniServe registers the served agent for background work. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory` for zero-config local use or `sql` for restart-persistent SQLite. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | unset | Optional SQL URL override. Setting this URL selects the SQL task store even if `OMNICOREAGENT_BACKGROUND_TASK_STORE` is unset. |
+| `OMNICOREAGENT_BACKGROUND_START_WORKER` | `true` | Start the scheduler and worker loop during server lifespan. |
+
+The background task store is separate from `MemoryRouter`. `MemoryRouter` stores
+conversation/session history. The task store stores scheduler/runtime state:
+tasks, schedule cursors, runs, attempts, leases, heartbeats, retries, and
+cancellation flags. Defaults are intentionally light. Use `sql` when background
+tasks must survive process restarts.
 
 ## 2. Agent Configuration
 

--- a/docs/how-to-guides/models.mdx
+++ b/docs/how-to-guides/models.mdx
@@ -87,7 +87,7 @@ model_config = {
 
 ```bash
 # Hosted providers use this single OmniCoreAgent key
-LLM_API_KEY=your_api_key
+export LLM_API_KEY=your_api_key
 ```
 
 OmniCoreAgent reads `LLM_API_KEY`. Select the provider through

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -27,7 +27,7 @@ from omnicoreagent import OmniCoreAgent
 agent = OmniCoreAgent(
     name="MyAgent",
     system_instruction="You are a helpful assistant.",
-    model_config={"provider": "gemini", "model": "gemini-2.0-flash"},
+    model_config={"provider": "openai", "model": "gpt-4o-mini"},
 )
 ```
 
@@ -40,7 +40,7 @@ def create_agent():
     return OmniCoreAgent(
         name="MyAgent",
         system_instruction="You are a helpful assistant.",
-        model_config={"provider": "gemini", "model": "gemini-2.0-flash"},
+        model_config={"provider": "openai", "model": "gpt-4o-mini"},
     )
 ```
 
@@ -74,7 +74,7 @@ def calculate(expression: str) -> dict:
 agent = OmniCoreAgent(
     name="MyAgent",
     system_instruction="You are a helpful assistant with access to greeting and calculation tools.",
-    model_config={"provider": "gemini", "model": "gemini-2.0-flash"},
+    model_config={"provider": "openai", "model": "gpt-4o-mini"},
     local_tools=tools,
 )
 ```
@@ -82,7 +82,7 @@ agent = OmniCoreAgent(
 ### Step 2: Set environment variables
 
 ```bash
-echo "LLM_API_KEY=your_api_key_here" > .env
+export LLM_API_KEY=your_api_key_here
 ```
 
 ### Step 3: Run the server
@@ -128,14 +128,14 @@ open http://localhost:8000/docs
 
 ```bash
 omniserve run \
-  --agent my_agent.py \        # Path to agent file (required)
-  --host 0.0.0.0 \             # Host to bind (default: 0.0.0.0)
-  --port 8000 \                # Port to bind (default: 8000)
-  --workers 1 \                # Worker processes (default: 1)
-  --auth-token YOUR_TOKEN \    # Enable Bearer token auth
-  --rate-limit 100 \           # Rate limit (requests per minute)
-  --cors-origins "*" \         # Comma-separated CORS origins
-  --no-docs                    # Disable Swagger UI
+  --agent my_agent.py \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --workers 1 \
+  --auth-token YOUR_TOKEN \
+  --rate-limit 100 \
+  --cors-origins "*" \
+  --no-docs
 ```
 
 **Examples:**
@@ -167,12 +167,15 @@ Start a server instantly without writing any code:
 
 ```bash
 omniserve quickstart \
-  --provider openai \          # LLM provider (openai, gemini, anthropic)
-  --model gpt-4o \             # Model name
-  --name QuickAgent \          # Agent name (default: QuickAgent)
-  --instruction "You are..." \ # System instruction
-  --port 8000                  # Port (default: 8000)
+  --provider openai \
+  --model gpt-4o \
+  --name QuickAgent \
+  --instruction "You are..." \
+  --port 8000
 ```
+
+Use the provider that matches your `LLM_API_KEY`. For an OpenAI key, run
+`omniserve quickstart --provider openai --model gpt-4o-mini`.
 
 **Examples:**
 
@@ -191,6 +194,8 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 
 ## API Endpoints
 
+### Core Endpoints
+
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | `POST` | `/run` | Yes* | SSE streaming response |
@@ -204,8 +209,31 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/docs` | No | Swagger UI |
 | `GET` | `/redoc` | No | ReDoc UI |
 
-*Auth required only if `--auth-token` is set or `OMNISERVE_AUTH_ENABLED=true`
-with `OMNISERVE_AUTH_TOKEN`.
+### Background Task Endpoints
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/background/agents` | Yes* | Register the served agent or an agent spec for background execution |
+| `GET` | `/background/agents` | Yes* | List registered background agents |
+| `GET` | `/background/agents/{agent_id}` | Yes* | Inspect a background agent spec |
+| `DELETE` | `/background/agents/{agent_id}` | Yes* | Delete a background agent spec |
+| `POST` | `/background/tasks` | Yes* | Create a background task |
+| `GET` | `/background/tasks` | Yes* | List background tasks |
+| `GET` | `/background/tasks/{task_id}` | Yes* | Inspect a background task |
+| `PATCH` | `/background/tasks/{task_id}` | Yes* | Patch a background task |
+| `POST` | `/background/tasks/{task_id}/run` | Yes* | Queue a manual background run |
+| `POST` | `/background/tasks/{task_id}/pause` | Yes* | Pause scheduled dispatch |
+| `POST` | `/background/tasks/{task_id}/resume` | Yes* | Resume scheduled dispatch |
+| `DELETE` | `/background/tasks/{task_id}` | Yes* | Delete a background task |
+| `POST` | `/background/runs/{run_id}/cancel` | Yes* | Cancel a queued or running run |
+| `GET` | `/background/runs` | Yes* | List background runs |
+| `GET` | `/background/runs/{run_id}` | Yes* | Inspect run status |
+| `GET` | `/background/runs/{run_id}/attempts` | Yes* | List run attempts |
+| `GET` | `/background/runs/{run_id}/events` | Yes* | Replay lifecycle events |
+| `GET` | `/background/runs/{run_id}/workspace` | Yes* | Inspect run workspace files |
+
+*Auth required only if `--auth-token` is set or `OMNICOREAGENT_SERVE_AUTH_ENABLED=true`
+with `OMNICOREAGENT_SERVE_AUTH_TOKEN`.
 
 ### Request/Response Examples
 
@@ -229,49 +257,98 @@ curl http://localhost:8000/tools \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
+### Background Task Example
+
+OmniServe registers the served agent as a background-capable agent during server
+startup. The default background agent id is `default`; override it with
+`OMNICOREAGENT_BACKGROUND_AGENT_ID` or `OmniServeConfig(background_agent_id="...")`.
+
+```bash
+curl -X POST http://localhost:8000/background/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task_id": "daily_report",
+    "query": "Write today'\''s operations report and save the output.",
+    "schedule": {"type": "manual"},
+    "timeout_seconds": 120,
+    "retry_policy": {"max_retries": 1, "initial_delay_seconds": 30}
+  }'
+
+curl -X POST http://localhost:8000/background/tasks/daily_report/run \
+  -H "Content-Type: application/json" \
+  -d '{"wait": false}'
+```
+
+If auth is enabled with `--auth-token` or
+`OMNICOREAGENT_SERVE_AUTH_ENABLED=true`, add
+`-H "Authorization: Bearer YOUR_TOKEN"` to protected requests.
+
+Each run stores operational state in the task store and writes lifecycle files
+into the configured workspace namespace. Use the default in-memory task store
+for local development, or choose `sql` when runs must survive restarts.
+
 ---
 
 ## Environment Variables
 
-All settings via `OMNISERVE_*` prefix. **Environment variables always override code values.**
+Server settings use the `OMNICOREAGENT_SERVE_*` prefix. Background task settings
+use the `OMNICOREAGENT_BACKGROUND_*` prefix. **Environment variables always
+override code values.**
+
+You can run OmniServe without adding any `OMNICOREAGENT_SERVE_*` variables. The defaults
+enable the background API, start the worker, and use in-memory background task
+state. Add variables only when you want to change server behavior,
+authentication, rate limits, or background storage.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OMNISERVE_HOST` | `0.0.0.0` | Server host |
-| `OMNISERVE_PORT` | `8000` | Server port |
-| `OMNISERVE_WORKERS` | `1` | Worker processes |
-| `OMNISERVE_API_PREFIX` | `""` | API path prefix (e.g., `/api/v1`) |
-| `OMNISERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
-| `OMNISERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
-| `OMNISERVE_CORS_ENABLED` | `true` | Enable CORS |
-| `OMNISERVE_CORS_ORIGINS` | `*` | Allowed origins (comma-separated) |
-| `OMNISERVE_CORS_METHODS` | `*` | Allowed methods (comma-separated) |
-| `OMNISERVE_CORS_HEADERS` | `*` | Allowed headers (comma-separated) |
-| `OMNISERVE_CORS_CREDENTIALS` | `true` | Allow credentials |
-| `OMNISERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth |
-| `OMNISERVE_AUTH_TOKEN` | — | Bearer token value |
-| `OMNISERVE_RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
-| `OMNISERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per window |
-| `OMNISERVE_RATE_LIMIT_WINDOW` | `60` | Window in seconds |
-| `OMNISERVE_REQUEST_LOGGING` | `true` | Log requests |
-| `OMNISERVE_LOG_LEVEL` | `INFO` | Log level (DEBUG/INFO/WARNING/ERROR) |
-| `OMNISERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds |
+| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host |
+| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix (e.g., `/api/v1`) |
+| `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
+| `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
+| `OMNICOREAGENT_SERVE_CORS_ENABLED` | `true` | Enable CORS |
+| `OMNICOREAGENT_SERVE_CORS_ORIGINS` | `*` | Allowed origins (comma-separated) |
+| `OMNICOREAGENT_SERVE_CORS_METHODS` | `*` | Allowed methods (comma-separated) |
+| `OMNICOREAGENT_SERVE_CORS_HEADERS` | `*` | Allowed headers (comma-separated) |
+| `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `true` | Allow credentials |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per window |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window in seconds |
+| `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log requests |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level (DEBUG/INFO/WARNING/ERROR) |
+| `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds |
+| `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints |
+| `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id for the served agent in background tasks |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory` or `sql` |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | — | Optional SQL URL override. Setting this URL selects the SQL task store. |
+| `OMNICOREAGENT_BACKGROUND_START_WORKER` | `true` | Start scheduler and worker loop during server lifespan |
 
-**Example `.env` file:**
+<Info>
+The background task store is not conversation memory. Memory stays in
+`MemoryRouter`. The task store is the control plane for schedules, runs,
+attempts, leases, retries, and cancellation. Leave it at the in-memory default
+to start; choose `sql` when that state must survive restarts.
+</Info>
+
+**Example shell environment:**
 
 ```bash
-# Required
-LLM_API_KEY=your_api_key_here
+# Model credential
+export LLM_API_KEY=your_api_key_here
 
-# OmniServe settings
-OMNISERVE_PORT=8000
-OMNISERVE_AUTH_ENABLED=true
-OMNISERVE_AUTH_TOKEN=my-secret-token
-OMNISERVE_RATE_LIMIT_ENABLED=true
-OMNISERVE_RATE_LIMIT_REQUESTS=100
-OMNISERVE_CORS_ORIGINS=https://myapp.com,https://api.myapp.com
-OMNISERVE_CORS_METHODS=GET,POST,OPTIONS
-OMNISERVE_CORS_HEADERS=Authorization,Content-Type
+# Optional OmniServe overrides
+export OMNICOREAGENT_SERVE_PORT=8000
+export OMNICOREAGENT_SERVE_AUTH_ENABLED=true
+export OMNICOREAGENT_SERVE_AUTH_TOKEN=my-secret-token
+export OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED=true
+export OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS=100
+export OMNICOREAGENT_SERVE_CORS_ORIGINS=https://myapp.com,https://api.myapp.com
+export OMNICOREAGENT_SERVE_CORS_METHODS=GET,POST,OPTIONS
+export OMNICOREAGENT_SERVE_CORS_HEADERS=Authorization,Content-Type
 ```
 
 ---
@@ -344,7 +421,7 @@ def get_time() -> dict:
 agent = OmniCoreAgent(
     name="MyAgent",
     system_instruction="You are a helpful assistant.",
-    model_config={"provider": "gemini", "model": "gemini-2.0-flash"},
+    model_config={"provider": "openai", "model": "gpt-4o-mini"},
     local_tools=tools,
 )
 
@@ -368,7 +445,7 @@ if __name__ == "__main__":
 Run with Python directly:
 
 ```bash
-echo "LLM_API_KEY=your_api_key" > .env
+export LLM_API_KEY=your_api_key
 python server.py
 ```
 
@@ -379,7 +456,7 @@ python server.py
 </Info>
 
 <Warning>
-**Environment Variable Precedence:** `.env` variables **always override** values set in `OmniServeConfig`.
+**Environment Variable Precedence:** environment variables **always override** values set in `OmniServeConfig`.
 </Warning>
 
 ---

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -250,8 +250,8 @@ The public task-store backend names are:
 
 | Backend | Purpose |
 |---------|---------|
-| `in_memory` | Fast development and tests; state is lost on process exit |
-| `sql` | Durable local SQLite storage |
+| `in_memory` | Default zero-config store for first-run UX; state is lost on process exit |
+| `sql` | Durable local SQLite storage when restart persistence is required |
 | `redis` | Reserved backend name for future Redis task-store support |
 | `mongodb` | Reserved backend name for future MongoDB task-store support |
 
@@ -262,7 +262,9 @@ library.
 Example:
 
 ```python
-manager = BackgroundAgentManager(
+manager = BackgroundAgentManager()  # defaults to in_memory
+
+durable_manager = BackgroundAgentManager(
     task_store={
         "backend": "sql",
         "url": "sqlite:///.omnicoreagent/background.db",
@@ -275,10 +277,15 @@ manager = BackgroundAgentManager(
 The selected task store is part of manager construction.
 
 ```text
+BackgroundAgentManager()
 BackgroundAgentManager(task_store="in_memory")
 BackgroundAgentManager(task_store="sql")
 BackgroundAgentManager(task_store={...})
 ```
+
+Omitting `task_store` means `in_memory`. This keeps the first-run developer
+experience lightweight. Production deployments that need restart persistence
+must choose `sql` explicitly.
 
 Bare string construction is limited to `in_memory` and `sql`.
 
@@ -790,6 +797,7 @@ DELETE /background/tasks/{task_id}
 GET    /background/runs
 GET    /background/runs/{run_id}
 POST   /background/runs/{run_id}/cancel
+GET    /background/runs/{run_id}/attempts
 GET    /background/runs/{run_id}/events
 GET    /background/runs/{run_id}/workspace
 ```

--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -52,6 +52,7 @@ serve/
     sessions.py          # session history and event endpoints
     tools.py             # /tools
     metrics.py           # /metrics agent usage endpoint
+    background.py        # /background durable task endpoints
   middleware/
     auth.py
     cors.py
@@ -100,6 +101,11 @@ of the production agent harness.
 - `omnicoreagent[serve]` owns FastAPI and Uvicorn dependencies.
 - Multiple `OmniServe` app instances must not share request metrics state.
 - `api_prefix` must apply consistently to API routes.
+- Background routes must use the same `api_prefix`, auth, rate-limit, logging,
+  and timeout middleware as other protected API routes.
+- OmniServe may own HTTP access to background execution, but
+  `BackgroundAgentManager` remains the runtime owner for task stores, schedules,
+  leases, retries, events, and workspace files.
 - Public endpoints that intentionally bypass auth must be explicit and tested.
 - `request_timeout` must be enforced for agent run endpoints.
 - Docs and cookbooks must describe only shipped behavior.

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -100,8 +100,9 @@ mongodb
 
 Rules:
 
-- `in_memory` is ephemeral and intended for tests/development.
-- `sql` is the durable local SQLite backend.
+- Omitting `task_store` selects `in_memory` for zero-config first-run UX.
+- `in_memory` is ephemeral and intended for local use, examples, and tests.
+- `sql` is the durable local SQLite backend for restart persistence.
 - `redis` is reserved for future Redis task-store support.
 - `mongodb` is reserved for future MongoDB task-store support.
 - The manager uses one task store for its lifecycle.

--- a/src/omnicoreagent/background/errors.py
+++ b/src/omnicoreagent/background/errors.py
@@ -25,7 +25,7 @@ class RunNotFoundError(BackgroundAgentError):
     """Raised when a run cannot be found."""
 
 
-class InvalidScheduleError(BackgroundAgentError):
+class InvalidScheduleError(BackgroundAgentError, ValueError):
     """Raised when schedule configuration is invalid."""
 
 

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -11,11 +11,13 @@ from uuid import uuid4
 from omnicoreagent.background.errors import (
     AgentAlreadyRegisteredError,
     AgentNotFoundError,
+    RunLeaseError,
     RunNotFoundError,
     TaskAlreadyRegisteredError,
     TaskNotFoundError,
 )
 from omnicoreagent.background.models import (
+    TERMINAL_RUN_STATUSES,
     AttemptReason,
     AttemptStatus,
     BackgroundAgentSpec,
@@ -61,6 +63,7 @@ class BackgroundAgentManager:
         self._stop_event = asyncio.Event()
         self._events: dict[str, list[dict[str, Any]]] = {}
         self._workspace = workspace
+        self._initialized = False
 
     async def register_agent(
         self, agent_id: str, agent: Any, replace: bool = False
@@ -92,6 +95,7 @@ class BackgroundAgentManager:
             raise AgentAlreadyRegisteredError(
                 f"Agent already registered: {agent_spec.agent_id}"
             )
+        self._agents.pop(agent_spec.agent_id, None)
         await self.task_store.save_agent(agent_spec)
         await self._emit("background_agent_registered", agent_id=agent_spec.agent_id)
         return agent_spec
@@ -117,6 +121,7 @@ class BackgroundAgentManager:
         agent_id: str | None = None,
         query: str | None = None,
         schedule: ScheduleSpec | dict[str, Any] | None = None,
+        enabled: bool = True,
         timeout_seconds: int | None = None,
         retry_policy: dict[str, Any] | None = None,
         overlap_policy: OverlapPolicy | str | None = None,
@@ -136,6 +141,7 @@ class BackgroundAgentManager:
                 agent_id=agent_id,
                 query=query,
                 schedule=schedule,
+                enabled=enabled,
                 timeout_seconds=timeout_seconds,
                 retry_policy=retry_policy or {},
                 overlap_policy=overlap_policy or OverlapPolicy.SKIP_IF_RUNNING,
@@ -182,24 +188,31 @@ class BackgroundAgentManager:
     async def start(self) -> None:
         if self._running:
             return
-        await self.task_store.initialize()
+        await self.initialize()
         self._stop_event.clear()
         self._running = True
         self._worker_task = asyncio.create_task(self._worker_loop())
 
-    async def shutdown(self) -> None:
-        if not self._running:
+    async def initialize(self) -> None:
+        if self._initialized:
             return
-        self._running = False
-        self._stop_event.set()
-        if self._worker_task:
+        await self.task_store.initialize()
+        self._initialized = True
+
+    async def shutdown(self) -> None:
+        if self._running:
+            self._running = False
+            self._stop_event.set()
+        if self._worker_task is not None:
             self._worker_task.cancel()
             try:
                 await self._worker_task
             except asyncio.CancelledError:
                 pass
             self._worker_task = None
-        await self.task_store.close()
+        if self._initialized:
+            await self.task_store.close()
+            self._initialized = False
 
     async def pause_task(self, task_id: str) -> None:
         state = await self.task_store.get_schedule_state(task_id)
@@ -233,18 +246,38 @@ class BackgroundAgentManager:
         if wait and created.status == RunStatus.QUEUED:
             while True:
                 latest = await self.task_store.get_run(created.run_id)
-                if latest and latest.status in {
-                    RunStatus.COMPLETED,
-                    RunStatus.FAILED,
-                    RunStatus.CANCELLED,
-                    RunStatus.TIMEOUT,
-                    RunStatus.SKIPPED,
-                }:
+                if latest and latest.status in TERMINAL_RUN_STATUSES:
                     return latest
-                did_work = await self._execute_one()
+                did_work = (
+                    await self._execute_run(created.run_id)
+                    if latest and latest.status == RunStatus.QUEUED
+                    else False
+                )
                 if not did_work:
                     return latest or created
         return created
+
+    async def wait_for_run(
+        self,
+        run_id: str,
+        timeout_seconds: float | None = None,
+        poll_interval_seconds: float = 0.05,
+    ) -> BackgroundRun:
+        """Wait for one specific run to become terminal without executing work."""
+        deadline = (
+            asyncio.get_running_loop().time() + timeout_seconds
+            if timeout_seconds and timeout_seconds > 0
+            else None
+        )
+        while True:
+            latest = await self.task_store.get_run(run_id)
+            if not latest:
+                raise RunNotFoundError(f"Run not found: {run_id}")
+            if latest.status in TERMINAL_RUN_STATUSES:
+                return latest
+            if deadline is not None and asyncio.get_running_loop().time() >= deadline:
+                return latest
+            await asyncio.sleep(poll_interval_seconds)
 
     async def cancel_run(self, run_id: str) -> None:
         run = await self.task_store.get_run(run_id)
@@ -252,7 +285,14 @@ class BackgroundAgentManager:
             raise RunNotFoundError(f"Run not found: {run_id}")
         await self.task_store.request_cancel(run_id)
         latest = await self.task_store.get_run(run_id)
-        if latest and latest.status in {RunStatus.QUEUED, RunStatus.CLAIMED}:
+        if not latest:
+            return
+        if latest.status == RunStatus.QUEUED:
+            await self._mark_terminal(latest, RunStatus.CANCELLED, "cancelled")
+        elif (
+            latest.status == RunStatus.CLAIMED
+            and latest.lease_owner == self.worker_id
+        ):
             await self._mark_terminal(latest, RunStatus.CANCELLED, "cancelled")
 
     async def recover_expired_runs(self) -> None:
@@ -363,6 +403,33 @@ class BackgroundAgentManager:
             return []
         return self._read_workspace_events(run.workspace_path)
 
+    async def get_run_workspace(self, run_id: str) -> dict[str, Any]:
+        """Return the durable workspace location and visible files for a run."""
+        run = await self.task_store.get_run(run_id)
+        if not run:
+            raise RunNotFoundError(f"Run not found: {run_id}")
+
+        workspace = self._resolve_workspace()
+        files = []
+        if workspace is not None:
+            for item in workspace.files.list_files(run.workspace_path):
+                files.append(
+                    {
+                        "path": item.path,
+                        "name": item.name,
+                        "modified_at": item.modified_at.isoformat(),
+                        "is_dir": item.is_dir,
+                    }
+                )
+
+        return {
+            "run_id": run.run_id,
+            "task_id": run.task_id,
+            "agent_id": run.agent_id,
+            "workspace_path": run.workspace_path,
+            "files": files,
+        }
+
     async def _worker_loop(self) -> None:
         while not self._stop_event.is_set():
             await self.recover_expired_runs()
@@ -407,8 +474,51 @@ class BackgroundAgentManager:
         )
         if not claimed:
             return False
-        await self._run_claimed(claimed)
+        try:
+            await self._run_claimed(claimed)
+        except asyncio.CancelledError:
+            await self._release_claimed_before_start(claimed.run_id)
+            raise
         return True
+
+    async def _execute_run(self, run_id: str) -> bool:
+        latest = await self.task_store.get_run(run_id)
+        if (
+            not latest
+            or latest.status != RunStatus.QUEUED
+            or (latest.queued_at is not None and latest.queued_at > utc_now())
+        ):
+            return False
+        try:
+            claimed = await self.task_store.claim_run(
+                run_id, self.worker_id, self.lease_seconds
+            )
+        except RunLeaseError:
+            return False
+        try:
+            await self._run_claimed(claimed)
+        except asyncio.CancelledError:
+            await self._release_claimed_before_start(claimed.run_id)
+            raise
+        return True
+
+    async def _release_claimed_before_start(self, run_id: str) -> None:
+        latest = await self.task_store.get_run(run_id)
+        if (
+            not latest
+            or latest.status != RunStatus.CLAIMED
+            or latest.lease_owner != self.worker_id
+            or latest.lease_token is None
+        ):
+            return
+        await self.task_store.transition_run(
+            latest.run_id,
+            {RunStatus.CLAIMED},
+            RunStatus.QUEUED,
+            self._release_lease_patch(),
+            self.worker_id,
+            latest.lease_token,
+        )
 
     async def _run_claimed(self, claimed: BackgroundRun) -> None:
         task = await self.task_store.get_task(claimed.task_id)
@@ -453,48 +563,63 @@ class BackgroundAgentManager:
                 if task.timeout_seconds
                 else await coro
             )
+        except asyncio.CancelledError:
+            try:
+                await self._handle_attempt_failure(
+                    task, run, attempt, "exception", RuntimeError("worker shutdown")
+                )
+            finally:
+                heartbeat_task.cancel()
+                await self._drain_cancelled_task(heartbeat_task)
+            raise
         except asyncio.TimeoutError as exc:
-            heartbeat_task.cancel()
-            await self._drain_cancelled_task(heartbeat_task)
-            await self._handle_attempt_failure(task, run, attempt, "timeout", exc)
+            try:
+                await self._handle_attempt_failure(task, run, attempt, "timeout", exc)
+            finally:
+                heartbeat_task.cancel()
+                await self._drain_cancelled_task(heartbeat_task)
             return
         except Exception as exc:
-            heartbeat_task.cancel()
-            await self._drain_cancelled_task(heartbeat_task)
-            await self._handle_attempt_failure(task, run, attempt, "exception", exc)
+            try:
+                await self._handle_attempt_failure(task, run, attempt, "exception", exc)
+            finally:
+                heartbeat_task.cancel()
+                await self._drain_cancelled_task(heartbeat_task)
             return
-        heartbeat_task.cancel()
-        await self._drain_cancelled_task(heartbeat_task)
 
-        preview = self._result_preview(result)
-        if await self.task_store.is_cancel_requested(run.run_id):
+        try:
+            preview = self._result_preview(result)
+            if await self.task_store.is_cancel_requested(run.run_id):
+                await self.task_store.update_attempt(
+                    attempt.attempt_id,
+                    {
+                        "status": AttemptStatus.CANCELLED,
+                        "finished_at": utc_now(),
+                        "error": "cancelled",
+                    },
+                    self.worker_id,
+                    run.lease_token,
+                )
+                await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
+                return
             await self.task_store.update_attempt(
                 attempt.attempt_id,
-                {
-                    "status": AttemptStatus.CANCELLED,
-                    "finished_at": utc_now(),
-                    "error": "cancelled",
-                },
+                {"status": AttemptStatus.COMPLETED, "finished_at": utc_now()},
                 self.worker_id,
                 run.lease_token,
             )
-            await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
-            return
-        await self.task_store.update_attempt(
-            attempt.attempt_id,
-            {"status": AttemptStatus.COMPLETED, "finished_at": utc_now()},
-            self.worker_id,
-            run.lease_token,
-        )
-        completed = await self.task_store.transition_run(
-            run.run_id,
-            {RunStatus.RUNNING},
-            RunStatus.COMPLETED,
-            {"result_preview": preview},
-            self.worker_id,
-            run.lease_token,
-        )
-        await self._emit_run("background_run_completed", completed)
+            completed = await self.task_store.transition_run(
+                run.run_id,
+                {RunStatus.RUNNING},
+                RunStatus.COMPLETED,
+                {"result_preview": preview},
+                self.worker_id,
+                run.lease_token,
+            )
+            await self._emit_run("background_run_completed", completed)
+        finally:
+            heartbeat_task.cancel()
+            await self._drain_cancelled_task(heartbeat_task)
 
     async def _handle_attempt_failure(
         self,

--- a/src/omnicoreagent/background/store/router.py
+++ b/src/omnicoreagent/background/store/router.py
@@ -41,8 +41,7 @@ class TaskStoreRouter:
     ) -> TaskStoreConfig:
         if config is None:
             return TaskStoreConfig(
-                backend=TaskStoreBackend.SQL,
-                url="sqlite:///.omnicoreagent/background.db",
+                backend=TaskStoreBackend.IN_MEMORY,
             )
         if isinstance(config, str):
             if config not in {

--- a/src/omnicoreagent/serve/app_factory.py
+++ b/src/omnicoreagent/serve/app_factory.py
@@ -26,6 +26,7 @@ def create_omniserve_app(
     config: OmniServeConfig,
     title: str,
     description: str,
+    background_manager: Any | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application for one agent."""
     app = FastAPI(
@@ -40,6 +41,10 @@ def create_omniserve_app(
     app.state.agent = agent
     app.state.config = config
     app.state.start_time = time.time()
+    app.state.background_manager = _build_background_manager(
+        config=config,
+        background_manager=background_manager,
+    )
 
     setup_all_middleware(app, config)
     setup_metrics(app, config)
@@ -48,3 +53,18 @@ def create_omniserve_app(
 
     logger.info(f"OmniServe: Created FastAPI app for agent '{get_agent_name(agent)}'")
     return app
+
+
+def _build_background_manager(
+    *,
+    config: OmniServeConfig,
+    background_manager: Any | None,
+) -> Any | None:
+    if not config.background_enabled:
+        return None
+    if background_manager is not None:
+        return background_manager
+
+    from omnicoreagent.background import BackgroundAgentManager
+
+    return BackgroundAgentManager(task_store=config.background_task_store_config())

--- a/src/omnicoreagent/serve/cli.py
+++ b/src/omnicoreagent/serve/cli.py
@@ -141,6 +141,10 @@ def run(
         f"  • Rate Limit: {'✓ ' + str(config.rate_limit_requests) + '/min' if config.rate_limit_enabled else '✗ (use --rate-limit N to enable)'}"
     )
     click.echo(f"  • CORS: {config.cors_origins}")
+    click.echo(
+        f"  • Background API: {'✓' if config.background_enabled else '✗'}, "
+        f"task store: {config.background_task_store}"
+    )
     click.echo("")
     click.echo(
         "💡 Available options: --auth-token, --rate-limit, --cors-origins, --no-docs"
@@ -238,52 +242,34 @@ def quickstart(
 @click.option(
     "--show", is_flag=True, help="Show current configuration from environment"
 )
-@click.option("--env-example", is_flag=True, help="Print example .env file")
+@click.option("--env-example", is_flag=True, help="Print example shell environment")
 def config_cmd(show: bool, env_example: bool):
     """View or generate configuration.
 
     Example:
         omniserve config --show
-        omniserve config --env-example > .env
+        eval "$(omniserve config --env-example)"
     """
     from omnicoreagent.serve import OmniServeConfig
 
     if env_example:
-        click.echo("""# OmniServe Configuration
-# Copy this to .env and modify as needed
+        click.echo("""# OmniCoreAgent / OmniServe
+# Most local runs need only the model key.
+export LLM_API_KEY=your_api_key_here
 
-# Server
-OMNISERVE_HOST=0.0.0.0
-OMNISERVE_PORT=8000
-OMNISERVE_WORKERS=1
+# Optional server overrides
+# export OMNICOREAGENT_SERVE_PORT=8000
+# export OMNICOREAGENT_SERVE_HOST=0.0.0.0
+# export OMNICOREAGENT_SERVE_AUTH_ENABLED=true
+# export OMNICOREAGENT_SERVE_AUTH_TOKEN=change-me
+# export OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED=true
+# export OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS=100
 
-# API
-OMNISERVE_API_PREFIX=
-OMNISERVE_ENABLE_DOCS=true
-OMNISERVE_ENABLE_REDOC=true
-
-# CORS
-OMNISERVE_CORS_ENABLED=true
-OMNISERVE_CORS_ORIGINS=*
-OMNISERVE_CORS_METHODS=*
-OMNISERVE_CORS_HEADERS=*
-OMNISERVE_CORS_CREDENTIALS=true
-
-# Authentication
-OMNISERVE_AUTH_ENABLED=false
-OMNISERVE_AUTH_TOKEN=
-
-# Logging
-OMNISERVE_REQUEST_LOGGING=true
-OMNISERVE_LOG_LEVEL=INFO
-
-# Rate Limiting
-OMNISERVE_RATE_LIMIT_ENABLED=false
-OMNISERVE_RATE_LIMIT_REQUESTS=100
-OMNISERVE_RATE_LIMIT_WINDOW=60
-
-# Timeout
-OMNISERVE_REQUEST_TIMEOUT=300
+# Optional background task persistence
+# Background APIs and the worker are enabled by default with in-memory task state.
+# Use SQL when tasks, runs, attempts, leases, and retries must survive restarts.
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE=sql
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db
 """)
         return
 
@@ -380,7 +366,7 @@ def generate_dockerfile(file_path: str, output_dir: str):
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
-RUN pip install --no-cache-dir omnicoreagent
+RUN pip install --no-cache-dir "omnicoreagent[serve]"
 
 # Copy entire project into image
 COPY . /app

--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -2,54 +2,60 @@
 OmniServe Configuration.
 
 Pydantic settings for server configuration with sensible defaults.
-Supports configuration via environment variables with OMNISERVE_ prefix.
+Supports configuration via OMNICOREAGENT_SERVE_* and
+OMNICOREAGENT_BACKGROUND_* environment variables.
 
 Environment Variables (OVERRIDE code values):
-    OMNISERVE_HOST: Host to bind to (default: 0.0.0.0)
-    OMNISERVE_PORT: Port to bind to (default: 8000)
-    OMNISERVE_WORKERS: Number of worker processes (default: 1)
-    OMNISERVE_API_PREFIX: API path prefix (default: "")
-    OMNISERVE_ENABLE_DOCS: Enable Swagger UI (default: true)
-    OMNISERVE_ENABLE_REDOC: Enable ReDoc UI (default: true)
-    OMNISERVE_CORS_ENABLED: Enable CORS (default: true)
-    OMNISERVE_CORS_ORIGINS: Comma-separated allowed origins (default: *)
-    OMNISERVE_CORS_METHODS: Comma-separated allowed methods (default: *)
-    OMNISERVE_CORS_HEADERS: Comma-separated allowed headers (default: *)
-    OMNISERVE_CORS_CREDENTIALS: Allow credentials in CORS (default: true)
-    OMNISERVE_AUTH_ENABLED: Enable Bearer token auth (default: false)
-    OMNISERVE_AUTH_TOKEN: Bearer token for auth
-    OMNISERVE_REQUEST_LOGGING: Log requests (default: true)
-    OMNISERVE_LOG_LEVEL: Logging level (default: INFO)
-    OMNISERVE_REQUEST_TIMEOUT: Request timeout in seconds (default: 300)
-    OMNISERVE_RATE_LIMIT_ENABLED: Enable rate limiting (default: false)
-    OMNISERVE_RATE_LIMIT_REQUESTS: Max requests per window (default: 100)
-    OMNISERVE_RATE_LIMIT_WINDOW: Time window in seconds (default: 60)
+    OMNICOREAGENT_SERVE_HOST: Host to bind to (default: 0.0.0.0)
+    OMNICOREAGENT_SERVE_PORT: Port to bind to (default: 8000)
+    OMNICOREAGENT_SERVE_WORKERS: Number of worker processes (default: 1)
+    OMNICOREAGENT_SERVE_API_PREFIX: API path prefix (default: "")
+    OMNICOREAGENT_SERVE_ENABLE_DOCS: Enable Swagger UI (default: true)
+    OMNICOREAGENT_SERVE_ENABLE_REDOC: Enable ReDoc UI (default: true)
+    OMNICOREAGENT_SERVE_CORS_ENABLED: Enable CORS (default: true)
+    OMNICOREAGENT_SERVE_CORS_ORIGINS: Comma-separated allowed origins (default: *)
+    OMNICOREAGENT_SERVE_CORS_METHODS: Comma-separated allowed methods (default: *)
+    OMNICOREAGENT_SERVE_CORS_HEADERS: Comma-separated allowed headers (default: *)
+    OMNICOREAGENT_SERVE_CORS_CREDENTIALS: Allow credentials in CORS (default: true)
+    OMNICOREAGENT_SERVE_AUTH_ENABLED: Enable Bearer token auth (default: false)
+    OMNICOREAGENT_SERVE_AUTH_TOKEN: Bearer token for auth
+    OMNICOREAGENT_SERVE_REQUEST_LOGGING: Log requests (default: true)
+    OMNICOREAGENT_SERVE_LOG_LEVEL: Logging level (default: INFO)
+    OMNICOREAGENT_SERVE_REQUEST_TIMEOUT: Request timeout in seconds (default: 300)
+    OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED: Enable rate limiting (default: false)
+    OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS: Max requests per window (default: 100)
+    OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW: Time window in seconds (default: 60)
+    OMNICOREAGENT_BACKGROUND_ENABLED: Enable background APIs (default: true)
+    OMNICOREAGENT_BACKGROUND_AGENT_ID: Agent id used for the served agent (default: default)
+    OMNICOREAGENT_BACKGROUND_TASK_STORE: Task store backend, in_memory or sql (default: in_memory)
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_URL: SQL task store URL
+    OMNICOREAGENT_BACKGROUND_START_WORKER: Start scheduler/worker loop (default: true)
 
 Priority: Environment variables ALWAYS override code values.
 """
 
 import os
-from typing import Optional
+from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-def _get_env(key: str) -> Optional[str]:
-    """Get environment variable with OMNISERVE_ prefix. Returns None if not set."""
-    val = os.environ.get(f"OMNISERVE_{key}")
+def _get_env(prefix: str, key: str) -> Optional[str]:
+    """Get a prefixed environment variable. Returns None if not set."""
+    val = os.environ.get(f"{prefix}_{key}")
     return val if val is not None and val != "" else None
 
 
-def _get_env_bool(key: str) -> Optional[bool]:
+def _get_env_bool(prefix: str, key: str) -> Optional[bool]:
     """Get boolean environment variable. Returns None if not set."""
-    val = _get_env(key)
+    val = _get_env(prefix, key)
     if val is None:
         return None
     return val.lower() in ("true", "1", "yes", "on")
 
 
-def _get_env_int(key: str) -> Optional[int]:
+def _get_env_int(prefix: str, key: str) -> Optional[int]:
     """Get integer environment variable. Returns None if not set."""
-    val = _get_env(key)
+    val = _get_env(prefix, key)
     if val is None:
         return None
     try:
@@ -58,9 +64,9 @@ def _get_env_int(key: str) -> Optional[int]:
         return None
 
 
-def _get_env_list(key: str) -> Optional[list[str]]:
+def _get_env_list(prefix: str, key: str) -> Optional[list[str]]:
     """Get list from comma-separated environment variable. Returns None if not set."""
-    val = _get_env(key)
+    val = _get_env(prefix, key)
     if val is None:
         return None
     return [item.strip() for item in val.split(",") if item.strip()]
@@ -70,8 +76,9 @@ class OmniServeConfig(BaseModel):
     """
     Configuration for OmniServe server.
 
-    Environment variables with OMNISERVE_ prefix ALWAYS override code values.
-    For example, if OMNISERVE_PORT=9000 is set, it will override port=8000 in code.
+    OMNICOREAGENT_SERVE_* and OMNICOREAGENT_BACKGROUND_* environment variables
+    ALWAYS override code values. For example, if
+    OMNICOREAGENT_SERVE_PORT=9000 is set, it overrides port=8000 in code.
     """
 
     # Server settings
@@ -123,6 +130,24 @@ class OmniServeConfig(BaseModel):
         default=60, description="Rate limit time window in seconds"
     )
 
+    # Background execution
+    background_enabled: bool = Field(
+        default=True, description="Expose background execution endpoints"
+    )
+    background_agent_id: str = Field(
+        default="default", description="Agent id used for the served agent"
+    )
+    background_task_store: str | dict[str, Any] | None = Field(
+        default="in_memory", description="Background task store backend or config"
+    )
+    background_task_store_url: str | None = Field(
+        default=None, description="SQL task store URL for background execution"
+    )
+    background_start_worker: bool = Field(
+        default=True,
+        description="Start the background scheduler/worker during OmniServe lifespan",
+    )
+
     @model_validator(mode="after")
     def apply_env_overrides(self) -> "OmniServeConfig":
         """
@@ -131,56 +156,71 @@ class OmniServeConfig(BaseModel):
         Environment variables always take priority over code-defined values.
         """
         # Server settings
-        if (val := _get_env("HOST")) is not None:
+        serve_prefix = "OMNICOREAGENT_SERVE"
+        background_prefix = "OMNICOREAGENT_BACKGROUND"
+
+        if (val := _get_env(serve_prefix, "HOST")) is not None:
             self.host = val
-        if (val := _get_env_int("PORT")) is not None:
+        if (val := _get_env_int(serve_prefix, "PORT")) is not None:
             self.port = val
-        if (val := _get_env_int("WORKERS")) is not None:
+        if (val := _get_env_int(serve_prefix, "WORKERS")) is not None:
             self.workers = val
 
         # API settings
-        if (val := _get_env("API_PREFIX")) is not None:
+        if (val := _get_env(serve_prefix, "API_PREFIX")) is not None:
             self.api_prefix = val
-        if (val := _get_env_bool("ENABLE_DOCS")) is not None:
+        if (val := _get_env_bool(serve_prefix, "ENABLE_DOCS")) is not None:
             self.enable_docs = val
-        if (val := _get_env_bool("ENABLE_REDOC")) is not None:
+        if (val := _get_env_bool(serve_prefix, "ENABLE_REDOC")) is not None:
             self.enable_redoc = val
 
         # CORS settings
-        if (val := _get_env_bool("CORS_ENABLED")) is not None:
+        if (val := _get_env_bool(serve_prefix, "CORS_ENABLED")) is not None:
             self.cors_enabled = val
-        if (val := _get_env_list("CORS_ORIGINS")) is not None:
+        if (val := _get_env_list(serve_prefix, "CORS_ORIGINS")) is not None:
             self.cors_origins = val
-        if (val := _get_env_list("CORS_METHODS")) is not None:
+        if (val := _get_env_list(serve_prefix, "CORS_METHODS")) is not None:
             self.cors_methods = val
-        if (val := _get_env_list("CORS_HEADERS")) is not None:
+        if (val := _get_env_list(serve_prefix, "CORS_HEADERS")) is not None:
             self.cors_headers = val
-        if (val := _get_env_bool("CORS_CREDENTIALS")) is not None:
+        if (val := _get_env_bool(serve_prefix, "CORS_CREDENTIALS")) is not None:
             self.cors_credentials = val
 
         # Authentication
-        if (val := _get_env_bool("AUTH_ENABLED")) is not None:
+        if (val := _get_env_bool(serve_prefix, "AUTH_ENABLED")) is not None:
             self.auth_enabled = val
-        if (val := _get_env("AUTH_TOKEN")) is not None:
+        if (val := _get_env(serve_prefix, "AUTH_TOKEN")) is not None:
             self.auth_token = val
 
         # Logging
-        if (val := _get_env_bool("REQUEST_LOGGING")) is not None:
+        if (val := _get_env_bool(serve_prefix, "REQUEST_LOGGING")) is not None:
             self.request_logging = val
-        if (val := _get_env("LOG_LEVEL")) is not None:
+        if (val := _get_env(serve_prefix, "LOG_LEVEL")) is not None:
             self.log_level = val
 
         # Timeouts
-        if (val := _get_env_int("REQUEST_TIMEOUT")) is not None:
+        if (val := _get_env_int(serve_prefix, "REQUEST_TIMEOUT")) is not None:
             self.request_timeout = val
 
         # Rate limiting
-        if (val := _get_env_bool("RATE_LIMIT_ENABLED")) is not None:
+        if (val := _get_env_bool(serve_prefix, "RATE_LIMIT_ENABLED")) is not None:
             self.rate_limit_enabled = val
-        if (val := _get_env_int("RATE_LIMIT_REQUESTS")) is not None:
+        if (val := _get_env_int(serve_prefix, "RATE_LIMIT_REQUESTS")) is not None:
             self.rate_limit_requests = val
-        if (val := _get_env_int("RATE_LIMIT_WINDOW")) is not None:
+        if (val := _get_env_int(serve_prefix, "RATE_LIMIT_WINDOW")) is not None:
             self.rate_limit_window = val
+
+        # Background execution
+        if (val := _get_env_bool(background_prefix, "ENABLED")) is not None:
+            self.background_enabled = val
+        if (val := _get_env(background_prefix, "AGENT_ID")) is not None:
+            self.background_agent_id = val
+        if (val := _get_env(background_prefix, "TASK_STORE")) is not None:
+            self.background_task_store = val
+        if (val := _get_env(background_prefix, "TASK_STORE_URL")) is not None:
+            self.background_task_store_url = val
+        if (val := _get_env_bool(background_prefix, "START_WORKER")) is not None:
+            self.background_start_worker = val
 
         return self
 
@@ -188,3 +228,17 @@ class OmniServeConfig(BaseModel):
     def from_env(cls) -> "OmniServeConfig":
         """Create config from environment variables only."""
         return cls()
+
+    def background_task_store_config(self) -> str | dict[str, Any] | None:
+        """Return normalized task-store config for BackgroundAgentManager."""
+        if isinstance(self.background_task_store, dict):
+            return self.background_task_store
+        if self.background_task_store_url:
+            backend = self.background_task_store or "sql"
+            if backend == "in_memory":
+                backend = "sql"
+            return {
+                "backend": backend,
+                "url": self.background_task_store_url,
+            }
+        return self.background_task_store

--- a/src/omnicoreagent/serve/lifespan.py
+++ b/src/omnicoreagent/serve/lifespan.py
@@ -14,8 +14,10 @@ from fastapi import FastAPI
 from omnicoreagent.core.logging import logger
 
 if TYPE_CHECKING:
+    from omnicoreagent.background import BackgroundAgentManager
     from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent as AgentType
 else:
+    BackgroundAgentManager = Any
     AgentType = Any
 
 
@@ -33,6 +35,10 @@ async def agent_lifespan(app: FastAPI):
         app.state.agent = my_agent
     """
     agent: AgentType = app.state.agent
+    config = app.state.config
+    background_manager: BackgroundAgentManager | None = getattr(
+        app.state, "background_manager", None
+    )
     agent_name = getattr(agent, "name", "UnknownAgent")
 
     logger.info(f"OmniServe: Starting up agent '{agent_name}'...")
@@ -44,12 +50,25 @@ async def agent_lifespan(app: FastAPI):
         if hasattr(agent, "connect_mcp_servers"):
             await agent.connect_mcp_servers()
 
+        if background_manager is not None:
+            await background_manager.initialize()
+            await background_manager.register_agent(
+                config.background_agent_id,
+                agent,
+                replace=True,
+            )
+            if config.background_start_worker:
+                await background_manager.start()
+
         logger.info(f"OmniServe: Agent '{agent_name}' is ready")
 
         yield
 
     finally:
         logger.info(f"OmniServe: Shutting down agent '{agent_name}'...")
+
+        if background_manager is not None:
+            await background_manager.shutdown()
 
         if hasattr(agent, "cleanup"):
             await agent.cleanup()

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -7,6 +7,17 @@ Pydantic models for API request/response schemas.
 from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnicoreagent.background import (
+    BackgroundAgentSpec,
+    BackgroundRun,
+    BackgroundTaskSpec,
+    OverlapPolicy,
+    RetryPolicy,
+    ScheduleSpec,
+    SessionPolicy,
+    WorkspacePolicy,
+)
+
 
 # =============================================================================
 # Request Models
@@ -19,6 +30,67 @@ class RunRequest(BaseModel):
     query: str = Field(..., description="The query/prompt for the agent")
     session_id: Optional[str] = Field(
         None, description="Optional session ID for conversation continuity"
+    )
+
+
+class BackgroundAgentRegistrationRequest(BaseModel):
+    """Register the served agent or an agent spec for background work."""
+
+    agent_id: str | None = Field(
+        default=None,
+        description="Agent id. Defaults to OmniServe background_agent_id.",
+    )
+    replace: bool = Field(default=False, description="Replace an existing agent spec")
+    spec: BackgroundAgentSpec | None = Field(
+        default=None,
+        description="Optional agent spec. Omit to register the served agent.",
+    )
+
+
+class BackgroundTaskCreateRequest(BaseModel):
+    """Create a background task."""
+
+    task_id: str = Field(..., description="Stable task identifier")
+    agent_id: str | None = Field(
+        default=None,
+        description="Agent id. Defaults to OmniServe background_agent_id.",
+    )
+    query: str = Field(..., description="Instruction executed for each run")
+    schedule: ScheduleSpec = Field(..., description="Manual, once, interval, or cron")
+    enabled: bool = Field(default=True, description="Whether the scheduler may run it")
+    timeout_seconds: int | None = Field(default=None, description="Per-run timeout")
+    retry_policy: RetryPolicy = Field(default_factory=RetryPolicy)
+    overlap_policy: OverlapPolicy = Field(default=OverlapPolicy.SKIP_IF_RUNNING)
+    session_policy: SessionPolicy = Field(default_factory=SessionPolicy)
+    workspace_policy: WorkspacePolicy = Field(default_factory=WorkspacePolicy)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    replace: bool = Field(default=False, description="Replace an existing task")
+
+
+class BackgroundTaskPatchRequest(BaseModel):
+    """Patch mutable fields on a background task."""
+
+    query: str | None = None
+    schedule: ScheduleSpec | None = None
+    enabled: bool | None = None
+    timeout_seconds: int | None = None
+    retry_policy: RetryPolicy | None = None
+    overlap_policy: OverlapPolicy | None = None
+    session_policy: SessionPolicy | None = None
+    workspace_policy: WorkspacePolicy | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class BackgroundTaskRunRequest(BaseModel):
+    """Queue a manual run for an existing task."""
+
+    query: str | None = Field(
+        default=None,
+        description="Optional one-off query override for this run",
+    )
+    wait: bool = Field(
+        default=False,
+        description="Wait for the run to reach a terminal status before returning",
     )
 
 
@@ -109,6 +181,51 @@ class TraceResponse(BaseModel):
     session_id: str = Field(..., description="Session ID")
     summary: dict[str, Any] = Field(..., description="Trace summary")
     steps: list[dict[str, Any]] = Field(..., description="Ordered trace steps")
+
+
+class BackgroundStatusResponse(BaseModel):
+    """Simple status response for background control endpoints."""
+
+    status: str = Field(..., description="Operation status")
+
+
+class BackgroundAgentsResponse(BaseModel):
+    """Response model for background agent listing."""
+
+    agents: list[BackgroundAgentSpec]
+    total: int
+
+
+class BackgroundTasksResponse(BaseModel):
+    """Response model for background task listing."""
+
+    tasks: list[BackgroundTaskSpec]
+    total: int
+
+
+class BackgroundRunsResponse(BaseModel):
+    """Response model for background run listing."""
+
+    runs: list[BackgroundRun]
+    total: int
+
+
+class BackgroundRunEventsResponse(BaseModel):
+    """Response model for background run event replay."""
+
+    run_id: str
+    events: list[dict[str, Any]]
+    count: int
+
+
+class BackgroundRunWorkspaceResponse(BaseModel):
+    """Response model for background run workspace inspection."""
+
+    run_id: str
+    task_id: str
+    agent_id: str
+    workspace_path: str
+    files: list[dict[str, Any]]
 
 
 class ErrorResponse(BaseModel):

--- a/src/omnicoreagent/serve/routes/__init__.py
+++ b/src/omnicoreagent/serve/routes/__init__.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from .background import create_background_router
 from .health import create_health_router
 from .metrics import create_metrics_router
 from .runs import create_runs_router
@@ -17,4 +18,5 @@ def create_agent_router() -> APIRouter:
     router.include_router(create_sessions_router())
     router.include_router(create_tools_router())
     router.include_router(create_metrics_router())
+    router.include_router(create_background_router())
     return router

--- a/src/omnicoreagent/serve/routes/background.py
+++ b/src/omnicoreagent/serve/routes/background.py
@@ -1,0 +1,370 @@
+"""Durable background execution routes for OmniServe."""
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from omnicoreagent.background import (
+    AgentAlreadyRegisteredError,
+    BackgroundAgentError,
+    BackgroundAgentSpec,
+    BackgroundAttempt,
+    BackgroundRun,
+    BackgroundTaskSpec,
+    RunNotFoundError,
+    TaskAlreadyRegisteredError,
+    TaskNotFoundError,
+)
+from omnicoreagent.background.models import TERMINAL_RUN_STATUSES
+
+from ..models import (
+    BackgroundAgentRegistrationRequest,
+    BackgroundAgentsResponse,
+    BackgroundRunEventsResponse,
+    BackgroundRunWorkspaceResponse,
+    BackgroundRunsResponse,
+    BackgroundStatusResponse,
+    BackgroundTaskCreateRequest,
+    BackgroundTaskPatchRequest,
+    BackgroundTaskRunRequest,
+    BackgroundTasksResponse,
+    ErrorResponse,
+)
+from ..state import get_agent, get_background_manager, get_config
+
+
+def create_background_router() -> APIRouter:
+    """Create durable background execution endpoints."""
+    router = APIRouter(prefix="/background", tags=["Background"])
+
+    @router.post(
+        "/agents",
+        response_model=BackgroundAgentSpec,
+        summary="Register a background agent",
+        responses={409: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def register_background_agent(
+        request: Request, body: BackgroundAgentRegistrationRequest
+    ) -> BackgroundAgentSpec:
+        manager = _require_background_manager(request)
+        config = get_config(request)
+
+        try:
+            if body.spec is not None:
+                spec = body.spec
+                if body.agent_id and body.agent_id != spec.agent_id:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="agent_id must match spec.agent_id when spec is provided",
+                    )
+                return await manager.register_agent_spec(spec, replace=body.replace)
+            return await manager.register_agent(
+                body.agent_id or config.background_agent_id,
+                get_agent(request),
+                replace=body.replace,
+            )
+        except AgentAlreadyRegisteredError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    @router.get(
+        "/agents",
+        response_model=BackgroundAgentsResponse,
+        summary="List background agents",
+    )
+    async def list_background_agents(request: Request) -> BackgroundAgentsResponse:
+        manager = _require_background_manager(request)
+        agents = await manager.list_agents()
+        return BackgroundAgentsResponse(agents=agents, total=len(agents))
+
+    @router.get(
+        "/agents/{agent_id}",
+        response_model=BackgroundAgentSpec,
+        summary="Get a background agent spec",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def get_background_agent(request: Request, agent_id: str) -> BackgroundAgentSpec:
+        manager = _require_background_manager(request)
+        agent = await manager.get_agent(agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        return agent
+
+    @router.delete(
+        "/agents/{agent_id}",
+        response_model=BackgroundStatusResponse,
+        summary="Delete a background agent spec",
+        responses={409: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def delete_background_agent(
+        request: Request,
+        agent_id: str,
+        force: bool = Query(default=False),
+    ) -> BackgroundStatusResponse:
+        manager = _require_background_manager(request)
+        try:
+            await manager.unregister_agent(agent_id, force=force)
+        except AgentAlreadyRegisteredError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return BackgroundStatusResponse(status="deleted")
+
+    @router.post(
+        "/tasks",
+        response_model=BackgroundTaskSpec,
+        summary="Create a background task",
+        responses={
+            404: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+            503: {"model": ErrorResponse},
+        },
+    )
+    async def create_background_task(
+        request: Request, body: BackgroundTaskCreateRequest
+    ) -> BackgroundTaskSpec:
+        manager = _require_background_manager(request)
+        config = get_config(request)
+        try:
+            return await manager.register_task(
+                task_id=body.task_id,
+                agent_id=body.agent_id or config.background_agent_id,
+                query=body.query,
+                schedule=body.schedule,
+                enabled=body.enabled,
+                timeout_seconds=body.timeout_seconds,
+                retry_policy=body.retry_policy.model_dump(mode="python"),
+                overlap_policy=body.overlap_policy,
+                session_policy=body.session_policy.model_dump(mode="python"),
+                workspace_policy=body.workspace_policy.model_dump(mode="python"),
+                metadata=body.metadata,
+                replace=body.replace,
+            )
+        except TaskAlreadyRegisteredError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except BackgroundAgentError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    @router.get(
+        "/tasks",
+        response_model=BackgroundTasksResponse,
+        summary="List background tasks",
+    )
+    async def list_background_tasks(
+        request: Request,
+        agent_id: str | None = Query(default=None),
+    ) -> BackgroundTasksResponse:
+        manager = _require_background_manager(request)
+        tasks = await manager.list_tasks(agent_id=agent_id)
+        return BackgroundTasksResponse(tasks=tasks, total=len(tasks))
+
+    @router.get(
+        "/tasks/{task_id}",
+        response_model=BackgroundTaskSpec,
+        summary="Get a background task",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def get_background_task(request: Request, task_id: str) -> BackgroundTaskSpec:
+        manager = _require_background_manager(request)
+        task = await manager.get_task(task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
+        return task
+
+    @router.patch(
+        "/tasks/{task_id}",
+        response_model=BackgroundTaskSpec,
+        summary="Patch a background task",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def patch_background_task(
+        request: Request, task_id: str, body: BackgroundTaskPatchRequest
+    ) -> BackgroundTaskSpec:
+        manager = _require_background_manager(request)
+        patch = body.model_dump(mode="python", exclude_unset=True)
+        try:
+            return await manager.update_task(task_id, patch)
+        except TaskNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    @router.post(
+        "/tasks/{task_id}/run",
+        response_model=BackgroundRun,
+        summary="Queue a manual task run",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def run_background_task(
+        request: Request, task_id: str, body: BackgroundTaskRunRequest | None = None
+    ) -> BackgroundRun:
+        manager = _require_background_manager(request)
+        config = get_config(request)
+        run_request = body or BackgroundTaskRunRequest()
+        try:
+            run = await manager.run_now(
+                task_id,
+                query=run_request.query,
+                wait=False,
+            )
+            if not run_request.wait:
+                return run
+            latest = await manager.wait_for_run(
+                run.run_id,
+                timeout_seconds=config.request_timeout,
+            )
+            if latest.status not in TERMINAL_RUN_STATUSES:
+                raise HTTPException(
+                    status_code=504,
+                    detail=f"Background run did not finish within {config.request_timeout} seconds",
+                )
+            return latest
+        except TaskNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    @router.post(
+        "/tasks/{task_id}/pause",
+        response_model=BackgroundStatusResponse,
+        summary="Pause scheduled dispatch for a task",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def pause_background_task(
+        request: Request, task_id: str
+    ) -> BackgroundStatusResponse:
+        manager = _require_background_manager(request)
+        try:
+            await manager.pause_task(task_id)
+        except TaskNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return BackgroundStatusResponse(status="paused")
+
+    @router.post(
+        "/tasks/{task_id}/resume",
+        response_model=BackgroundStatusResponse,
+        summary="Resume scheduled dispatch for a task",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def resume_background_task(
+        request: Request, task_id: str
+    ) -> BackgroundStatusResponse:
+        manager = _require_background_manager(request)
+        try:
+            await manager.resume_task(task_id)
+        except TaskNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return BackgroundStatusResponse(status="resumed")
+
+    @router.delete(
+        "/tasks/{task_id}",
+        response_model=BackgroundStatusResponse,
+        summary="Delete a background task",
+        responses={503: {"model": ErrorResponse}},
+    )
+    async def delete_background_task(
+        request: Request,
+        task_id: str,
+        delete_runs: bool = Query(default=False),
+    ) -> BackgroundStatusResponse:
+        manager = _require_background_manager(request)
+        await manager.delete_task(task_id, delete_runs=delete_runs)
+        return BackgroundStatusResponse(status="deleted")
+
+    @router.post(
+        "/runs/{run_id}/cancel",
+        response_model=BackgroundStatusResponse,
+        summary="Cancel a queued or running background run",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def cancel_background_run(
+        request: Request, run_id: str
+    ) -> BackgroundStatusResponse:
+        manager = _require_background_manager(request)
+        try:
+            await manager.cancel_run(run_id)
+        except RunNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return BackgroundStatusResponse(status="cancel_requested")
+
+    @router.get(
+        "/runs",
+        response_model=BackgroundRunsResponse,
+        summary="List background runs",
+        responses={503: {"model": ErrorResponse}},
+    )
+    async def list_background_runs(
+        request: Request,
+        task_id: str | None = Query(default=None),
+        status: str | None = Query(default=None),
+    ) -> BackgroundRunsResponse:
+        manager = _require_background_manager(request)
+        try:
+            runs = await manager.list_runs(task_id=task_id, status=status)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return BackgroundRunsResponse(runs=runs, total=len(runs))
+
+    @router.get(
+        "/runs/{run_id}",
+        response_model=BackgroundRun,
+        summary="Get background run status",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def get_background_run(request: Request, run_id: str) -> BackgroundRun:
+        manager = _require_background_manager(request)
+        run = await manager.get_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+        return run
+
+    @router.get(
+        "/runs/{run_id}/attempts",
+        response_model=list[BackgroundAttempt],
+        summary="List background run attempts",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def list_background_run_attempts(request: Request, run_id: str):
+        manager = _require_background_manager(request)
+        await _require_run(manager, run_id)
+        return await manager.list_attempts(run_id)
+
+    @router.get(
+        "/runs/{run_id}/events",
+        response_model=BackgroundRunEventsResponse,
+        summary="Replay background run lifecycle events",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def list_background_run_events(
+        request: Request, run_id: str
+    ) -> BackgroundRunEventsResponse:
+        manager = _require_background_manager(request)
+        await _require_run(manager, run_id)
+        events = await manager.get_run_events(run_id)
+        return BackgroundRunEventsResponse(
+            run_id=run_id,
+            events=events,
+            count=len(events),
+        )
+
+    @router.get(
+        "/runs/{run_id}/workspace",
+        response_model=BackgroundRunWorkspaceResponse,
+        summary="Inspect background run workspace files",
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+    )
+    async def get_background_run_workspace(
+        request: Request, run_id: str
+    ) -> BackgroundRunWorkspaceResponse:
+        manager = _require_background_manager(request)
+        try:
+            return BackgroundRunWorkspaceResponse(**await manager.get_run_workspace(run_id))
+        except RunNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return router
+
+
+def _require_background_manager(request: Request):
+    manager = get_background_manager(request)
+    if manager is None:
+        raise HTTPException(status_code=503, detail="Background execution is disabled")
+    return manager
+
+
+async def _require_run(manager, run_id: str) -> BackgroundRun:
+    run = await manager.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    return run

--- a/src/omnicoreagent/serve/server.py
+++ b/src/omnicoreagent/serve/server.py
@@ -59,6 +59,7 @@ class OmniServe:
         config: Optional[OmniServeConfig] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        background_manager: Any | None = None,
     ):
         """
         Initialize OmniServe.
@@ -68,6 +69,7 @@ class OmniServe:
             config: Optional server configuration
             title: Optional API title (defaults to agent name)
             description: Optional API description
+            background_manager: Optional durable background manager to serve
         """
         self.agent = agent
         self.config = config or OmniServeConfig()
@@ -75,6 +77,7 @@ class OmniServe:
         self.description = description or (
             f"OmniServe API for {get_agent_name(agent)}. Powered by OmniCoreAgent."
         )
+        self.background_manager = background_manager
 
         self.app = self._create_app()
 
@@ -90,6 +93,7 @@ class OmniServe:
             config=self.config,
             title=self.title,
             description=self.description,
+            background_manager=self.background_manager,
         )
 
     def start(

--- a/src/omnicoreagent/serve/state.py
+++ b/src/omnicoreagent/serve/state.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING, Any
 from fastapi import Request
 
 if TYPE_CHECKING:
+    from omnicoreagent.background import BackgroundAgentManager
     from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent as AgentType
 
     from .config import OmniServeConfig
 else:
+    BackgroundAgentManager = Any
     AgentType = Any
     OmniServeConfig = Any
 
@@ -21,6 +23,11 @@ def get_agent(request: Request) -> AgentType:
 def get_config(request: Request) -> OmniServeConfig:
     """Return the OmniServe config bound to the FastAPI app."""
     return request.app.state.config
+
+
+def get_background_manager(request: Request) -> BackgroundAgentManager | None:
+    """Return the optional background manager bound to the FastAPI app."""
+    return getattr(request.app.state, "background_manager", None)
 
 
 def get_agent_name(agent: AgentType) -> str:

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -381,6 +381,33 @@ async def test_manager_run_now_executes_agent_and_records_events():
 
 
 @pytest.mark.asyncio
+async def test_manager_run_now_wait_executes_only_created_run():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="first",
+        agent_id="agent",
+        query="first work",
+        schedule={"type": "manual"},
+    )
+    await manager.register_task(
+        task_id="second",
+        agent_id="agent",
+        query="second work",
+        schedule={"type": "manual"},
+    )
+    first = await manager.run_now("first")
+
+    second = await manager.run_now("second", wait=True)
+
+    first_latest = await manager.get_run(first.run_id)
+    assert first_latest.status == RunStatus.QUEUED
+    assert second.status == RunStatus.COMPLETED
+    assert agent.calls[0]["query"].endswith("second work")
+
+
+@pytest.mark.asyncio
 async def test_manager_run_now_missing_or_disabled_task_raises():
     manager = BackgroundAgentManager(task_store="in_memory")
     await manager.register_agent("agent", FakeAgent())
@@ -541,6 +568,32 @@ async def test_running_cancel_finishes_cancelled_not_completed():
     await manager.shutdown()
 
     assert terminal.status == RunStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_execute_one_releases_claim_when_cancelled_before_run_starts():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent())
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task")
+
+    async def cancelled_before_start(claimed):
+        raise asyncio.CancelledError
+
+    manager._run_claimed = cancelled_before_start
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._execute_one()
+
+    released = await manager.get_run(run.run_id)
+    assert released.status == RunStatus.QUEUED
+    assert released.lease_owner is None
+    assert released.lease_token is None
 
 
 @pytest.mark.asyncio
@@ -740,6 +793,45 @@ async def test_cancel_delayed_retry_marks_run_cancelled_immediately():
     cancelled = await manager.get_run(run.run_id)
 
     assert cancelled.status == RunStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_cancel_claimed_run_owned_by_manager_marks_terminal():
+    manager = BackgroundAgentManager(task_store="in_memory", worker_id="owner")
+    await manager.register_agent("agent", FakeAgent())
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task")
+    await manager.task_store.claim_run(run.run_id, "owner", lease_seconds=30)
+
+    await manager.cancel_run(run.run_id)
+
+    cancelled = await manager.get_run(run.run_id)
+    assert cancelled.status == RunStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_cancel_claimed_run_owned_by_other_worker_records_intent_only():
+    manager = BackgroundAgentManager(task_store="in_memory", worker_id="requester")
+    await manager.register_agent("agent", FakeAgent())
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task")
+    await manager.task_store.claim_run(run.run_id, "other_worker", lease_seconds=30)
+
+    await manager.cancel_run(run.run_id)
+
+    latest = await manager.get_run(run.run_id)
+    assert latest.status == RunStatus.CLAIMED
+    assert latest.cancel_requested_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -5,6 +5,7 @@ DOC_ROOTS = [
     Path("README.md"),
     Path("cookbook"),
     Path("docs"),
+    Path("docker"),
 ]
 
 FORBIDDEN_PUBLIC_API_KEY_NAMES = {
@@ -21,7 +22,13 @@ def _iter_user_facing_files():
             yield root
             continue
         for path in root.rglob("*"):
-            if path.suffix in {".md", ".mdx", ".py"}:
+            if path.name in {"Dockerfile", ".env.example"} or path.suffix in {
+                ".md",
+                ".mdx",
+                ".py",
+                ".yml",
+                ".yaml",
+            }:
                 yield path
 
 
@@ -41,27 +48,47 @@ def test_user_facing_docs_use_single_llm_api_key_name():
     )
 
 
+def test_user_facing_docs_do_not_use_stale_omniserve_prefixes():
+    stale_prefixes = {"OMNISERVE_", "OMNISERVER_"}
+    offenders = []
+    for path in _iter_user_facing_files():
+        text = path.read_text(encoding="utf-8")
+        found = sorted(prefix for prefix in stale_prefixes if prefix in text)
+        if found:
+            offenders.append(f"{path}: {', '.join(found)}")
+
+    assert not offenders, (
+        "User-facing docs and Docker examples must use OMNICOREAGENT_SERVE_* "
+        "or OMNICOREAGENT_BACKGROUND_* env prefixes:\n" + "\n".join(offenders)
+    )
+
+
 def test_omniserve_docs_include_all_public_env_vars():
     expected = {
-        "OMNISERVE_HOST",
-        "OMNISERVE_PORT",
-        "OMNISERVE_WORKERS",
-        "OMNISERVE_API_PREFIX",
-        "OMNISERVE_ENABLE_DOCS",
-        "OMNISERVE_ENABLE_REDOC",
-        "OMNISERVE_CORS_ENABLED",
-        "OMNISERVE_CORS_ORIGINS",
-        "OMNISERVE_CORS_METHODS",
-        "OMNISERVE_CORS_HEADERS",
-        "OMNISERVE_CORS_CREDENTIALS",
-        "OMNISERVE_AUTH_ENABLED",
-        "OMNISERVE_AUTH_TOKEN",
-        "OMNISERVE_REQUEST_LOGGING",
-        "OMNISERVE_LOG_LEVEL",
-        "OMNISERVE_REQUEST_TIMEOUT",
-        "OMNISERVE_RATE_LIMIT_ENABLED",
-        "OMNISERVE_RATE_LIMIT_REQUESTS",
-        "OMNISERVE_RATE_LIMIT_WINDOW",
+        "OMNICOREAGENT_SERVE_HOST",
+        "OMNICOREAGENT_SERVE_PORT",
+        "OMNICOREAGENT_SERVE_WORKERS",
+        "OMNICOREAGENT_SERVE_API_PREFIX",
+        "OMNICOREAGENT_SERVE_ENABLE_DOCS",
+        "OMNICOREAGENT_SERVE_ENABLE_REDOC",
+        "OMNICOREAGENT_SERVE_CORS_ENABLED",
+        "OMNICOREAGENT_SERVE_CORS_ORIGINS",
+        "OMNICOREAGENT_SERVE_CORS_METHODS",
+        "OMNICOREAGENT_SERVE_CORS_HEADERS",
+        "OMNICOREAGENT_SERVE_CORS_CREDENTIALS",
+        "OMNICOREAGENT_SERVE_AUTH_ENABLED",
+        "OMNICOREAGENT_SERVE_AUTH_TOKEN",
+        "OMNICOREAGENT_SERVE_REQUEST_LOGGING",
+        "OMNICOREAGENT_SERVE_LOG_LEVEL",
+        "OMNICOREAGENT_SERVE_REQUEST_TIMEOUT",
+        "OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED",
+        "OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS",
+        "OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW",
+        "OMNICOREAGENT_BACKGROUND_ENABLED",
+        "OMNICOREAGENT_BACKGROUND_AGENT_ID",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL",
+        "OMNICOREAGENT_BACKGROUND_START_WORKER",
     }
     docs = {
         Path("docs/how-to-guides/omniserve.mdx"),

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -7,7 +7,7 @@ import sys
 def _run_import_probe(tmp_path, code: str) -> dict:
     env = os.environ.copy()
     for key in list(env):
-        if key.startswith("OMNISERVE_"):
+        if key.startswith(("OMNICOREAGENT_SERVE_", "OMNICOREAGENT_BACKGROUND_")):
             env.pop(key)
 
     result = subprocess.run(
@@ -22,7 +22,7 @@ def _run_import_probe(tmp_path, code: str) -> dict:
 
 
 def test_root_import_does_not_load_dotenv_or_provider_clients(tmp_path):
-    (tmp_path / ".env").write_text("OMNISERVE_AUTH_ENABLED=false\n")
+    (tmp_path / ".env").write_text("OMNICOREAGENT_SERVE_AUTH_ENABLED=false\n")
 
     result = _run_import_probe(
         tmp_path,
@@ -34,7 +34,7 @@ import sys
 import omnicoreagent
 
 print(json.dumps({
-    "omniserve_auth": os.environ.get("OMNISERVE_AUTH_ENABLED"),
+    "omniserve_auth": os.environ.get("OMNICOREAGENT_SERVE_AUTH_ENABLED"),
     "dotenv_loaded": "dotenv" in sys.modules,
     "litellm_loaded": "litellm" in sys.modules,
     "openai_loaded": "openai" in sys.modules,

--- a/tests/test_omniserve_background.py
+++ b/tests/test_omniserve_background.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+import pytest
+
+from omnicoreagent import OmniServe, OmniServeConfig
+from omnicoreagent.background import BackgroundAgentManager
+from omnicoreagent.core.workspace.manager import Workspace
+
+
+@pytest.fixture(autouse=True)
+def isolate_omniserve_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith(("OMNICOREAGENT_SERVE_", "OMNICOREAGENT_BACKGROUND_")):
+            monkeypatch.delenv(key, raising=False)
+
+
+class ServedAgent:
+    name = "ServeBackgroundAgent"
+    system_instruction = "Execute background tasks."
+    model_config = {"provider": "openai", "model": "gpt-5.4-mini"}
+    agent_config = {}
+    mcp_tools = []
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.connected = False
+        self.cleaned = False
+
+    async def connect_mcp_servers(self) -> None:
+        self.connected = True
+
+    async def cleanup(self) -> None:
+        self.cleaned = True
+
+    def generate_session_id(self) -> str:
+        return "serve-background-session"
+
+    async def run(self, query: str, session_id: str | None = None) -> dict:
+        self.calls.append({"query": query, "session_id": session_id})
+        return {"response": f"completed:{session_id}:{query[-16:]}"}
+
+
+def make_background_manager(tmp_path):
+    workspace = Workspace.from_config(
+        {
+            "workspace_backend": "local",
+            "workspace_dir": str(tmp_path / "workspace"),
+        }
+    ).ensure()
+    return BackgroundAgentManager(task_store="in_memory", workspace=workspace)
+
+
+def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
+    agent = ServedAgent()
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=True,
+            request_timeout=2,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        agents = client.get("/background/agents")
+        assert agents.status_code == 200
+        assert agents.json()["agents"][0]["agent_id"] == "served"
+
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "daily_report",
+                "query": "write the durable report",
+                "schedule": {"type": "manual"},
+                "enabled": False,
+                "retry_policy": {"max_retries": 0},
+            },
+        )
+        assert created.status_code == 200
+        assert created.json()["agent_id"] == "served"
+        assert created.json()["enabled"] is False
+
+        task = client.get("/background/tasks/daily_report")
+        assert task.status_code == 200
+        assert task.json()["enabled"] is False
+
+        patched = client.patch(
+            "/background/tasks/daily_report",
+            json={"enabled": True, "metadata": {"owner": "ops"}},
+        )
+        assert patched.status_code == 200
+        assert patched.json()["enabled"] is True
+        assert patched.json()["metadata"] == {"owner": "ops"}
+
+        run_response = client.post(
+            "/background/tasks/daily_report/run",
+            json={"wait": True},
+        )
+        assert run_response.status_code == 200
+        run = run_response.json()
+        assert run["status"] == "completed"
+        assert run["result_preview"].startswith("completed:background:served:daily_report")
+
+        latest = client.get(f"/background/runs/{run['run_id']}")
+        assert latest.status_code == 200
+        assert latest.json()["status"] == "completed"
+
+        runs = client.get("/background/runs", params={"task_id": "daily_report"})
+        assert runs.status_code == 200
+        assert runs.json()["total"] == 1
+        assert client.get("/background/runs", params={"status": "unknown"}).status_code == 422
+
+        attempts = client.get(f"/background/runs/{run['run_id']}/attempts")
+        assert attempts.status_code == 200
+        assert attempts.json()[0]["status"] == "completed"
+
+        events = client.get(f"/background/runs/{run['run_id']}/events")
+        assert events.status_code == 200
+        event_names = [item["event"] for item in events.json()["events"]]
+        assert "background_run_started" in event_names
+        assert "background_run_completed" in event_names
+        assert client.get("/background/runs/missing/events").status_code == 404
+
+        workspace = client.get(f"/background/runs/{run['run_id']}/workspace")
+        assert workspace.status_code == 200
+        workspace_files = {item["name"] for item in workspace.json()["files"]}
+        assert {"run.json", "events.jsonl"}.issubset(workspace_files)
+
+        deleted = client.delete("/background/tasks/daily_report", params={"delete_runs": True})
+        assert deleted.status_code == 200
+        assert client.delete("/background/agents/served").status_code == 200
+
+    assert agent.connected is True
+    assert agent.cleaned is True
+    assert agent.calls
+    assert agent.calls[0]["session_id"] == "background:served:daily_report"
+
+
+def test_background_api_rejects_invalid_schedule_payload(tmp_path):
+    agent = ServedAgent()
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=False,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        response = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "bad_schedule",
+                "query": "bad",
+                "schedule": {"type": "manual", "seconds": 1},
+            },
+        )
+
+    assert response.status_code == 422
+
+
+def test_background_api_respects_auth_and_api_prefix(tmp_path):
+    agent = ServedAgent()
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            api_prefix="/api",
+            auth_enabled=True,
+            auth_token="secret",
+            background_agent_id="served",
+            background_start_worker=False,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        assert client.get("/api/health").status_code == 200
+        assert client.get("/api/background/agents").status_code == 401
+
+        authed = client.get(
+            "/api/background/agents",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert authed.status_code == 200
+        assert authed.json()["total"] == 1
+
+
+def test_background_api_can_be_disabled():
+    server = OmniServe(
+        ServedAgent(),
+        OmniServeConfig(background_enabled=False),
+    )
+    client = TestClient(server.app)
+
+    response = client.get("/background/agents")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Background execution is disabled"

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -3,14 +3,16 @@ import pytest
 import asyncio
 from unittest.mock import MagicMock, patch, AsyncMock
 from fastapi.testclient import TestClient
+from click.testing import CliRunner
 from omnicoreagent import OmniCoreAgent, OmniServe, OmniServeConfig
+from omnicoreagent.serve.cli import cli
 
 
 @pytest.fixture(autouse=True)
 def isolate_omniserve_env(monkeypatch):
     """Keep local dotenv values from changing explicit test config."""
     for key in list(os.environ):
-        if key.startswith("OMNISERVE_"):
+        if key.startswith(("OMNICOREAGENT_SERVE_", "OMNICOREAGENT_BACKGROUND_")):
             monkeypatch.delenv(key, raising=False)
 
 
@@ -31,21 +33,46 @@ class TestConfiguration:
         assert config.host == "127.0.0.1"
 
     def test_env_vars_override_code(self):
-        """Verify OMNISERVE_* env vars override code values."""
+        """Verify public env vars override code values."""
         with patch.dict(
             os.environ,
             {
-                "OMNISERVE_PORT": "7777",
-                "OMNISERVE_AUTH_ENABLED": "true",
-                "OMNISERVE_LOG_LEVEL": "DEBUG",
+                "OMNICOREAGENT_SERVE_PORT": "7777",
+                "OMNICOREAGENT_SERVE_AUTH_ENABLED": "true",
+                "OMNICOREAGENT_SERVE_LOG_LEVEL": "DEBUG",
+                "OMNICOREAGENT_BACKGROUND_TASK_STORE": "sql",
             },
         ):
             # Code says port 8000, but Env says 7777
-            config = OmniServeConfig(port=8000, auth_enabled=False)
+            config = OmniServeConfig(
+                port=8000, auth_enabled=False, background_task_store="in_memory"
+            )
 
             assert config.port == 7777
             assert config.auth_enabled is True
             assert config.log_level == "DEBUG"
+            assert config.background_task_store == "sql"
+
+    def test_background_task_store_url_infers_sql(self):
+        config = OmniServeConfig(
+            background_task_store_url="sqlite:///custom-background.db"
+        )
+
+        assert config.background_task_store_config() == {
+            "backend": "sql",
+            "url": "sqlite:///custom-background.db",
+        }
+
+    def test_env_example_includes_background_settings(self):
+        result = CliRunner().invoke(cli, ["config", "--env-example"])
+
+        assert result.exit_code == 0
+        for key in [
+            "OMNICOREAGENT_BACKGROUND_TASK_STORE",
+            "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL",
+        ]:
+            assert key in result.output
+        assert "export LLM_API_KEY=your_api_key_here" in result.output
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- wire the durable BackgroundAgentManager into OmniServe lifecycle and app state
- add protected /background HTTP endpoints for agents, tasks, runs, attempts, events, and workspace inspection
- expose background OmniServe config/env vars and document the shipped API surface
- harden manager wait/cancel/shutdown semantics found during evaluator review

## Verification
- uv run ruff check src tests
- uv run pytest tests -q
- evaluator agents reviewed contract, runtime reliability, and docs/API coverage; follow-up fixes were reverified
