### PR TITLE
Add Redis and MongoDB background task stores

### DIFF
--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -3,8 +3,8 @@
 Background Agents run OmniCoreAgent tasks outside the foreground request path.
 They are built around tracked runs, task-store state, retries, cancellation,
 workspace output, and inspectable lifecycle events. Use the default in-memory
-store for local development, or `task_store="sql"` when runs must survive
-restarts.
+store for local development, or `sql`, `redis`, or `mongodb` when runs must
+survive restarts.
 
 ## Key Concepts
 
@@ -15,7 +15,15 @@ restarts.
 
 You can run the background manager without storage configuration. Use
 `BackgroundAgentManager()` for the default zero-config in-memory task store. Use
-`task_store="sql"` when task state must survive process restarts.
+`task_store="sql"`, `task_store="redis"`, or `task_store="mongodb"` when task
+state must survive process restarts.
+
+Redis and MongoDB task stores use optional backend drivers:
+
+```bash
+pip install "omnicoreagent[redis]"
+pip install "omnicoreagent[mongodb]"
+```
 
 ## Quick Start
 
@@ -77,8 +85,23 @@ await manager.resume_task("health_report")
 | `overlap_policy` | `skip_if_running`, `queue_next`, `cancel_previous`, or `allow_parallel`. |
 | `session_policy` | `task`, `run`, or `fixed` memory-session behavior. |
 
-The current implementation includes the tracked run model, SQLite task store,
-in-memory task store for local development and tests, manager lifecycle, manual
-and scheduled runs, retries with delay/backoff, lease fencing, expired-lease
-recovery, cancellation, workspace lifecycle files, and event history. State is
-restart-persistent when the task store is SQL.
+The current implementation includes the tracked run model, in-memory, SQL,
+Redis, and MongoDB task stores, manager lifecycle, manual and scheduled runs,
+retries with delay/backoff, lease fencing, expired-lease recovery, cancellation,
+workspace lifecycle files, and event history. State is restart-persistent when
+the task store is SQL, Redis, or MongoDB.
+
+Redis durable deployments need persistence enabled and a no-eviction policy for
+task-store keys. MongoDB task-store writes use majority write concern.
+
+```python
+BackgroundAgentManager(task_store="sql")
+BackgroundAgentManager(task_store={"backend": "redis", "url": "redis://localhost:6379/0"})
+BackgroundAgentManager(
+    task_store={
+        "backend": "mongodb",
+        "uri": "mongodb://localhost:27017",
+        "database": "omnicoreagent",
+    }
+)
+```

--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -97,8 +97,13 @@ limiting until you opt in.
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Timeout seconds |
 | `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints |
 | `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id for the served agent in background tasks |
-| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background task store backend |
-| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | — | SQL task store URL; setting it selects the SQL task store |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background task store backend: `in_memory`, `sql`, `redis`, or `mongodb` |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | — | SQL or Redis task store URL. Use `OMNICOREAGENT_BACKGROUND_TASK_STORE=redis` for Redis URLs |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URI` | — | MongoDB task store URI |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE` | `omnicoreagent` | MongoDB database name |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX` | — | Redis key prefix |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX` | — | MongoDB collection prefix |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT` | — | Backend connect timeout in seconds |
 | `OMNICOREAGENT_BACKGROUND_START_WORKER` | `true` | Start scheduler and worker loop |
 
 ---

--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -7,11 +7,11 @@ icon: 'clock'
 # Background Agents
 
 Background agents run tracked OmniCoreAgent tasks outside the foreground request
-path. Use the default in-memory store for local development, or `task_store="sql"`
-when tasks, runs, attempts, leases, retries, and cancellation state must survive
-process restarts. A task can run manually, once at a fixed time, on an interval,
-or from a five-field cron expression. Each run is tracked through queued,
-claimed, running, retrying, and terminal states.
+path. Use the default in-memory store for local development, or choose `sql`,
+`redis`, or `mongodb` when tasks, runs, attempts, leases, retries, and
+cancellation state must survive process restarts. A task can run manually, once
+at a fixed time, on an interval, or from a five-field cron expression. Each run
+is tracked through queued, claimed, running, retrying, and terminal states.
 
 Background execution is part of the core package:
 
@@ -19,10 +19,18 @@ Background execution is part of the core package:
 pip install omnicoreagent
 ```
 
+Redis and MongoDB task stores use optional backend drivers:
+
+```bash
+pip install "omnicoreagent[redis]"
+pip install "omnicoreagent[mongodb]"
+```
+
 No storage configuration is required to start. `BackgroundAgentManager()` uses an
 in-memory task store by default so the first run has no database requirement.
-Use `task_store="sql"` when tasks, runs, attempts, leases, retries, and
-cancellation state must survive process restarts.
+Use `task_store="sql"`, `task_store="redis"`, or `task_store="mongodb"` when
+tasks, runs, attempts, leases, retries, and cancellation state must survive
+process restarts.
 
 The task store is separate from agent memory. `MemoryRouter` stores
 conversation/session history. The task store stores operational background
@@ -147,7 +155,23 @@ The task store is the source of truth for:
 - runs and attempts
 - leases, heartbeats, and cancellation flags
 
-The current runtime includes the tracked run model, SQLite and in-memory task
-stores, schedule dispatch, manual runs, retries with delay/backoff, lease
-fencing, expired-lease recovery, cancellation, workspace lifecycle files, and run
-event history. State is restart-persistent when the task store is SQL.
+The current runtime includes the tracked run model, in-memory, SQL, Redis, and
+MongoDB task stores, schedule dispatch, manual runs, retries with delay/backoff,
+lease fencing, expired-lease recovery, cancellation, workspace lifecycle files,
+and run event history. State is restart-persistent when the task store is SQL,
+Redis, or MongoDB.
+
+Redis durable deployments need persistence enabled and a no-eviction policy for
+task-store keys. MongoDB task-store writes use majority write concern.
+
+```python
+BackgroundAgentManager(task_store="sql")
+BackgroundAgentManager(task_store={"backend": "redis", "url": "redis://localhost:6379/0"})
+BackgroundAgentManager(
+    task_store={
+        "backend": "mongodb",
+        "uri": "mongodb://localhost:27017",
+        "database": "omnicoreagent",
+    }
+)
+```

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -101,15 +101,23 @@ and use an in-memory task store. Set only the values you want to override.
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Rate-limit window in seconds. |
 | `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints. |
 | `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id used when OmniServe registers the served agent for background work. |
-| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory` for zero-config local use or `sql` for restart-persistent SQLite. |
-| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | unset | Optional SQL URL override. Setting this URL selects the SQL task store even if `OMNICOREAGENT_BACKGROUND_TASK_STORE` is unset. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory`, `sql`, `redis`, or `mongodb`. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | unset | SQL or Redis URL. A URL with no backend selects SQL; use `OMNICOREAGENT_BACKGROUND_TASK_STORE=redis` for Redis URLs. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URI` | unset | MongoDB URI. Setting this selects the MongoDB task store. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE` | `omnicoreagent` | MongoDB database name. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX` | unset | Redis key prefix. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX` | unset | MongoDB collection prefix. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT` | unset | Optional backend connect timeout in seconds. |
 | `OMNICOREAGENT_BACKGROUND_START_WORKER` | `true` | Start the scheduler and worker loop during server lifespan. |
 
 The background task store is separate from `MemoryRouter`. `MemoryRouter` stores
 conversation/session history. The task store stores scheduler/runtime state:
 tasks, schedule cursors, runs, attempts, leases, heartbeats, retries, and
-cancellation flags. Defaults are intentionally light. Use `sql` when background
-tasks must survive process restarts.
+cancellation flags. Defaults are intentionally light. Use `sql`, `redis`, or
+`mongodb` when background tasks must survive process restarts.
+
+For Redis durability, enable Redis persistence and keep task-store keys out of
+eviction. MongoDB task-store writes use majority write concern.
 
 ## 2. Agent Configuration
 

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -285,7 +285,8 @@ If auth is enabled with `--auth-token` or
 
 Each run stores operational state in the task store and writes lifecycle files
 into the configured workspace namespace. Use the default in-memory task store
-for local development, or choose `sql` when runs must survive restarts.
+for local development, or choose `sql`, `redis`, or `mongodb` when runs must
+survive restarts.
 
 ---
 
@@ -323,15 +324,22 @@ authentication, rate limits, or background storage.
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds |
 | `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints |
 | `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id for the served agent in background tasks |
-| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory` or `sql` |
-| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | — | Optional SQL URL override. Setting this URL selects the SQL task store. |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory`, `sql`, `redis`, or `mongodb` |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | — | SQL or Redis URL. Use `OMNICOREAGENT_BACKGROUND_TASK_STORE=redis` for Redis URLs |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URI` | — | MongoDB URI |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE` | `omnicoreagent` | MongoDB database name |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX` | — | Redis key prefix |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX` | — | MongoDB collection prefix |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT` | — | Backend connect timeout in seconds |
 | `OMNICOREAGENT_BACKGROUND_START_WORKER` | `true` | Start scheduler and worker loop during server lifespan |
 
 <Info>
 The background task store is not conversation memory. Memory stays in
 `MemoryRouter`. The task store is the control plane for schedules, runs,
 attempts, leases, retries, and cancellation. Leave it at the in-memory default
-to start; choose `sql` when that state must survive restarts.
+to start; choose `sql`, `redis`, or `mongodb` when that state must survive
+restarts. Redis durable deployments need persistence enabled and a no-eviction
+policy for task-store keys. MongoDB durable deployments use majority writes.
 </Info>
 
 **Example shell environment:**

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -65,7 +65,7 @@ execution layer around the agent harness.
 | Workspace is mandatory | Every background run gets a workspace namespace for durable outputs |
 | Memory is separate | Conversation/session memory stays in `MemoryRouter`; operational state stays in the task store |
 | Events are visibility, not truth | Events describe lifecycle transitions; the task store is the source of truth |
-| Storage is pluggable | `AbstractTaskStore` supports the shipped `sql` and `in_memory` stores and leaves Redis/MongoDB behind the same interface |
+| Storage is pluggable | `AbstractTaskStore` supports the shipped `in_memory`, `sql`, `redis`, and `mongodb` stores behind the same interface |
 | Backend choice is explicit | A running manager uses one task store; backend transfer is explicit, not hot-swapped mid-run |
 | Root import stays light | Background imports do not pull Redis, MongoDB, or heavyweight scheduler packages |
 
@@ -155,9 +155,9 @@ redis
 mongodb
 ```
 
-The shipped implementations are `sql` and `in_memory`. Redis and MongoDB use
-the same contract when implemented. The router is a construction boundary only.
-Runtime code depends on `AbstractTaskStore`, not on backend-specific classes.
+The shipped implementations are `in_memory`, `sql`, `redis`, and `mongodb`.
+The router is a construction boundary only. Runtime code depends on
+`AbstractTaskStore`, not on backend-specific classes.
 
 ### `AbstractTaskStore`
 
@@ -252,8 +252,8 @@ The public task-store backend names are:
 |---------|---------|
 | `in_memory` | Default zero-config store for first-run UX; state is lost on process exit |
 | `sql` | Durable local SQLite storage when restart persistence is required |
-| `redis` | Reserved backend name for future Redis task-store support |
-| `mongodb` | Reserved backend name for future MongoDB task-store support |
+| `redis` | Redis-backed task store for durable remote state; stores one serialized state snapshot behind a token-checked lock |
+| `mongodb` | MongoDB-backed task store for durable remote state; stores one serialized state snapshot behind an expiring lock document |
 
 Do not expose separate public routers named after each SQL database. The
 current `sql` implementation is SQLite-backed and uses the Python standard
@@ -285,9 +285,11 @@ BackgroundAgentManager(task_store={...})
 
 Omitting `task_store` means `in_memory`. This keeps the first-run developer
 experience lightweight. Production deployments that need restart persistence
-must choose `sql` explicitly.
+must choose `sql`, `redis`, or `mongodb` explicitly.
 
-Bare string construction is limited to `in_memory` and `sql`.
+Bare string construction is supported for all backend names. Redis uses
+`REDIS_URL` when no URL is provided. MongoDB uses `MONGODB_URI` and defaults the
+database to `omnicoreagent` when no database is provided.
 
 The manager must not hot-swap task stores while runs are active. Operational
 state is stateful by design. Moving from one backend to another requires an

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -66,6 +66,8 @@ AbstractTaskStore
 TaskStoreRouter
 InMemoryTaskStore
 SqlTaskStore
+RedisTaskStore
+MongoDbTaskStore
 BackgroundAgentError
 AgentAlreadyRegisteredError
 AgentNotFoundError
@@ -103,8 +105,8 @@ Rules:
 - Omitting `task_store` selects `in_memory` for zero-config first-run UX.
 - `in_memory` is ephemeral and intended for local use, examples, and tests.
 - `sql` is the durable local SQLite backend for restart persistence.
-- `redis` is reserved for future Redis task-store support.
-- `mongodb` is reserved for future MongoDB task-store support.
+- `redis` is the durable Redis backend for remote task-store state.
+- `mongodb` is the durable MongoDB backend for remote task-store state.
 - The manager uses one task store for its lifecycle.
 - Switching task-store backend during active runs is not supported.
 - Moving state between task-store backends requires explicit export/import or
@@ -117,8 +119,10 @@ Redis requirements:
   equivalent managed durability setting with an explicit acknowledged-write loss
   bound. RDB-only persistence is not sufficient for strict durable task state.
 - eviction policy must not evict task-store keys.
-- atomic claim, transition, overlap, and schedule-advance operations must use
-  transactions or Lua scripts.
+- claim, transition, overlap, and schedule-advance operations must be serialized
+  by a backend lock before the state snapshot is read, mutated, and persisted.
+  The lock release must be token-checked so one worker cannot release another
+  worker's lock.
 
 SQL requirements:
 
@@ -128,15 +132,15 @@ SQL requirements:
   `occurrence_id` is not null.
 - claim and transition queries must use row-level locking or an equivalent
   compare-and-set condition.
+
 MongoDB requirements:
 
-- task-store writes that must be atomic across schedule/run/attempt records must
-  use MongoDB transactions on deployments that support them.
 - deployments must use majority write concern for durable task state.
-- MongoDB backends must create a unique index for `(task_id, occurrence_id)`
-  when `occurrence_id` is not null.
-- claim and transition updates must include expected status and lease token in
-  the filter.
+- claim, transition, overlap, and schedule-advance operations must be serialized
+  by a backend lock document before the state snapshot is read, mutated, and
+  persisted.
+- lock acquisition must be token and expiry based so a dead worker does not hold
+  the store forever.
 
 ---
 
@@ -154,7 +158,7 @@ manager = BackgroundAgentManager(
 
 Defaults:
 
-- `task_store`: `{"backend": "sql", "url": "sqlite:///.omnicoreagent/background.db"}`
+- `task_store`: `None` selects `in_memory`
 - `memory_router`: normal OmniCoreAgent default memory router
 - `event_router`: normal OmniCoreAgent default event router
 - `workspace`: normal OmniCoreAgent default workspace
@@ -165,6 +169,8 @@ Accepted `task_store` forms:
 ```python
 "in_memory"
 "sql"
+{"backend": "redis", "url": "redis://localhost:6379/0"}
+{"backend": "mongodb", "uri": "mongodb://localhost:27017", "database": "omnicoreagent"}
 {"backend": "sql", "url": "sqlite:///.omnicoreagent/background.db"}
 AbstractTaskStore(...)
 ```
@@ -198,13 +204,14 @@ Backend-specific fields:
 |---------|--------|
 | `in_memory` | no required fields |
 | `sql` | `url`; accepts SQLite URLs; defaults to `sqlite:///.omnicoreagent/background.db` when omitted |
-| `redis` | reserved; runtime raises `InvalidTaskStoreError` until implemented |
-| `mongodb` | reserved; runtime raises `InvalidTaskStoreError` until implemented |
+| `redis` | `url`; defaults from `REDIS_URL` when bare `task_store="redis"` is used |
+| `mongodb` | `uri`, `database`; URI defaults from `MONGODB_URI`, database defaults to `omnicoreagent` for bare `task_store="mongodb"` |
 
 Unknown fields raise `InvalidTaskStoreError`. `uri` is only accepted for the
-reserved MongoDB config. `url` is used for SQL.
+MongoDB config. `url` is used for SQL and Redis.
 
-Bare string construction is accepted only for `in_memory` and `sql`.
+Bare string construction is accepted for all backend names. Redis and MongoDB
+still require their connection environment variables before initialization.
 
 ---
 
@@ -1025,8 +1032,10 @@ Run the same contract tests against every backend:
 The implementation satisfies this specification when:
 
 - `BackgroundAgentManager` uses `AbstractTaskStore` for all operational state.
-- `TaskStoreRouter` supports the shipped `in_memory` and `sql` stores.
+- `TaskStoreRouter` supports the shipped `in_memory`, `sql`, `redis`, and `mongodb` stores.
 - `sql` supports local SQLite durability.
+- `redis` supports durable Redis state through a serialized snapshot and backend lock.
+- `mongodb` supports durable MongoDB state through a serialized snapshot and lock document.
 - durable stores survive manager restart.
 - every run has a durable `run_id`.
 - every run has a durable `query_snapshot`.

--- a/src/omnicoreagent/background/__init__.py
+++ b/src/omnicoreagent/background/__init__.py
@@ -34,6 +34,8 @@ from omnicoreagent.background.models import (
 from omnicoreagent.background.store import (
     AbstractTaskStore,
     InMemoryTaskStore,
+    MongoDbTaskStore,
+    RedisTaskStore,
     SqlTaskStore,
     TaskStoreRouter,
 )
@@ -52,7 +54,9 @@ __all__ = [
     "InMemoryTaskStore",
     "InvalidScheduleError",
     "InvalidTaskStoreError",
+    "MongoDbTaskStore",
     "OverlapPolicy",
+    "RedisTaskStore",
     "RetryPolicy",
     "RunCancelledError",
     "RunExecutionError",

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -210,9 +210,8 @@ class BackgroundAgentManager:
             except asyncio.CancelledError:
                 pass
             self._worker_task = None
-        if self._initialized:
-            await self.task_store.close()
-            self._initialized = False
+        await self.task_store.close()
+        self._initialized = False
 
     async def pause_task(self, task_id: str) -> None:
         state = await self.task_store.get_schedule_state(task_id)

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -214,21 +214,11 @@ class BackgroundAgentManager:
         self._initialized = False
 
     async def pause_task(self, task_id: str) -> None:
-        state = await self.task_store.get_schedule_state(task_id)
-        if not state:
-            raise TaskNotFoundError(f"Task not found: {task_id}")
-        await self.task_store.save_schedule_state(
-            state.model_copy(update={"paused": True, "updated_at": utc_now()})
-        )
+        await self.task_store.set_schedule_paused(task_id, True)
         await self._emit("background_task_paused", task_id=task_id)
 
     async def resume_task(self, task_id: str) -> None:
-        state = await self.task_store.get_schedule_state(task_id)
-        if not state:
-            raise TaskNotFoundError(f"Task not found: {task_id}")
-        await self.task_store.save_schedule_state(
-            state.model_copy(update={"paused": False, "updated_at": utc_now()})
-        )
+        await self.task_store.set_schedule_paused(task_id, False)
         await self._emit("background_task_resumed", task_id=task_id)
 
     async def run_now(

--- a/src/omnicoreagent/background/store/__init__.py
+++ b/src/omnicoreagent/background/store/__init__.py
@@ -2,12 +2,16 @@
 
 from .base import AbstractTaskStore
 from .in_memory import InMemoryTaskStore
+from .mongodb import MongoDbTaskStore
+from .redis import RedisTaskStore
 from .router import TaskStoreRouter
 from .sql import SqlTaskStore
 
 __all__ = [
     "AbstractTaskStore",
     "InMemoryTaskStore",
+    "MongoDbTaskStore",
+    "RedisTaskStore",
     "SqlTaskStore",
     "TaskStoreRouter",
 ]

--- a/src/omnicoreagent/background/store/base.py
+++ b/src/omnicoreagent/background/store/base.py
@@ -58,6 +58,11 @@ class AbstractTaskStore(ABC):
     async def save_schedule_state(self, state: BackgroundScheduleState) -> None: ...
 
     @abstractmethod
+    async def set_schedule_paused(
+        self, task_id: str, paused: bool
+    ) -> BackgroundScheduleState: ...
+
+    @abstractmethod
     async def get_schedule_state(
         self, task_id: str
     ) -> BackgroundScheduleState | None: ...

--- a/src/omnicoreagent/background/store/in_memory.py
+++ b/src/omnicoreagent/background/store/in_memory.py
@@ -156,6 +156,18 @@ class InMemoryTaskStore(AbstractTaskStore):
                 raise TaskNotFoundError(f"Task not found: {state.task_id}")
             self._schedule_states[state.task_id] = _copy_model(state)
 
+    async def set_schedule_paused(
+        self, task_id: str, paused: bool
+    ) -> BackgroundScheduleState:
+        async with self._lock:
+            state = self._require_schedule_state(task_id)
+            updated = state.model_copy(
+                update={"paused": paused, "updated_at": _now()},
+                deep=True,
+            )
+            self._schedule_states[task_id] = updated
+            return _copy_model(updated)
+
     async def get_schedule_state(
         self, task_id: str
     ) -> BackgroundScheduleState | None:

--- a/src/omnicoreagent/background/store/mongodb.py
+++ b/src/omnicoreagent/background/store/mongodb.py
@@ -1,0 +1,261 @@
+"""MongoDB-backed task store for background execution."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+import time
+from typing import TypeVar
+from uuid import uuid4
+
+from omnicoreagent.background.errors import InvalidTaskStoreError, TaskStoreError
+from omnicoreagent.background.models import utc_now
+from omnicoreagent.background.store.serialized import SerializedTaskStore
+
+
+T = TypeVar("T")
+
+
+class MongoDbTaskStore(SerializedTaskStore):
+    """Durable MongoDB task store using versioned record snapshots."""
+
+    def __init__(
+        self,
+        uri: str,
+        database: str,
+        *,
+        collection_prefix: str | None = None,
+        connect_timeout: float | None = None,
+        lock_timeout: float = 30.0,
+        lock_lease_seconds: float = 300.0,
+    ) -> None:
+        super().__init__()
+        self.uri = uri
+        self.database_name = database
+        self.collection_prefix = collection_prefix or "omnicoreagent_background"
+        self.connect_timeout = connect_timeout
+        self.lock_timeout = lock_timeout
+        self.lock_lease_seconds = lock_lease_seconds
+        self._client = None
+        self._db = None
+        self._backend_init_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        await super().initialize()
+        try:
+            from motor.motor_asyncio import AsyncIOMotorClient
+            from pymongo.write_concern import WriteConcern
+        except ImportError as exc:  # pragma: no cover - exercised without extra
+            raise InvalidTaskStoreError(
+                "MongoDB task store requires the mongodb extra: "
+                "pip install 'omnicoreagent[mongodb]'"
+            ) from exc
+
+        kwargs = {}
+        if self.connect_timeout is not None:
+            kwargs["serverSelectionTimeoutMS"] = int(self.connect_timeout * 1000)
+        self._client = AsyncIOMotorClient(self.uri, **kwargs)
+        self._db = self._client[self.database_name].with_options(
+            write_concern=WriteConcern("majority")
+        )
+        await self._db.command("ping")
+        await self._lock_collection.update_one(
+            {"_id": "task_store"},
+            {
+                "$setOnInsert": {
+                    "token": None,
+                    "expires_at": utc_now(),
+                    "updated_at": utc_now(),
+                }
+            },
+            upsert=True,
+        )
+        await self._load_backend_state()
+
+    async def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+            self._db = None
+        await super().close()
+
+    async def _load_backend_state(self) -> None:
+        await self._ensure_initialized()
+        state = await self._lock_collection.find_one({"_id": "task_store"})
+        generation = state.get("active_generation") if state else None
+        if not generation:
+            await self._load_snapshot(None)
+            return
+        await self._load_snapshot(
+            {
+                "agents": await self._load_records(generation, "agents"),
+                "tasks": await self._load_records(generation, "tasks"),
+                "schedule_states": await self._load_records(
+                    generation, "schedule_states"
+                ),
+                "runs": await self._load_records(generation, "runs"),
+                "attempts": await self._load_records(generation, "attempts"),
+                "cancel_requested": sorted(
+                    await self._load_record_ids(generation, "cancelled")
+                ),
+            }
+        )
+
+    async def _mutate(self, operation: Callable[[], Awaitable[T]]) -> T:
+        await self._ensure_initialized()
+        async with self._operation_lock:
+            token = await self._acquire_lock()
+            try:
+                await self._load_backend_state()
+                result = await operation()
+                await self._persist_backend_state(token)
+                return result
+            finally:
+                await self._release_lock(token)
+
+    async def _read(self, operation: Callable[[], Awaitable[T]]) -> T:
+        await self._ensure_initialized()
+        async with self._operation_lock:
+            token = await self._acquire_lock()
+            try:
+                await self._load_backend_state()
+                return await operation()
+            finally:
+                await self._release_lock(token)
+
+    async def _persist_backend_state(self, token: str) -> None:
+        snapshot = await self._snapshot()
+        generation = uuid4().hex
+        state = await self._lock_collection.find_one({"_id": "task_store"})
+        previous_generation = state.get("active_generation") if state else None
+        stale_generation = state.get("previous_generation") if state else None
+
+        await self._refresh_lock(token)
+        try:
+            for name in ("agents", "tasks", "schedule_states", "runs", "attempts"):
+                records = [
+                    {
+                        "_id": f"{generation}:{record_id}",
+                        "_generation": generation,
+                        "record_id": record_id,
+                        "value": value,
+                    }
+                    for record_id, value in snapshot[name].items()
+                ]
+                if records:
+                    await self._collection(name).insert_many(records)
+            cancelled = [
+                {
+                    "_id": f"{generation}:{run_id}",
+                    "_generation": generation,
+                    "record_id": run_id,
+                }
+                for run_id in snapshot["cancel_requested"]
+            ]
+            if cancelled:
+                await self._collection("cancelled").insert_many(cancelled)
+            await self._commit_generation(token, generation, previous_generation)
+        except Exception:
+            await self._delete_generation(generation)
+            raise
+        if stale_generation and stale_generation not in {previous_generation, generation}:
+            await self._delete_generation(stale_generation)
+
+    async def _acquire_lock(self) -> str:
+        token = uuid4().hex
+        deadline = time.monotonic() + self.lock_timeout
+        while time.monotonic() < deadline:
+            now = utc_now()
+            expires_at = now + timedelta(seconds=self.lock_lease_seconds)
+            result = await self._lock_collection.update_one(
+                {
+                    "_id": "task_store",
+                    "$or": [
+                        {"token": None},
+                        {"token": {"$exists": False}},
+                        {"expires_at": {"$lte": now}},
+                        {"token": token},
+                    ],
+                },
+                {
+                    "$set": {
+                        "token": token,
+                        "expires_at": expires_at,
+                        "updated_at": now,
+                    }
+                },
+            )
+            if result.matched_count:
+                return token
+            await asyncio.sleep(0.05)
+        raise TaskStoreError("Timed out acquiring MongoDB task-store lock")
+
+    async def _refresh_lock(self, token: str) -> None:
+        result = await self._lock_collection.update_one(
+            {"_id": "task_store", "token": token},
+            {
+                "$set": {
+                    "expires_at": utc_now()
+                    + timedelta(seconds=self.lock_lease_seconds),
+                    "updated_at": utc_now(),
+                }
+            },
+        )
+        if not result.matched_count:
+            raise TaskStoreError("MongoDB task-store lock expired before commit")
+
+    async def _commit_generation(
+        self, token: str, generation: str, previous_generation: str | None
+    ) -> None:
+        await self._refresh_lock(token)
+        result = await self._lock_collection.update_one(
+            {"_id": "task_store", "token": token},
+            {
+                "$set": {
+                    "active_generation": generation,
+                    "previous_generation": previous_generation,
+                    "updated_at": utc_now(),
+                }
+            },
+        )
+        if not result.matched_count:
+            raise TaskStoreError("MongoDB task-store lock expired before commit")
+
+    async def _release_lock(self, token: str) -> None:
+        await self._lock_collection.update_one(
+            {"_id": "task_store", "token": token},
+            {"$set": {"token": None, "expires_at": utc_now(), "updated_at": utc_now()}},
+        )
+
+    @property
+    def _lock_collection(self):
+        return self._collection("locks")
+
+    def _collection(self, name: str):
+        if self._db is None:
+            raise TaskStoreError("MongoDB task store is not initialized")
+        return self._db[f"{self.collection_prefix}_{name}"]
+
+    async def _ensure_initialized(self) -> None:
+        if self._db is not None:
+            return
+        async with self._backend_init_lock:
+            if self._db is None:
+                await self.initialize()
+
+    async def _load_records(self, generation: str, name: str) -> dict:
+        docs = await self._collection(name).find({"_generation": generation}).to_list(
+            length=None
+        )
+        return {doc["record_id"]: doc["value"] for doc in docs}
+
+    async def _load_record_ids(self, generation: str, name: str) -> list[str]:
+        docs = await self._collection(name).find({"_generation": generation}).to_list(
+            length=None
+        )
+        return [doc["record_id"] for doc in docs]
+
+    async def _delete_generation(self, generation: str) -> None:
+        for name in ("agents", "tasks", "schedule_states", "runs", "attempts", "cancelled"):
+            await self._collection(name).delete_many({"_generation": generation})

--- a/src/omnicoreagent/background/store/redis.py
+++ b/src/omnicoreagent/background/store/redis.py
@@ -1,0 +1,261 @@
+"""Redis-backed task store for background execution."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import json
+import time
+from typing import TypeVar
+from uuid import uuid4
+
+from omnicoreagent.background.errors import InvalidTaskStoreError, TaskStoreError
+from omnicoreagent.background.store.serialized import SerializedTaskStore
+
+
+T = TypeVar("T")
+
+
+class RedisTaskStore(SerializedTaskStore):
+    """Durable Redis task store using versioned record snapshots."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        prefix: str | None = None,
+        connect_timeout: float | None = None,
+        lock_timeout: float = 30.0,
+        lock_lease_seconds: float = 300.0,
+    ) -> None:
+        super().__init__()
+        self.url = url
+        self.prefix = (prefix or "omnicoreagent:background").rstrip(":")
+        self.connect_timeout = connect_timeout
+        self.lock_timeout = lock_timeout
+        self.lock_lease_seconds = lock_lease_seconds
+        self._client = None
+        self._backend_init_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        await super().initialize()
+        try:
+            from redis.asyncio import Redis
+        except ImportError as exc:  # pragma: no cover - exercised without extra
+            raise InvalidTaskStoreError(
+                "Redis task store requires the redis extra: "
+                "pip install 'omnicoreagent[redis]'"
+            ) from exc
+
+        kwargs = {}
+        if self.connect_timeout is not None:
+            kwargs["socket_connect_timeout"] = self.connect_timeout
+        self._client = Redis.from_url(self.url, decode_responses=True, **kwargs)
+        await self._client.ping()
+        await self._load_backend_state()
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+        await super().close()
+
+    async def _load_backend_state(self) -> None:
+        await self._ensure_initialized()
+        client = self._require_client()
+        generation = await client.get(self._active_generation_key)
+        if not generation:
+            await self._load_snapshot(None)
+            return
+        await self._load_snapshot(
+            {
+                "agents": await self._load_hash(client, generation, "agents"),
+                "tasks": await self._load_hash(client, generation, "tasks"),
+                "schedule_states": await self._load_hash(
+                    client, generation, "schedule_states"
+                ),
+                "runs": await self._load_hash(client, generation, "runs"),
+                "attempts": await self._load_hash(client, generation, "attempts"),
+                "cancel_requested": sorted(
+                    await client.smembers(self._generation_key(generation, "cancelled"))
+                ),
+            }
+        )
+
+    async def _mutate(self, operation: Callable[[], Awaitable[T]]) -> T:
+        await self._ensure_initialized()
+        async with self._operation_lock:
+            token = await self._acquire_lock()
+            try:
+                await self._load_backend_state()
+                result = await operation()
+                await self._persist_backend_state(token)
+                return result
+            finally:
+                await self._release_lock(token)
+
+    async def _read(self, operation: Callable[[], Awaitable[T]]) -> T:
+        await self._ensure_initialized()
+        async with self._operation_lock:
+            token = await self._acquire_lock()
+            try:
+                await self._load_backend_state()
+                return await operation()
+            finally:
+                await self._release_lock(token)
+
+    async def _persist_backend_state(self, token: str) -> None:
+        client = self._require_client()
+        snapshot = await self._snapshot()
+        generation = uuid4().hex
+        previous_generation = await client.get(self._active_generation_key)
+        stale_generation = await client.get(self._previous_generation_key)
+
+        await self._refresh_lock(token)
+        try:
+            for name in ("agents", "tasks", "schedule_states", "runs", "attempts"):
+                key = self._generation_key(generation, name)
+                records = snapshot[name]
+                if records:
+                    await client.hset(
+                        key,
+                        mapping={
+                            record_id: json.dumps(value)
+                            for record_id, value in records.items()
+                        },
+                    )
+            cancelled = snapshot["cancel_requested"]
+            if cancelled:
+                await client.sadd(
+                    self._generation_key(generation, "cancelled"), *cancelled
+                )
+            await self._commit_generation(token, generation, previous_generation)
+        except Exception:
+            await self._delete_generation(generation)
+            raise
+        if stale_generation and stale_generation not in {previous_generation, generation}:
+            await self._delete_generation(stale_generation)
+
+    async def _acquire_lock(self) -> str:
+        client = self._require_client()
+        token = uuid4().hex
+        deadline = time.monotonic() + self.lock_timeout
+        while time.monotonic() < deadline:
+            acquired = await client.set(
+                self._lock_key,
+                token,
+                nx=True,
+                px=self._lock_lease_ms,
+            )
+            if acquired:
+                return token
+            await asyncio.sleep(0.05)
+        raise TaskStoreError("Timed out acquiring Redis task-store lock")
+
+    async def _refresh_lock(self, token: str) -> None:
+        client = self._require_client()
+        refreshed = await client.eval(
+            """
+            if redis.call("GET", KEYS[1]) == ARGV[1] then
+                return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+            end
+            return 0
+            """,
+            1,
+            self._lock_key,
+            token,
+            self._lock_lease_ms,
+        )
+        if not refreshed:
+            raise TaskStoreError("Redis task-store lock expired before commit")
+
+    async def _commit_generation(
+        self, token: str, generation: str, previous_generation: str | None
+    ) -> None:
+        client = self._require_client()
+        committed = await client.eval(
+            """
+            if redis.call("GET", KEYS[1]) == ARGV[1] then
+                redis.call("SET", KEYS[2], ARGV[2])
+                if ARGV[3] ~= "" then
+                    redis.call("SET", KEYS[3], ARGV[3])
+                end
+                return 1
+            end
+            return 0
+            """,
+            3,
+            self._lock_key,
+            self._active_generation_key,
+            self._previous_generation_key,
+            token,
+            generation,
+            previous_generation or "",
+        )
+        if not committed:
+            raise TaskStoreError("Redis task-store lock expired before commit")
+
+    async def _release_lock(self, token: str) -> None:
+        client = self._require_client()
+        await client.eval(
+            """
+            if redis.call("GET", KEYS[1]) == ARGV[1] then
+                return redis.call("DEL", KEYS[1])
+            end
+            return 0
+            """,
+            1,
+            self._lock_key,
+            token,
+        )
+
+    def _require_client(self):
+        if self._client is None:
+            raise TaskStoreError("Redis task store is not initialized")
+        return self._client
+
+    async def _ensure_initialized(self) -> None:
+        if self._client is not None:
+            return
+        async with self._backend_init_lock:
+            if self._client is None:
+                await self.initialize()
+
+    async def _load_hash(self, client, generation: str, name: str) -> dict:
+        raw = await client.hgetall(self._generation_key(generation, name))
+        return {record_id: json.loads(value) for record_id, value in raw.items()}
+
+    def _generation_key(self, generation: str, name: str) -> str:
+        return f"{self.prefix}:generation:{generation}:{name}"
+
+    async def _delete_generation(self, generation: str) -> None:
+        client = self._require_client()
+        await client.delete(
+            *[
+                self._generation_key(generation, name)
+                for name in (
+                    "agents",
+                    "tasks",
+                    "schedule_states",
+                    "runs",
+                    "attempts",
+                    "cancelled",
+                )
+            ]
+        )
+
+    @property
+    def _active_generation_key(self) -> str:
+        return f"{self.prefix}:active_generation"
+
+    @property
+    def _previous_generation_key(self) -> str:
+        return f"{self.prefix}:previous_generation"
+
+    @property
+    def _lock_key(self) -> str:
+        return f"{self.prefix}:lock"
+
+    @property
+    def _lock_lease_ms(self) -> int:
+        return int(self.lock_lease_seconds * 1000)

--- a/src/omnicoreagent/background/store/router.py
+++ b/src/omnicoreagent/background/store/router.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from omnicoreagent.background.errors import InvalidTaskStoreError
 from omnicoreagent.background.models import TaskStoreBackend, TaskStoreConfig
 from omnicoreagent.background.store.base import AbstractTaskStore
 from omnicoreagent.background.store.in_memory import InMemoryTaskStore
+from omnicoreagent.background.store.mongodb import MongoDbTaskStore
+from omnicoreagent.background.store.redis import RedisTaskStore
 from omnicoreagent.background.store.sql import SqlTaskStore
 
 
@@ -26,12 +29,17 @@ class TaskStoreRouter:
         if store_config.backend == TaskStoreBackend.SQL:
             return SqlTaskStore(url=store_config.url)
         if store_config.backend == TaskStoreBackend.REDIS:
-            raise InvalidTaskStoreError(
-                "Redis task store is not implemented yet. Use task_store='sql' or 'in_memory'."
+            return RedisTaskStore(
+                url=store_config.url or "",
+                prefix=store_config.prefix,
+                connect_timeout=store_config.connect_timeout,
             )
         if store_config.backend == TaskStoreBackend.MONGODB:
-            raise InvalidTaskStoreError(
-                "MongoDB task store is not implemented yet. Use task_store='sql' or 'in_memory'."
+            return MongoDbTaskStore(
+                uri=store_config.uri or "",
+                database=store_config.database or "",
+                collection_prefix=store_config.collection_prefix or store_config.prefix,
+                connect_timeout=store_config.connect_timeout,
             )
         raise InvalidTaskStoreError(f"Unsupported task store backend: {store_config.backend}")
 
@@ -39,19 +47,39 @@ class TaskStoreRouter:
     def normalize_config(
         cls, config: str | dict[str, Any] | None = None
     ) -> TaskStoreConfig:
-        if config is None:
-            return TaskStoreConfig(
-                backend=TaskStoreBackend.IN_MEMORY,
-            )
-        if isinstance(config, str):
-            if config not in {
-                TaskStoreBackend.IN_MEMORY.value,
-                TaskStoreBackend.SQL.value,
-            }:
-                raise InvalidTaskStoreError(
-                    "Bare task_store strings are only accepted for 'in_memory' and 'sql'"
+        try:
+            if config is None:
+                return TaskStoreConfig(
+                    backend=TaskStoreBackend.IN_MEMORY,
                 )
-            return TaskStoreConfig(backend=TaskStoreBackend(config))
-        if isinstance(config, dict):
-            return TaskStoreConfig(**config)
+            if isinstance(config, str):
+                if config not in {
+                    TaskStoreBackend.IN_MEMORY.value,
+                    TaskStoreBackend.SQL.value,
+                    TaskStoreBackend.REDIS.value,
+                    TaskStoreBackend.MONGODB.value,
+                }:
+                    raise InvalidTaskStoreError(
+                        "task_store must be 'in_memory', 'sql', 'redis', or 'mongodb'"
+                    )
+                backend = TaskStoreBackend(config)
+                if backend == TaskStoreBackend.REDIS:
+                    return TaskStoreConfig(
+                        backend=backend,
+                        url=os.getenv("REDIS_URL"),
+                    )
+                if backend == TaskStoreBackend.MONGODB:
+                    return TaskStoreConfig(
+                        backend=backend,
+                        uri=os.getenv("MONGODB_URI"),
+                        database=os.getenv(
+                            "OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE",
+                            os.getenv("MONGODB_DATABASE", "omnicoreagent"),
+                        ),
+                    )
+                return TaskStoreConfig(backend=backend)
+            if isinstance(config, dict):
+                return TaskStoreConfig(**config)
+        except ValueError as exc:
+            raise InvalidTaskStoreError(str(exc)) from exc
         raise InvalidTaskStoreError("task_store must be a backend name, config, or store")

--- a/src/omnicoreagent/background/store/serialized.py
+++ b/src/omnicoreagent/background/store/serialized.py
@@ -65,6 +65,13 @@ class SerializedTaskStore(InMemoryTaskStore):
     async def save_schedule_state(self, state: BackgroundScheduleState) -> None:
         await self._mutate(lambda: InMemoryTaskStore.save_schedule_state(self, state))
 
+    async def set_schedule_paused(
+        self, task_id: str, paused: bool
+    ) -> BackgroundScheduleState:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.set_schedule_paused(self, task_id, paused)
+        )
+
     async def get_schedule_state(
         self, task_id: str
     ) -> BackgroundScheduleState | None:

--- a/src/omnicoreagent/background/store/serialized.py
+++ b/src/omnicoreagent/background/store/serialized.py
@@ -1,0 +1,300 @@
+"""Shared serialized task-store wrapper for remote durable backends."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import abstractmethod
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+from omnicoreagent.background.models import (
+    BackgroundAgentSpec,
+    BackgroundAttempt,
+    BackgroundRun,
+    BackgroundScheduleState,
+    BackgroundTaskSpec,
+    OverlapPolicy,
+    RunStatus,
+)
+from omnicoreagent.background.store.in_memory import InMemoryTaskStore
+
+
+T = TypeVar("T")
+
+
+class SerializedTaskStore(InMemoryTaskStore):
+    """Persist in-memory task-store state through backend load/save hooks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._operation_lock = asyncio.Lock()
+
+    async def save_agent(self, spec: BackgroundAgentSpec) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.save_agent(self, spec))
+
+    async def get_agent(self, agent_id: str) -> BackgroundAgentSpec | None:
+        return await self._read(lambda: InMemoryTaskStore.get_agent(self, agent_id))
+
+    async def delete_agent(self, agent_id: str) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.delete_agent(self, agent_id))
+
+    async def list_agents(self) -> list[BackgroundAgentSpec]:
+        return await self._read(lambda: InMemoryTaskStore.list_agents(self))
+
+    async def save_task(self, spec: BackgroundTaskSpec) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.save_task(self, spec))
+
+    async def get_task(self, task_id: str) -> BackgroundTaskSpec | None:
+        return await self._read(lambda: InMemoryTaskStore.get_task(self, task_id))
+
+    async def delete_task(self, task_id: str) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.delete_task(self, task_id))
+
+    async def delete_runs_for_task(self, task_id: str) -> None:
+        await self._mutate(
+            lambda: InMemoryTaskStore.delete_runs_for_task(self, task_id)
+        )
+
+    async def list_tasks(
+        self, agent_id: str | None = None, enabled: bool | None = None
+    ) -> list[BackgroundTaskSpec]:
+        return await self._read(
+            lambda: InMemoryTaskStore.list_tasks(self, agent_id=agent_id, enabled=enabled)
+        )
+
+    async def save_schedule_state(self, state: BackgroundScheduleState) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.save_schedule_state(self, state))
+
+    async def get_schedule_state(
+        self, task_id: str
+    ) -> BackgroundScheduleState | None:
+        return await self._read(
+            lambda: InMemoryTaskStore.get_schedule_state(self, task_id)
+        )
+
+    async def get_due_schedules(self, now, limit: int):
+        return await self._read(
+            lambda: InMemoryTaskStore.get_due_schedules(self, now, limit)
+        )
+
+    async def advance_schedule(
+        self,
+        task_id: str,
+        expected_revision: int,
+        occurrence_id: str,
+        next_due_at,
+    ) -> BackgroundScheduleState:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.advance_schedule(
+                self, task_id, expected_revision, occurrence_id, next_due_at
+            )
+        )
+
+    async def dispatch_scheduled_run(
+        self,
+        run: BackgroundRun,
+        overlap_policy: OverlapPolicy,
+        expected_schedule_revision: int,
+        next_due_at,
+    ) -> BackgroundRun:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.dispatch_scheduled_run(
+                self, run, overlap_policy, expected_schedule_revision, next_due_at
+            )
+        )
+
+    async def create_run_with_overlap_guard(
+        self, run: BackgroundRun, overlap_policy: OverlapPolicy
+    ) -> BackgroundRun:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.create_run_with_overlap_guard(
+                self, run, overlap_policy
+            )
+        )
+
+    async def get_run(self, run_id: str) -> BackgroundRun | None:
+        return await self._read(lambda: InMemoryTaskStore.get_run(self, run_id))
+
+    async def update_run_metadata(
+        self,
+        run_id: str,
+        patch: dict,
+        worker_id: str | None = None,
+        lease_token: str | None = None,
+    ) -> BackgroundRun:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.update_run_metadata(
+                self,
+                run_id,
+                patch,
+                worker_id=worker_id,
+                lease_token=lease_token,
+            )
+        )
+
+    async def transition_run(
+        self,
+        run_id: str,
+        expected: set[RunStatus],
+        next_status: RunStatus,
+        patch: dict | None = None,
+        worker_id: str | None = None,
+        lease_token: str | None = None,
+    ) -> BackgroundRun:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.transition_run(
+                self,
+                run_id,
+                expected,
+                next_status,
+                patch=patch,
+                worker_id=worker_id,
+                lease_token=lease_token,
+            )
+        )
+
+    async def list_runs(
+        self, task_id: str | None = None, status: RunStatus | None = None
+    ) -> list[BackgroundRun]:
+        return await self._read(
+            lambda: InMemoryTaskStore.list_runs(self, task_id=task_id, status=status)
+        )
+
+    async def list_active_runs(self, task_id: str | None = None) -> list[BackgroundRun]:
+        return await self._read(
+            lambda: InMemoryTaskStore.list_active_runs(self, task_id=task_id)
+        )
+
+    async def list_claimable_runs(self, limit: int) -> list[BackgroundRun]:
+        return await self._read(
+            lambda: InMemoryTaskStore.list_claimable_runs(self, limit)
+        )
+
+    async def claim_next_run(
+        self, worker_id: str, lease_seconds: int
+    ) -> BackgroundRun | None:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.claim_next_run(self, worker_id, lease_seconds)
+        )
+
+    async def create_attempt(self, attempt: BackgroundAttempt) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.create_attempt(self, attempt))
+
+    async def update_attempt(
+        self, attempt_id: str, patch: dict, worker_id: str, lease_token: str
+    ) -> BackgroundAttempt:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.update_attempt(
+                self, attempt_id, patch, worker_id, lease_token
+            )
+        )
+
+    async def list_attempts(self, run_id: str) -> list[BackgroundAttempt]:
+        return await self._read(lambda: InMemoryTaskStore.list_attempts(self, run_id))
+
+    async def claim_run(
+        self, run_id: str, worker_id: str, lease_seconds: int
+    ) -> BackgroundRun:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.claim_run(self, run_id, worker_id, lease_seconds)
+        )
+
+    async def steal_expired_run(
+        self, run_id: str, worker_id: str, lease_seconds: int
+    ) -> BackgroundRun:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.steal_expired_run(
+                self, run_id, worker_id, lease_seconds
+            )
+        )
+
+    async def refresh_lease(
+        self, run_id: str, worker_id: str, lease_token: str, lease_seconds: int
+    ) -> None:
+        await self._mutate(
+            lambda: InMemoryTaskStore.refresh_lease(
+                self, run_id, worker_id, lease_token, lease_seconds
+            )
+        )
+
+    async def release_lease(
+        self, run_id: str, worker_id: str, lease_token: str
+    ) -> None:
+        await self._mutate(
+            lambda: InMemoryTaskStore.release_lease(
+                self, run_id, worker_id, lease_token
+            )
+        )
+
+    async def list_expired_leases(self, now) -> list[BackgroundRun]:
+        return await self._read(lambda: InMemoryTaskStore.list_expired_leases(self, now))
+
+    async def request_cancel(self, run_id: str) -> None:
+        await self._mutate(lambda: InMemoryTaskStore.request_cancel(self, run_id))
+
+    async def is_cancel_requested(self, run_id: str) -> bool:
+        return await self._read(
+            lambda: InMemoryTaskStore.is_cancel_requested(self, run_id)
+        )
+
+    async def _read(self, operation: Callable[[], Awaitable[T]]) -> T:
+        async with self._operation_lock:
+            await self._load_backend_state()
+            return await operation()
+
+    @abstractmethod
+    async def _mutate(self, operation: Callable[[], Awaitable[T]]) -> T: ...
+
+    @abstractmethod
+    async def _load_backend_state(self) -> None: ...
+
+    async def _load_snapshot(self, snapshot: dict[str, Any] | None) -> None:
+        snapshot = snapshot or {}
+        async with self._lock:
+            self._agents = {
+                key: BackgroundAgentSpec.model_validate(value)
+                for key, value in snapshot.get("agents", {}).items()
+            }
+            self._tasks = {
+                key: BackgroundTaskSpec.model_validate(value)
+                for key, value in snapshot.get("tasks", {}).items()
+            }
+            self._schedule_states = {
+                key: BackgroundScheduleState.model_validate(value)
+                for key, value in snapshot.get("schedule_states", {}).items()
+            }
+            self._runs = {
+                key: BackgroundRun.model_validate(value)
+                for key, value in snapshot.get("runs", {}).items()
+            }
+            self._attempts = {
+                key: BackgroundAttempt.model_validate(value)
+                for key, value in snapshot.get("attempts", {}).items()
+            }
+            self._cancel_requested = set(snapshot.get("cancel_requested", []))
+
+    async def _snapshot(self) -> dict[str, Any]:
+        async with self._lock:
+            return {
+                "agents": {
+                    key: value.model_dump(mode="json")
+                    for key, value in self._agents.items()
+                },
+                "tasks": {
+                    key: value.model_dump(mode="json")
+                    for key, value in self._tasks.items()
+                },
+                "schedule_states": {
+                    key: value.model_dump(mode="json")
+                    for key, value in self._schedule_states.items()
+                },
+                "runs": {
+                    key: value.model_dump(mode="json")
+                    for key, value in self._runs.items()
+                },
+                "attempts": {
+                    key: value.model_dump(mode="json")
+                    for key, value in self._attempts.items()
+                },
+                "cancel_requested": sorted(self._cancel_requested),
+            }

--- a/src/omnicoreagent/background/store/sql.py
+++ b/src/omnicoreagent/background/store/sql.py
@@ -76,6 +76,13 @@ class SqlTaskStore(InMemoryTaskStore):
     async def save_schedule_state(self, state: BackgroundScheduleState) -> None:
         await self._mutate(lambda: InMemoryTaskStore.save_schedule_state(self, state))
 
+    async def set_schedule_paused(
+        self, task_id: str, paused: bool
+    ) -> BackgroundScheduleState:
+        return await self._mutate(
+            lambda: InMemoryTaskStore.set_schedule_paused(self, task_id, paused)
+        )
+
     async def get_schedule_state(
         self, task_id: str
     ) -> BackgroundScheduleState | None:

--- a/src/omnicoreagent/serve/cli.py
+++ b/src/omnicoreagent/serve/cli.py
@@ -267,9 +267,14 @@ export LLM_API_KEY=your_api_key_here
 
 # Optional background task persistence
 # Background APIs and the worker are enabled by default with in-memory task state.
-# Use SQL when tasks, runs, attempts, leases, and retries must survive restarts.
+# Use SQL, Redis, or MongoDB when task control-plane state must survive restarts.
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE=sql
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE=redis
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=redis://localhost:6379/0
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE=mongodb
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=mongodb://localhost:27017
+# export OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent
 """)
         return
 

--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -27,8 +27,13 @@ Environment Variables (OVERRIDE code values):
     OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW: Time window in seconds (default: 60)
     OMNICOREAGENT_BACKGROUND_ENABLED: Enable background APIs (default: true)
     OMNICOREAGENT_BACKGROUND_AGENT_ID: Agent id used for the served agent (default: default)
-    OMNICOREAGENT_BACKGROUND_TASK_STORE: Task store backend, in_memory or sql (default: in_memory)
-    OMNICOREAGENT_BACKGROUND_TASK_STORE_URL: SQL task store URL
+    OMNICOREAGENT_BACKGROUND_TASK_STORE: Task store backend (default: in_memory)
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_URL: SQL or Redis task-store URL
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_URI: MongoDB task-store URI
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE: MongoDB task-store database
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX: Redis task-store key prefix
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX: MongoDB collection prefix
+    OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT: Backend connect timeout
     OMNICOREAGENT_BACKGROUND_START_WORKER: Start scheduler/worker loop (default: true)
 
 Priority: Environment variables ALWAYS override code values.
@@ -141,7 +146,22 @@ class OmniServeConfig(BaseModel):
         default="in_memory", description="Background task store backend or config"
     )
     background_task_store_url: str | None = Field(
-        default=None, description="SQL task store URL for background execution"
+        default=None, description="SQL or Redis task store URL for background execution"
+    )
+    background_task_store_uri: str | None = Field(
+        default=None, description="MongoDB task store URI for background execution"
+    )
+    background_task_store_database: str | None = Field(
+        default=None, description="MongoDB task store database"
+    )
+    background_task_store_prefix: str | None = Field(
+        default=None, description="Redis task store key prefix"
+    )
+    background_task_store_collection_prefix: str | None = Field(
+        default=None, description="MongoDB task store collection prefix"
+    )
+    background_task_store_connect_timeout: float | None = Field(
+        default=None, description="Task store backend connect timeout"
     )
     background_start_worker: bool = Field(
         default=True,
@@ -219,6 +239,19 @@ class OmniServeConfig(BaseModel):
             self.background_task_store = val
         if (val := _get_env(background_prefix, "TASK_STORE_URL")) is not None:
             self.background_task_store_url = val
+        if (val := _get_env(background_prefix, "TASK_STORE_URI")) is not None:
+            self.background_task_store_uri = val
+        if (val := _get_env(background_prefix, "TASK_STORE_DATABASE")) is not None:
+            self.background_task_store_database = val
+        if (val := _get_env(background_prefix, "TASK_STORE_PREFIX")) is not None:
+            self.background_task_store_prefix = val
+        if (val := _get_env(background_prefix, "TASK_STORE_COLLECTION_PREFIX")) is not None:
+            self.background_task_store_collection_prefix = val
+        if (val := _get_env(background_prefix, "TASK_STORE_CONNECT_TIMEOUT")) is not None:
+            try:
+                self.background_task_store_connect_timeout = float(val)
+            except ValueError:
+                pass
         if (val := _get_env_bool(background_prefix, "START_WORKER")) is not None:
             self.background_start_worker = val
 
@@ -233,6 +266,14 @@ class OmniServeConfig(BaseModel):
         """Return normalized task-store config for BackgroundAgentManager."""
         if isinstance(self.background_task_store, dict):
             return self.background_task_store
+        if self.background_task_store_uri:
+            return {
+                "backend": "mongodb",
+                "uri": self.background_task_store_uri,
+                "database": self.background_task_store_database or "omnicoreagent",
+                "collection_prefix": self.background_task_store_collection_prefix,
+                "connect_timeout": self.background_task_store_connect_timeout,
+            }
         if self.background_task_store_url:
             backend = self.background_task_store or "sql"
             if backend == "in_memory":
@@ -240,5 +281,23 @@ class OmniServeConfig(BaseModel):
             return {
                 "backend": backend,
                 "url": self.background_task_store_url,
+                "prefix": self.background_task_store_prefix,
+                "connect_timeout": self.background_task_store_connect_timeout,
+            }
+        if self.background_task_store == "mongodb":
+            return {
+                "backend": "mongodb",
+                "uri": os.getenv("MONGODB_URI"),
+                "database": self.background_task_store_database or "omnicoreagent",
+                "prefix": self.background_task_store_prefix,
+                "collection_prefix": self.background_task_store_collection_prefix,
+                "connect_timeout": self.background_task_store_connect_timeout,
+            }
+        if self.background_task_store == "redis":
+            return {
+                "backend": "redis",
+                "url": os.getenv("REDIS_URL"),
+                "prefix": self.background_task_store_prefix,
+                "connect_timeout": self.background_task_store_connect_timeout,
             }
         return self.background_task_store

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -13,13 +13,17 @@ from omnicoreagent.background import (
     BackgroundRun,
     BackgroundTaskSpec,
     InMemoryTaskStore,
+    MongoDbTaskStore,
     OverlapPolicy,
+    RedisTaskStore,
     RetryPolicy,
     RunLeaseError,
     RunStatus,
     ScheduleSpec,
     SqlTaskStore,
     TaskNotFoundError,
+    TaskStoreError,
+    TaskStoreRouter,
 )
 from omnicoreagent.background.models import (
     AttemptReason,
@@ -74,6 +78,204 @@ class CountingStore(InMemoryTaskStore):
     async def refresh_lease(self, run_id, worker_id, lease_token, lease_seconds):
         self.refresh_count += 1
         await super().refresh_lease(run_id, worker_id, lease_token, lease_seconds)
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.values = {}
+        self.hashes = {}
+        self.sets = {}
+
+    async def get(self, key):
+        return self.values.get(key)
+
+    async def set(self, key, value, nx=False, px=None):
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    async def hset(self, key, mapping):
+        self.hashes.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+    async def hgetall(self, key):
+        return self.hashes.get(key, {})
+
+    async def sadd(self, key, *values):
+        self.sets.setdefault(key, set()).update(values)
+        return len(values)
+
+    async def smembers(self, key):
+        return self.sets.get(key, set())
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.values.pop(key, None)
+            self.hashes.pop(key, None)
+            self.sets.pop(key, None)
+        return len(keys)
+
+    async def eval(self, script, numkeys, *args):
+        if "PEXPIRE" in script:
+            key, token, _lease_ms = args
+            return 1 if self.values.get(key) == token else 0
+        if "SET" in script and numkeys == 2:
+            lock_key, active_generation_key, token, generation = args
+            if self.values.get(lock_key) == token:
+                self.values[active_generation_key] = generation
+                return 1
+            return 0
+        if "SET" in script and numkeys == 3:
+            (
+                lock_key,
+                active_generation_key,
+                previous_generation_key,
+                token,
+                generation,
+                previous_generation,
+            ) = args
+            if self.values.get(lock_key) == token:
+                self.values[active_generation_key] = generation
+                if previous_generation:
+                    self.values[previous_generation_key] = previous_generation
+                return 1
+            return 0
+        key, token = args
+        if self.values.get(key) == token:
+            self.values.pop(key, None)
+            return 1
+        return 0
+
+
+class FakeMongoUpdateResult:
+    def __init__(self, matched_count=0, upserted_id=None):
+        self.matched_count = matched_count
+        self.upserted_id = upserted_id
+
+
+class FakeMongoCollection:
+    def __init__(self):
+        self.docs = {}
+
+    async def find_one(self, filter):
+        return self.docs.get(filter["_id"])
+
+    async def replace_one(self, filter, document, upsert=False):
+        self.docs[filter["_id"]] = document
+        return FakeMongoUpdateResult(matched_count=1)
+
+    def find(self, filter):
+        class Cursor:
+            def __init__(self, docs):
+                self.docs = docs
+
+            async def to_list(self, length=None):
+                return self.docs
+
+        generation = filter["_generation"]
+        return Cursor(
+            [doc for doc in self.docs.values() if doc.get("_generation") == generation]
+        )
+
+    async def insert_many(self, documents):
+        for document in documents:
+            if document["_id"] in self.docs:
+                raise ValueError(f"duplicate document id: {document['_id']}")
+            self.docs[document["_id"]] = document
+
+    async def delete_many(self, filter):
+        generation = filter["_generation"]
+        to_delete = [
+            doc_id
+            for doc_id, doc in self.docs.items()
+            if doc.get("_generation") == generation
+        ]
+        for doc_id in to_delete:
+            self.docs.pop(doc_id, None)
+        return FakeMongoUpdateResult(matched_count=len(to_delete))
+
+    async def update_one(self, filter, update, upsert=False):
+        doc_id = filter["_id"]
+        doc = self.docs.get(doc_id)
+        if doc is None:
+            if not upsert:
+                return FakeMongoUpdateResult()
+            doc = {"_id": doc_id}
+            doc.update(update.get("$setOnInsert", {}))
+            self.docs[doc_id] = doc
+            return FakeMongoUpdateResult(upserted_id=doc_id)
+
+        if "$or" in filter and not any(
+            self._matches(doc, condition) for condition in filter["$or"]
+        ):
+            return FakeMongoUpdateResult()
+        if "token" in filter and doc.get("token") != filter["token"]:
+            return FakeMongoUpdateResult()
+        doc.update(update.get("$set", {}))
+        self.docs[doc_id] = doc
+        return FakeMongoUpdateResult(matched_count=1)
+
+    def _matches(self, doc, condition):
+        if condition == {"token": None}:
+            return doc.get("token") is None
+        if condition == {"token": {"$exists": False}}:
+            return "token" not in doc
+        if "expires_at" in condition:
+            return doc.get("expires_at") <= condition["expires_at"]["$lte"]
+        if "token" in condition:
+            return doc.get("token") == condition["token"]
+        return False
+
+
+class FakeMongoDb:
+    def __init__(self):
+        self.collections = {}
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, FakeMongoCollection())
+
+    def with_options(self, **kwargs):
+        return self
+
+
+class FakeRedisTaskStore(RedisTaskStore):
+    def __init__(self, client):
+        super().__init__(url="redis://localhost:6379", prefix="lazy")
+        self.client = client
+        self.initialize_count = 0
+        self.close_count = 0
+
+    async def initialize(self):
+        self.initialize_count += 1
+        self._client = self.client
+        await self._load_backend_state()
+
+    async def close(self):
+        self.close_count += 1
+        self._client = None
+
+
+class FakeMongoTaskStore(MongoDbTaskStore):
+    def __init__(self, db):
+        super().__init__(uri="mongodb://localhost:27017", database="test")
+        self.db = db
+        self.initialize_count = 0
+        self.close_count = 0
+
+    async def initialize(self):
+        self.initialize_count += 1
+        self._db = self.db
+        await self._lock_collection.update_one(
+            {"_id": "task_store"},
+            {"$setOnInsert": {"token": None, "expires_at": datetime.now(timezone.utc)}},
+            upsert=True,
+        )
+        await self._load_backend_state()
+
+    async def close(self):
+        self.close_count += 1
+        self._db = None
 
 
 async def wait_for(predicate, timeout=1.0):
@@ -774,6 +976,274 @@ async def test_sql_task_store_claim_is_atomic_across_managers(tmp_path):
 
     assert claimed_a.run_id == run.run_id
     assert claimed_b is None
+
+
+def test_task_store_router_builds_redis_and_mongodb_stores(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/1")
+    monkeypatch.setenv("MONGODB_URI", "mongodb://localhost:27017")
+    monkeypatch.setenv("OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE", "env_tasks")
+
+    redis_store = TaskStoreRouter.create("redis")
+    mongo_store = TaskStoreRouter.create("mongodb")
+
+    assert isinstance(redis_store, RedisTaskStore)
+    assert redis_store.url == "redis://localhost:6379/1"
+    assert isinstance(mongo_store, MongoDbTaskStore)
+    assert mongo_store.uri == "mongodb://localhost:27017"
+    assert mongo_store.database_name == "env_tasks"
+
+
+def test_task_store_router_accepts_explicit_redis_and_mongodb_config():
+    redis_store = TaskStoreRouter.create(
+        {
+            "backend": "redis",
+            "url": "redis://localhost:6379/2",
+            "prefix": "custom:background",
+            "connect_timeout": 1.5,
+        }
+    )
+    mongo_store = TaskStoreRouter.create(
+        {
+            "backend": "mongodb",
+            "uri": "mongodb://localhost:27017",
+            "database": "tasks",
+            "collection_prefix": "custom_tasks",
+            "connect_timeout": 2.0,
+        }
+    )
+
+    assert isinstance(redis_store, RedisTaskStore)
+    assert redis_store.prefix == "custom:background"
+    assert redis_store.connect_timeout == 1.5
+    assert isinstance(mongo_store, MongoDbTaskStore)
+    assert mongo_store.database_name == "tasks"
+    assert mongo_store.collection_prefix == "custom_tasks"
+    assert mongo_store.connect_timeout == 2.0
+
+
+def test_task_store_router_uses_common_prefix_for_mongodb_collections():
+    mongo_store = TaskStoreRouter.create(
+        {
+            "backend": "mongodb",
+            "uri": "mongodb://localhost:27017",
+            "database": "tasks",
+            "prefix": "common_tasks",
+        }
+    )
+
+    assert isinstance(mongo_store, MongoDbTaskStore)
+    assert mongo_store.collection_prefix == "common_tasks"
+
+
+@pytest.mark.asyncio
+async def test_remote_task_stores_lazy_initialize_before_manager_registration():
+    redis_store = FakeRedisTaskStore(FakeRedisClient())
+    redis_manager = BackgroundAgentManager(task_store=redis_store)
+
+    await redis_manager.register_agent("agent", FakeAgent())
+
+    assert redis_store.initialize_count == 1
+    assert (await redis_manager.get_agent("agent")).agent_id == "agent"
+
+    mongo_store = FakeMongoTaskStore(FakeMongoDb())
+    mongo_manager = BackgroundAgentManager(task_store=mongo_store)
+
+    await mongo_manager.register_agent("agent", FakeAgent())
+
+    assert mongo_store.initialize_count == 1
+    assert (await mongo_manager.get_agent("agent")).agent_id == "agent"
+
+
+@pytest.mark.asyncio
+async def test_manager_shutdown_closes_lazy_initialized_task_store():
+    store = FakeRedisTaskStore(FakeRedisClient())
+    manager = BackgroundAgentManager(task_store=store)
+
+    await manager.register_agent("agent", FakeAgent())
+    await manager.shutdown()
+
+    assert store.close_count == 1
+    assert store._client is None
+
+
+@pytest.mark.asyncio
+async def test_redis_task_store_persists_state_through_backend_snapshot():
+    client = FakeRedisClient()
+    first = RedisTaskStore(url="redis://localhost:6379", prefix="test")
+    first._client = client
+    await first.save_agent(agent_spec())
+    await first.save_task(task_spec())
+    run = await first.create_run_with_overlap_guard(
+        BackgroundRun(
+            task_id="task",
+            agent_id="agent",
+            query_snapshot="do work",
+            trigger_type=TriggerType.MANUAL,
+            session_id="background:agent:task",
+            workspace_path="background/agent/task/run",
+        ),
+        OverlapPolicy.SKIP_IF_RUNNING,
+    )
+
+    restored = RedisTaskStore(url="redis://localhost:6379", prefix="test")
+    restored._client = client
+
+    assert (await restored.get_task("task")).task_id == "task"
+    assert (await restored.get_run(run.run_id)).query_snapshot == "do work"
+
+
+@pytest.mark.asyncio
+async def test_redis_task_store_cleans_previous_generation_after_commit():
+    client = FakeRedisClient()
+    store = RedisTaskStore(url="redis://localhost:6379", prefix="test")
+    store._client = client
+
+    await store.save_agent(agent_spec())
+    first_generation = client.values[store._active_generation_key]
+    await store.save_task(task_spec())
+    second_generation = client.values[store._active_generation_key]
+
+    assert second_generation != first_generation
+    assert first_generation in client.values[store._previous_generation_key]
+
+    await store.save_task(task_spec(task_id="task_2"))
+
+    assert all(first_generation not in key for key in client.hashes)
+    assert all(first_generation not in key for key in client.sets)
+
+
+@pytest.mark.asyncio
+async def test_redis_task_store_reads_use_backend_lock():
+    client = FakeRedisClient()
+    store = RedisTaskStore(
+        url="redis://localhost:6379", prefix="test", lock_timeout=0.01
+    )
+    store._client = client
+    client.values[store._lock_key] = "other-worker"
+
+    with pytest.raises(TaskStoreError, match="Timed out acquiring Redis"):
+        await store.get_agent("agent")
+
+
+@pytest.mark.asyncio
+async def test_redis_task_store_rejects_commit_after_lock_loss():
+    client = FakeRedisClient()
+    store = RedisTaskStore(url="redis://localhost:6379", prefix="test")
+    store._client = client
+
+    token = await store._acquire_lock()
+    client.values.pop(store._lock_key)
+
+    with pytest.raises(Exception, match="lock expired before commit"):
+        await store._persist_backend_state(token)
+
+
+@pytest.mark.asyncio
+async def test_mongodb_task_store_persists_state_through_backend_snapshot():
+    db = FakeMongoDb()
+    first = MongoDbTaskStore(uri="mongodb://localhost:27017", database="test")
+    first._db = db
+    await first._lock_collection.update_one(
+        {"_id": "task_store"},
+        {"$setOnInsert": {"token": None, "expires_at": datetime.now(timezone.utc)}},
+        upsert=True,
+    )
+    await first.save_agent(agent_spec())
+    await first.save_task(task_spec())
+    run = await first.create_run_with_overlap_guard(
+        BackgroundRun(
+            task_id="task",
+            agent_id="agent",
+            query_snapshot="do work",
+            trigger_type=TriggerType.MANUAL,
+            session_id="background:agent:task",
+            workspace_path="background/agent/task/run",
+        ),
+        OverlapPolicy.SKIP_IF_RUNNING,
+    )
+
+    restored = MongoDbTaskStore(uri="mongodb://localhost:27017", database="test")
+    restored._db = db
+
+    assert (await restored.get_task("task")).task_id == "task"
+    assert (await restored.get_run(run.run_id)).query_snapshot == "do work"
+
+
+@pytest.mark.asyncio
+async def test_mongodb_task_store_cleans_previous_generation_after_commit():
+    db = FakeMongoDb()
+    store = MongoDbTaskStore(uri="mongodb://localhost:27017", database="test")
+    store._db = db
+    await store._lock_collection.update_one(
+        {"_id": "task_store"},
+        {"$setOnInsert": {"token": None, "expires_at": datetime.now(timezone.utc)}},
+        upsert=True,
+    )
+
+    await store.save_agent(agent_spec())
+    first_generation = db["omnicoreagent_background_locks"].docs["task_store"][
+        "active_generation"
+    ]
+    await store.save_task(task_spec())
+    second_generation = db["omnicoreagent_background_locks"].docs["task_store"][
+        "active_generation"
+    ]
+
+    assert second_generation != first_generation
+    assert (
+        db["omnicoreagent_background_locks"].docs["task_store"]["previous_generation"]
+        == first_generation
+    )
+
+    await store.save_task(task_spec(task_id="task_2"))
+
+    for collection in db.collections.values():
+        assert all(
+            doc.get("_generation") != first_generation
+            for doc in collection.docs.values()
+        )
+
+
+@pytest.mark.asyncio
+async def test_mongodb_task_store_reads_use_backend_lock():
+    db = FakeMongoDb()
+    store = MongoDbTaskStore(
+        uri="mongodb://localhost:27017", database="test", lock_timeout=0.01
+    )
+    store._db = db
+    await store._lock_collection.update_one(
+        {"_id": "task_store"},
+        {
+            "$setOnInsert": {
+                "token": "other-worker",
+                "expires_at": datetime.now(timezone.utc) + timedelta(seconds=60),
+            }
+        },
+        upsert=True,
+    )
+
+    with pytest.raises(TaskStoreError, match="Timed out acquiring MongoDB"):
+        await store.get_agent("agent")
+
+
+@pytest.mark.asyncio
+async def test_mongodb_task_store_rejects_commit_after_lock_loss():
+    db = FakeMongoDb()
+    store = MongoDbTaskStore(uri="mongodb://localhost:27017", database="test")
+    store._db = db
+    await store._lock_collection.update_one(
+        {"_id": "task_store"},
+        {"$setOnInsert": {"token": None, "expires_at": datetime.now(timezone.utc)}},
+        upsert=True,
+    )
+    token = await store._acquire_lock()
+    await store._lock_collection.update_one(
+        {"_id": "task_store", "token": token},
+        {"$set": {"token": None, "expires_at": datetime.now(timezone.utc)}},
+    )
+
+    with pytest.raises(Exception, match="lock expired before commit"):
+        await store._persist_backend_state(token)
 
 
 @pytest.mark.asyncio

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -978,6 +978,30 @@ async def test_sql_task_store_claim_is_atomic_across_managers(tmp_path):
     assert claimed_b is None
 
 
+@pytest.mark.asyncio
+async def test_set_schedule_paused_preserves_latest_schedule_cursor():
+    store = InMemoryTaskStore()
+    await store.save_agent(agent_spec())
+    await store.save_task(task_spec(schedule={"type": "interval", "seconds": 60}))
+    state = await store.get_schedule_state("task")
+    next_due_at = state.next_due_at + timedelta(minutes=5)
+    occurrence_id = build_occurrence_id(
+        ScheduleType.INTERVAL, state.schedule_revision, state.next_due_at
+    )
+
+    await store.advance_schedule(
+        "task",
+        expected_revision=state.schedule_revision,
+        occurrence_id=occurrence_id,
+        next_due_at=next_due_at,
+    )
+    paused = await store.set_schedule_paused("task", True)
+
+    assert paused.paused is True
+    assert paused.next_due_at == next_due_at
+    assert paused.last_due_at == state.next_due_at
+
+
 def test_task_store_router_builds_redis_and_mongodb_stores(monkeypatch):
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/1")
     monkeypatch.setenv("MONGODB_URI", "mongodb://localhost:27017")

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -88,6 +88,11 @@ def test_omniserve_docs_include_all_public_env_vars():
         "OMNICOREAGENT_BACKGROUND_AGENT_ID",
         "OMNICOREAGENT_BACKGROUND_TASK_STORE",
         "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_URI",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT",
         "OMNICOREAGENT_BACKGROUND_START_WORKER",
     }
     docs = {
@@ -100,3 +105,42 @@ def test_omniserve_docs_include_all_public_env_vars():
         text = path.read_text(encoding="utf-8")
         missing = sorted(name for name in expected if name not in text)
         assert not missing, f"{path} is missing OmniServe env vars: {missing}"
+
+
+def test_background_docs_do_not_claim_sql_is_only_durable_store():
+    docs = [
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("docs/how-to-guides/configuration.mdx"),
+        Path("docs/core-concepts/background-agents.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+        Path("cookbook/omniserve/README.mdx"),
+    ]
+    forbidden = [
+        "choose `sql` when",
+        'task_store="sql"` when',
+        "State is restart-persistent when the task store is SQL.",
+    ]
+
+    offenders = []
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        found = [phrase for phrase in forbidden if phrase in text]
+        if found:
+            offenders.append(f"{path}: {', '.join(found)}")
+
+    assert not offenders, (
+        "Background docs must present sql, redis, and mongodb as durable "
+        "task-store choices:\n" + "\n".join(offenders)
+    )
+
+
+def test_background_docs_show_optional_extras_for_remote_task_stores():
+    docs = [
+        Path("docs/core-concepts/background-agents.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert 'omnicoreagent[redis]' in text
+        assert 'omnicoreagent[mongodb]' in text

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -300,6 +300,32 @@ asyncio.run(main())
     }
 
 
+def test_background_import_does_not_load_backend_clients(tmp_path):
+    result = _run_import_probe(
+        tmp_path,
+        """
+import json
+import sys
+
+from omnicoreagent.background import TaskStoreRouter
+
+print(json.dumps({
+    "router": TaskStoreRouter.__name__,
+    "redis_loaded": "redis" in sys.modules or "redis.asyncio" in sys.modules,
+    "motor_loaded": "motor" in sys.modules or "motor.motor_asyncio" in sys.modules,
+    "pymongo_loaded": "pymongo" in sys.modules,
+}))
+""",
+    )
+
+    assert result == {
+        "router": "TaskStoreRouter",
+        "redis_loaded": False,
+        "motor_loaded": False,
+        "pymongo_loaded": False,
+    }
+
+
 def test_core_logging_import_has_no_runtime_side_effects(tmp_path):
     result = _run_import_probe(
         tmp_path,

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -61,7 +61,54 @@ class TestConfiguration:
         assert config.background_task_store_config() == {
             "backend": "sql",
             "url": "sqlite:///custom-background.db",
+            "prefix": None,
+            "connect_timeout": None,
         }
+
+    def test_background_task_store_uri_selects_mongodb(self):
+        config = OmniServeConfig(
+            background_task_store_uri="mongodb://localhost:27017",
+            background_task_store_database="tasks",
+        )
+
+        assert config.background_task_store_config() == {
+            "backend": "mongodb",
+            "uri": "mongodb://localhost:27017",
+            "database": "tasks",
+            "collection_prefix": None,
+            "connect_timeout": None,
+        }
+
+    def test_background_task_store_redis_keeps_tuning_without_url(self):
+        with patch.dict(os.environ, {"REDIS_URL": "redis://localhost:6379/3"}):
+            config = OmniServeConfig(
+                background_task_store="redis",
+                background_task_store_prefix="tasks",
+                background_task_store_connect_timeout=1.25,
+            )
+            assert config.background_task_store_config() == {
+                "backend": "redis",
+                "url": "redis://localhost:6379/3",
+                "prefix": "tasks",
+                "connect_timeout": 1.25,
+            }
+
+    def test_background_task_store_mongodb_keeps_tuning_without_uri(self):
+        with patch.dict(os.environ, {"MONGODB_URI": "mongodb://localhost:27017"}):
+            config = OmniServeConfig(
+                background_task_store="mongodb",
+                background_task_store_database="tasks",
+                background_task_store_collection_prefix="background_tasks",
+                background_task_store_connect_timeout=2.5,
+            )
+            assert config.background_task_store_config() == {
+                "backend": "mongodb",
+                "uri": "mongodb://localhost:27017",
+                "database": "tasks",
+                "prefix": None,
+                "collection_prefix": "background_tasks",
+                "connect_timeout": 2.5,
+            }
 
     def test_env_example_includes_background_settings(self):
         result = CliRunner().invoke(cli, ["config", "--env-example"])
@@ -70,6 +117,8 @@ class TestConfiguration:
         for key in [
             "OMNICOREAGENT_BACKGROUND_TASK_STORE",
             "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL",
+            "OMNICOREAGENT_BACKGROUND_TASK_STORE_URI",
+            "OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE",
         ]:
             assert key in result.output
         assert "export LLM_API_KEY=your_api_key_here" in result.output


### PR DESCRIPTION
## Summary
- add Redis and MongoDB implementations behind the background `AbstractTaskStore` contract
- use lazy backend initialization, backend-locked reads/writes, commit fencing, and versioned record snapshots
- wire router, exports, OmniServe config/env handling, CLI env examples, docs, cookbook, and engineering specs
- add regression coverage for config normalization, import startup, docs claims, lazy initialization, generation cleanup, and lock-loss behavior

## Verification
- `uv run ruff check src/omnicoreagent/background src/omnicoreagent/serve tests/test_background_agent.py tests/test_omniserve_full.py tests/test_docs_claims.py tests/test_import_startup.py`
- `uv run pytest tests/test_background_agent.py tests/test_omniserve_full.py tests/test_docs_claims.py tests/test_import_startup.py -q`
- `uv run pytest tests -q` -> 570 passed

## Review notes
- evaluator agents found and drove fixes for write-loss races, lock-expiry fencing, MongoDB single-document limits, lazy initialization, old generation retention, backend-locked reads, and Redis/Mongo docs setup clarity.