### PR TITLE
Replay background events through EventRouter

### DIFF
--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -107,6 +107,30 @@ await manager.resume_task("hourly_report")
 await manager.delete_task("hourly_report", delete_runs=True)
 ```
 
+## Run Event Replay
+
+Each run emits ordered lifecycle events with a run-local `sequence` number.
+`get_run_events(run_id)` returns the most complete trace it can read from the
+available runtime sources:
+
+- the configured `EventRouter`, when it can replay events
+- the current process cache
+- the run workspace `events.jsonl` mirror, when workspace event mirroring is enabled
+
+If more than one source is available, OmniCoreAgent returns a complete terminal
+trace first. If no source has reached a terminal event yet, it prefers the
+event router, then the process cache, then the workspace mirror. Event-router
+replay is filtered by `run_id`, so multiple runs sharing the same memory
+session do not mix their lifecycle events. Sources with malformed or duplicate
+run-local sequence numbers are ignored during replay selection. A valid source
+uses contiguous integer sequence numbers starting at `1`.
+
+Durable restart replay needs at least one durable event source. Use a
+replay-capable event router backend or keep workspace event mirroring enabled.
+If a process exits with only in-memory events and no workspace mirror, the task
+store still preserves run status, attempts, leases, and results, but old event
+history may not be replayable.
+
 ## OmniServe API
 
 When an agent is served through OmniServe, the server registers that agent with
@@ -158,8 +182,10 @@ The task store is the source of truth for:
 The current runtime includes the tracked run model, in-memory, SQL, Redis, and
 MongoDB task stores, schedule dispatch, manual runs, retries with delay/backoff,
 lease fencing, expired-lease recovery, cancellation, workspace lifecycle files,
-and run event history. State is restart-persistent when the task store is SQL,
-Redis, or MongoDB.
+and run event replay. Task, schedule, run, attempt, lease, retry, and
+cancellation state is restart-persistent when the task store is SQL, Redis, or
+MongoDB. Event history follows the replay rules above and needs either a
+replay-capable event router or the workspace `events.jsonl` mirror.
 
 Redis durable deployments need persistence enabled and a no-eviction policy for
 task-store keys. MongoDB task-store writes use majority write concern.

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -711,20 +711,19 @@ system.
 
 ## Event Model
 
-Background lifecycle events go through `EventRouter`.
+Background lifecycle events are captured in the process cache and, when enabled,
+the run workspace `events.jsonl` mirror. If an `EventRouter` is configured, the
+manager also mirrors those events to the router on a best-effort bounded path.
 
-Required events:
+Current emitted events:
 
 - `background_agent_registered`
 - `background_task_registered`
-- `background_task_scheduled`
 - `background_task_paused`
 - `background_task_resumed`
 - `background_task_deleted`
 - `background_run_queued`
-- `background_run_claimed`
 - `background_run_started`
-- `background_run_heartbeat`
 - `background_run_retrying`
 - `background_run_completed`
 - `background_run_failed`
@@ -734,6 +733,28 @@ Required events:
 - `background_run_recovered`
 
 Events make the run observable. They do not replace the task store.
+
+Run event replay is best-effort across the event router, process cache, and the
+workspace `events.jsonl` mirror. `get_run_events(run_id)` returns the most
+complete terminal trace available; while a run is still active, it prefers the
+event router, then cache, then workspace mirror. Event-router replay is always
+filtered by `run_id` because the same task can intentionally reuse one memory
+session across many runs. Replay reads from the event router are bounded so a
+slow event backend cannot prevent fallback to process cache or workspace mirror.
+Sources with duplicate or malformed run-local sequence numbers are ignored
+during source selection. A valid replay source uses contiguous integer sequence
+numbers starting at `1`.
+
+Event-router appends are also bounded. A slow event backend can delay lifecycle
+emission only up to the append timeout; it must not hold the run lifecycle or
+agent execution indefinitely.
+
+The sequence allocator is run-local. Fresh run events start at sequence `1`
+without scanning historical task events. If a manager restarts and continues an
+existing run, it reconstructs the next sequence from persisted router or
+workspace events when one of those replay sources is available. Without durable
+event replay data, the task store still preserves run state, but sequence
+continuity cannot be reconstructed.
 
 ---
 

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -839,19 +839,16 @@ Use scratchpad files for progress, notes, todos, and resumable work.
 
 ## Event Contract
 
-Required event names:
+Current emitted event names:
 
 ```text
 background_agent_registered
 background_task_registered
-background_task_scheduled
 background_task_paused
 background_task_resumed
 background_task_deleted
 background_run_queued
-background_run_claimed
 background_run_started
-background_run_heartbeat
 background_run_retrying
 background_run_completed
 background_run_failed
@@ -877,17 +874,47 @@ Common payload fields:
 | `workspace_path` | on run events | Run workspace namespace |
 | `worker_id` | on worker events | Supervisor worker id |
 
-Events must be emitted through `EventRouter`.
+Run-scoped events are always captured in the manager process cache. When
+workspace event mirroring is enabled, they are also appended to the run
+workspace `events.jsonl` file. When an `EventRouter` is configured, the manager
+mirrors events to it on a best-effort bounded path.
 
 Every background event includes `run_id` for run-scoped events. Event backends
 that store task-level streams must filter by `run_id` when returning a run
 trace.
 
-`get_run_events(run_id)` reads events from `EventRouter` when the event backend
-supports replay and run filtering. If the event backend cannot replay, the
-manager reads the run workspace `events.jsonl` mirror. Returned events are
-ordered by `sequence`, then `timestamp`. Missing event history returns an empty
-list; it does not change run state.
+`get_run_events(run_id)` is a run-scoped replay helper. It reads the available
+event sources in this order:
+
+1. `EventRouter`, when configured and replay-capable
+2. current process event cache
+3. run workspace `events.jsonl` mirror, when enabled
+
+Selection rules:
+
+- A source is complete when its last event is terminal:
+  `background_run_completed`, `background_run_failed`,
+  `background_run_timeout`, `background_run_cancelled`, or
+  `background_run_skipped`.
+- If one or more complete sources exist, return the longest complete trace.
+- If no complete source exists, prefer `EventRouter`, then process cache, then
+  workspace mirror.
+- Returned events must be ordered by `sequence`, then `timestamp`.
+- Sources with missing, non-positive, malformed, or duplicate run-local
+  `sequence` values are ignored during replay selection. A valid replay source
+  uses contiguous integer sequence numbers starting at `1`.
+- Event-router reads must filter by `run_id` because one background task can run
+  multiple times under the same memory `session_id`.
+- Event-router replay reads are bounded. A slow or unavailable event backend
+  must not block replay from process cache or workspace mirror sources.
+- Event-router appends are bounded. A slow or unavailable event backend can
+  delay lifecycle emission only up to the append timeout; it must not hold task
+  execution indefinitely.
+- Missing event history returns an empty list; it does not change run state.
+
+Durable restart replay requires a replay-capable event backend or the workspace
+`events.jsonl` mirror. The task store remains the source of truth for run state
+even when event replay is unavailable.
 
 ---
 

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -18,6 +18,7 @@ from omnicoreagent.background.errors import (
 )
 from omnicoreagent.background.models import (
     TERMINAL_RUN_STATUSES,
+    TERMINAL_EVENT_NAMES,
     AttemptReason,
     AttemptStatus,
     BackgroundAgentSpec,
@@ -384,13 +385,25 @@ class BackgroundAgentManager:
         }
 
     async def get_run_events(self, run_id: str) -> list[dict[str, Any]]:
-        events = self._events.get(run_id)
-        if events:
-            return list(events)
         run = await self.task_store.get_run(run_id)
         if not run:
             return []
-        return self._read_workspace_events(run.workspace_path)
+        events = self._events.get(run_id)
+        workspace_events = self._read_workspace_events(run.workspace_path)
+        router_events = await self._read_event_router_events(run)
+        candidates = [router_events, list(events or []), workspace_events]
+        complete = [
+            candidate
+            for candidate in candidates
+            if candidate and candidate[-1].get("event") in TERMINAL_EVENT_NAMES
+        ]
+        if complete:
+            return max(complete, key=len)
+        if router_events:
+            return router_events
+        if events:
+            return list(events)
+        return workspace_events
 
     async def get_run_workspace(self, run_id: str) -> dict[str, Any]:
         """Return the durable workspace location and visible files for a run."""
@@ -846,14 +859,64 @@ class BackgroundAgentManager:
                     payload={
                         "agent_id": event.get("agent_id") or "background",
                         "status": event["event"],
+                        "event": event["event"],
                         "timestamp": event["timestamp"],
                         "session_id": event.get("session_id"),
+                        "task_id": event.get("task_id"),
+                        "run_id": event.get("run_id"),
+                        "run_status": event.get("status"),
+                        "attempt": event.get("attempt"),
+                        "sequence": event.get("sequence"),
+                        "workspace_path": event.get("workspace_path"),
+                        "last_run": event.get("run_id"),
+                        "run_count": event.get("sequence"),
+                        "error": event.get("error"),
                     },
                     agent_name=event.get("agent_id") or "background",
                 ),
             )
         except Exception:
             return
+
+    async def _read_event_router_events(self, run: BackgroundRun) -> list[dict[str, Any]]:
+        if self.event_router is None:
+            return []
+        try:
+            router_events = await self.event_router.get_events(session_id=run.session_id)
+        except Exception:
+            return []
+
+        events: list[dict[str, Any]] = []
+        for item in router_events:
+            raw = item.model_dump() if hasattr(item, "model_dump") else dict(item)
+            payload = raw.get("payload", {})
+            if hasattr(payload, "model_dump"):
+                payload = payload.model_dump()
+            if payload.get("run_id") != run.run_id and payload.get("last_run") != run.run_id:
+                continue
+            event = {
+                "event": payload.get("event") or payload.get("status"),
+                "timestamp": payload.get("timestamp") or raw.get("timestamp"),
+                "agent_id": payload.get("agent_id"),
+                "task_id": payload.get("task_id"),
+                "run_id": payload.get("run_id") or payload.get("last_run"),
+                "session_id": payload.get("session_id"),
+                "status": payload.get("run_status"),
+                "attempt": payload.get("attempt"),
+                "sequence": payload.get("sequence") or payload.get("run_count"),
+                "workspace_path": payload.get("workspace_path"),
+            }
+            if payload.get("error"):
+                event["error"] = payload["error"]
+            events.append({key: value for key, value in event.items() if value is not None})
+
+        return sorted(
+            events,
+            key=lambda event: (
+                event.get("sequence", 0),
+                event.get("timestamp", ""),
+            ),
+        )
 
     def _resolve_workspace(self) -> Any | None:
         if self._workspace is not None:

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -18,6 +18,7 @@ from omnicoreagent.background.errors import (
 )
 from omnicoreagent.background.models import (
     TERMINAL_RUN_STATUSES,
+    INITIAL_EVENT_NAMES,
     TERMINAL_EVENT_NAMES,
     AttemptReason,
     AttemptStatus,
@@ -38,6 +39,10 @@ from omnicoreagent.background.models import (
 )
 from omnicoreagent.background.store.base import AbstractTaskStore
 from omnicoreagent.background.store.router import TaskStoreRouter
+
+
+_EVENT_REPLAY_TIMEOUT_SECONDS = 2.0
+_EVENT_APPEND_TIMEOUT_SECONDS = 2.0
 
 
 class BackgroundAgentManager:
@@ -63,6 +68,9 @@ class BackgroundAgentManager:
         self._worker_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
         self._events: dict[str, list[dict[str, Any]]] = {}
+        self._event_sequences: dict[str, int] = {}
+        self._event_replay_timeout_seconds = _EVENT_REPLAY_TIMEOUT_SECONDS
+        self._event_append_timeout_seconds = _EVENT_APPEND_TIMEOUT_SECONDS
         self._workspace = workspace
         self._initialized = False
 
@@ -388,10 +396,14 @@ class BackgroundAgentManager:
         run = await self.task_store.get_run(run_id)
         if not run:
             return []
-        events = self._events.get(run_id)
-        workspace_events = self._read_workspace_events(run.workspace_path)
-        router_events = await self._read_event_router_events(run)
-        candidates = [router_events, list(events or []), workspace_events]
+        events = self._prepare_event_trace(self._events.get(run_id) or [])
+        workspace_events = self._prepare_event_trace(
+            self._read_workspace_events(run.workspace_path)
+        )
+        router_events = self._prepare_event_trace(
+            await self._read_event_router_events(run)
+        )
+        candidates = [router_events, events, workspace_events]
         complete = [
             candidate
             for candidate in candidates
@@ -402,7 +414,7 @@ class BackgroundAgentManager:
         if router_events:
             return router_events
         if events:
-            return list(events)
+            return events
         return workspace_events
 
     async def get_run_workspace(self, run_id: str) -> dict[str, Any]:
@@ -812,10 +824,47 @@ class BackgroundAgentManager:
         }
         if run_id:
             events = self._events.setdefault(run_id, [])
-            event["sequence"] = len(events) + 1
+            event["sequence"] = await self._next_run_event_sequence(
+                run_id, event_name, events
+            )
             events.append(event)
             await self._write_run_event(event)
             await self._append_event_router(event)
+
+    async def _next_run_event_sequence(
+        self, run_id: str, event_name: str, local_events: list[dict[str, Any]]
+    ) -> int:
+        cached = self._event_sequences.get(run_id)
+        if cached is not None:
+            self._event_sequences[run_id] = cached + 1
+            return cached + 1
+        sequences = [
+            int(event["sequence"])
+            for event in local_events
+            if isinstance(event.get("sequence"), int)
+        ]
+        if sequences:
+            next_sequence = max(sequences) + 1
+            self._event_sequences[run_id] = next_sequence
+            return next_sequence
+        if event_name in INITIAL_EVENT_NAMES:
+            self._event_sequences[run_id] = 1
+            return 1
+
+        run = await self.task_store.get_run(run_id)
+        if run:
+            for source in (
+                await self._read_event_router_events(run),
+                self._read_workspace_events(run.workspace_path),
+            ):
+                sequences.extend(
+                    int(event["sequence"])
+                    for event in source
+                    if isinstance(event.get("sequence"), int)
+                )
+        next_sequence = (max(sequences) if sequences else 0) + 1
+        self._event_sequences[run_id] = next_sequence
+        return next_sequence
 
     async def _write_run_snapshot(self, run: BackgroundRun) -> None:
         task = await self.task_store.get_task(run.task_id)
@@ -852,28 +901,31 @@ class BackgroundAgentManager:
         try:
             from omnicoreagent.core.events.base import Event, EventType
 
-            await self.event_router.append(
-                session_id=event.get("session_id") or event.get("run_id"),
-                event=Event(
-                    type=EventType.BACKGROUND_AGENT_STATUS,
-                    payload={
-                        "agent_id": event.get("agent_id") or "background",
-                        "status": event["event"],
-                        "event": event["event"],
-                        "timestamp": event["timestamp"],
-                        "session_id": event.get("session_id"),
-                        "task_id": event.get("task_id"),
-                        "run_id": event.get("run_id"),
-                        "run_status": event.get("status"),
-                        "attempt": event.get("attempt"),
-                        "sequence": event.get("sequence"),
-                        "workspace_path": event.get("workspace_path"),
-                        "last_run": event.get("run_id"),
-                        "run_count": event.get("sequence"),
-                        "error": event.get("error"),
-                    },
-                    agent_name=event.get("agent_id") or "background",
+            await asyncio.wait_for(
+                self.event_router.append(
+                    session_id=event.get("session_id") or event.get("run_id"),
+                    event=Event(
+                        type=EventType.BACKGROUND_AGENT_STATUS,
+                        payload={
+                            "agent_id": event.get("agent_id") or "background",
+                            "status": event["event"],
+                            "event": event["event"],
+                            "timestamp": event["timestamp"],
+                            "session_id": event.get("session_id"),
+                            "task_id": event.get("task_id"),
+                            "run_id": event.get("run_id"),
+                            "run_status": event.get("status"),
+                            "attempt": event.get("attempt"),
+                            "sequence": event.get("sequence"),
+                            "workspace_path": event.get("workspace_path"),
+                            "last_run": event.get("run_id"),
+                            "run_count": event.get("sequence"),
+                            "error": event.get("error"),
+                        },
+                        agent_name=event.get("agent_id") or "background",
+                    ),
                 ),
+                timeout=self._event_append_timeout_seconds,
             )
         except Exception:
             return
@@ -882,7 +934,10 @@ class BackgroundAgentManager:
         if self.event_router is None:
             return []
         try:
-            router_events = await self.event_router.get_events(session_id=run.session_id)
+            router_events = await asyncio.wait_for(
+                self.event_router.get_events(session_id=run.session_id),
+                timeout=self._event_replay_timeout_seconds,
+            )
         except Exception:
             return []
 
@@ -917,6 +972,37 @@ class BackgroundAgentManager:
                 event.get("timestamp", ""),
             ),
         )
+
+    @staticmethod
+    def _prepare_event_trace(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not events:
+            return []
+
+        normalized: list[dict[str, Any]] = []
+        seen_sequences: set[int] = set()
+        for event in events:
+            sequence = event.get("sequence")
+            if isinstance(sequence, bool) or not isinstance(sequence, int):
+                return []
+            if sequence < 1 or sequence in seen_sequences:
+                return []
+            seen_sequences.add(sequence)
+            normalized_event = dict(event)
+            normalized_event["sequence"] = sequence
+            normalized.append(normalized_event)
+
+        normalized = sorted(
+            normalized,
+            key=lambda event: (
+                event.get("sequence", 0),
+                event.get("timestamp", ""),
+            ),
+        )
+        if [event["sequence"] for event in normalized] != list(
+            range(1, len(normalized) + 1)
+        ):
+            return []
+        return normalized
 
     def _resolve_workspace(self) -> Any | None:
         if self._workspace is not None:

--- a/src/omnicoreagent/background/models.py
+++ b/src/omnicoreagent/background/models.py
@@ -103,6 +103,14 @@ TERMINAL_RUN_STATUSES = {
     RunStatus.SKIPPED,
 }
 
+TERMINAL_EVENT_NAMES = {
+    "background_run_completed",
+    "background_run_failed",
+    "background_run_timeout",
+    "background_run_cancelled",
+    "background_run_skipped",
+}
+
 ACTIVE_RUN_STATUSES = {
     RunStatus.QUEUED,
     RunStatus.CLAIMED,

--- a/src/omnicoreagent/background/models.py
+++ b/src/omnicoreagent/background/models.py
@@ -111,6 +111,11 @@ TERMINAL_EVENT_NAMES = {
     "background_run_skipped",
 }
 
+INITIAL_EVENT_NAMES = {
+    "background_run_queued",
+    "background_run_skipped",
+}
+
 ACTIVE_RUN_STATUSES = {
     RunStatus.QUEUED,
     RunStatus.CLAIMED,

--- a/src/omnicoreagent/core/events/base.py
+++ b/src/omnicoreagent/core/events/base.py
@@ -143,6 +143,13 @@ class BackgroundAgentStatusPayload(SerializableRecord):
     run_count: int | None = None
     error_count: int | None = None
     error: str | None = None
+    task_id: str | None = None
+    run_id: str | None = None
+    event: str | None = None
+    run_status: str | None = None
+    attempt: int | None = None
+    sequence: int | None = None
+    workspace_path: str | None = None
 
 
 EventPayload = (

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -294,6 +294,62 @@ class DroppingEventRouter(EventRouter):
         await super().append(session_id, event)
 
 
+class DuplicatingEventRouter(EventRouter):
+    async def get_events(self, session_id):
+        events = await super().get_events(session_id)
+        for index, event in enumerate(events):
+            if getattr(event.payload, "status", None) == "background_run_started":
+                return [*events[: index + 1], event, *events[index + 1 :]]
+        return events
+
+
+class MalformedSequenceEventRouter(EventRouter):
+    async def get_events(self, session_id):
+        events = await super().get_events(session_id)
+        if len(events) >= 3:
+            events[1].payload.sequence = 1.5
+            events[1].payload.run_count = 1.5
+        return events
+
+
+class GappedSequenceEventRouter(EventRouter):
+    async def get_events(self, session_id):
+        events = await super().get_events(session_id)
+        if len(events) >= 3:
+            events[1].payload.sequence = 3
+            events[1].payload.run_count = 3
+            events[2].payload.sequence = 4
+            events[2].payload.run_count = 4
+        return events
+
+
+class HangingEventRouter:
+    async def append(self, session_id, event):
+        return None
+
+    async def get_events(self, session_id):
+        await asyncio.sleep(60)
+        return []
+
+
+class HangingAppendEventRouter:
+    async def append(self, session_id, event):
+        await asyncio.sleep(60)
+
+    async def get_events(self, session_id):
+        return []
+
+
+class CountingEventRouter(EventRouter):
+    def __init__(self):
+        super().__init__()
+        self.get_events_count = 0
+
+    async def get_events(self, session_id):
+        self.get_events_count += 1
+        return await super().get_events(session_id)
+
+
 async def wait_for(predicate, timeout=1.0):
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
@@ -635,6 +691,7 @@ async def test_background_event_router_filters_same_session_runs():
             agent_id="agent",
             query=f"{task_id} work",
             schedule={"type": "manual"},
+            session_policy={"mode": "fixed", "session_id": "shared-session"},
             workspace_policy={"write_events_jsonl": False},
         )
     first = await manager.run_now("first", wait=True)
@@ -693,6 +750,177 @@ async def test_background_event_replay_uses_complete_workspace_over_partial_rout
 
     assert events[-1]["event"] == "background_run_completed"
     assert len(events) > len(await manager._read_event_router_events(run))
+
+
+@pytest.mark.asyncio
+async def test_background_event_replay_ignores_duplicate_sequence_sources(tmp_path):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=DuplicatingEventRouter(),
+        workspace=workspace,
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task", wait=True)
+    manager._events.clear()
+
+    events = await manager.get_run_events(run.run_id)
+
+    assert [(event["event"], event["sequence"]) for event in events] == [
+        ("background_run_queued", 1),
+        ("background_run_started", 2),
+        ("background_run_completed", 3),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "router_cls",
+    [MalformedSequenceEventRouter, GappedSequenceEventRouter],
+)
+async def test_background_event_replay_ignores_invalid_sequence_sources(
+    tmp_path, router_cls
+):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=router_cls(),
+        workspace=workspace,
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task", wait=True)
+    manager._events.clear()
+
+    events = await manager.get_run_events(run.run_id)
+
+    assert [(event["event"], event["sequence"]) for event in events] == [
+        ("background_run_queued", 1),
+        ("background_run_started", 2),
+        ("background_run_completed", 3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_background_event_replay_falls_back_when_router_hangs(tmp_path):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=HangingEventRouter(),
+        workspace=workspace,
+    )
+    manager._event_replay_timeout_seconds = 0.01
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task", wait=True)
+
+    events = await asyncio.wait_for(manager.get_run_events(run.run_id), timeout=0.5)
+
+    assert events[0]["event"] == "background_run_queued"
+    assert events[-1]["event"] == "background_run_completed"
+
+
+@pytest.mark.asyncio
+async def test_background_run_does_not_block_on_hanging_event_append(tmp_path):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=HangingAppendEventRouter(),
+        workspace=workspace,
+    )
+    manager._event_append_timeout_seconds = 0.01
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    run = await asyncio.wait_for(manager.run_now("task", wait=True), timeout=0.5)
+
+    assert run.status == RunStatus.COMPLETED
+    events = await manager.get_run_events(run.run_id)
+    assert events[0]["event"] == "background_run_queued"
+    assert events[-1]["event"] == "background_run_completed"
+
+
+@pytest.mark.asyncio
+async def test_background_initial_event_sequence_does_not_scan_history():
+    event_router = CountingEventRouter()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=event_router,
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        workspace_policy={"write_events_jsonl": False},
+    )
+
+    run = await manager.run_now("task")
+
+    assert event_router.get_events_count == 0
+    assert manager._events[run.run_id][0]["event"] == "background_run_queued"
+    assert manager._events[run.run_id][0]["sequence"] == 1
+
+
+@pytest.mark.asyncio
+async def test_background_event_sequence_continues_after_manager_restart(tmp_path):
+    url = f"sqlite:///{tmp_path / 'background.db'}"
+    workspace = Workspace.from_config(workspace_dir=tmp_path / "workspace").ensure()
+    event_router = EventRouter()
+    first = BackgroundAgentManager(
+        task_store={"backend": "sql", "url": url},
+        event_router=event_router,
+        workspace=workspace,
+    )
+    await first.register_agent("agent", FakeAgent(response="first"))
+    await first.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await first.run_now("task")
+
+    second = BackgroundAgentManager(
+        task_store={"backend": "sql", "url": url},
+        event_router=event_router,
+        workspace=workspace,
+    )
+    await second.register_agent("agent", FakeAgent(response="second"), replace=True)
+    executed = await second._execute_run(run.run_id)
+    completed = await second.get_run(run.run_id)
+
+    assert executed is True
+    assert completed.run_id == run.run_id
+    events = await second.get_run_events(run.run_id)
+
+    assert [(event["event"], event["sequence"]) for event in events] == [
+        ("background_run_queued", 1),
+        ("background_run_started", 2),
+        ("background_run_completed", 3),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from omnicoreagent.core.workspace.manager import Workspace
+from omnicoreagent.core.events.event_router import EventRouter
 from omnicoreagent.background import (
     BackgroundAgentManager,
     BackgroundAgentSpec,
@@ -276,6 +277,21 @@ class FakeMongoTaskStore(MongoDbTaskStore):
     async def close(self):
         self.close_count += 1
         self._db = None
+
+
+class BrokenEventRouter:
+    async def append(self, session_id, event):
+        raise RuntimeError("event backend down")
+
+    async def get_events(self, session_id):
+        raise RuntimeError("event backend down")
+
+
+class DroppingEventRouter(EventRouter):
+    async def append(self, session_id, event):
+        if getattr(event.payload, "status", None) == "background_run_completed":
+            return
+        await super().append(session_id, event)
 
 
 async def wait_for(predicate, timeout=1.0):
@@ -580,6 +596,103 @@ async def test_manager_run_now_executes_agent_and_records_events():
     events = await manager.get_run_events(run.run_id)
     assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
     assert events[-1]["event"] == "background_run_completed"
+
+
+@pytest.mark.asyncio
+async def test_background_run_events_replay_from_event_router():
+    event_router = EventRouter()
+    manager = BackgroundAgentManager(task_store="in_memory", event_router=event_router)
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        workspace_policy={"write_events_jsonl": False},
+    )
+    run = await manager.run_now("task", wait=True)
+    manager._events.clear()
+
+    events = await manager.get_run_events(run.run_id)
+
+    assert events[0]["event"] == "background_run_queued"
+    assert events[-1]["event"] == "background_run_completed"
+    assert events[-1]["run_id"] == run.run_id
+    assert events[-1]["task_id"] == "task"
+    assert events[-1]["status"] == RunStatus.COMPLETED.value
+    assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
+
+
+@pytest.mark.asyncio
+async def test_background_event_router_filters_same_session_runs():
+    event_router = EventRouter()
+    manager = BackgroundAgentManager(task_store="in_memory", event_router=event_router)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    for task_id in ("first", "second"):
+        await manager.register_task(
+            task_id=task_id,
+            agent_id="agent",
+            query=f"{task_id} work",
+            schedule={"type": "manual"},
+            workspace_policy={"write_events_jsonl": False},
+        )
+    first = await manager.run_now("first", wait=True)
+    second = await manager.run_now("second", wait=True)
+    manager._events.clear()
+
+    events = await manager.get_run_events(second.run_id)
+
+    assert {event["run_id"] for event in events} == {second.run_id}
+    assert first.run_id not in {event["run_id"] for event in events}
+
+
+@pytest.mark.asyncio
+async def test_background_event_router_failure_keeps_workspace_replay(tmp_path):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=BrokenEventRouter(),
+        workspace=workspace,
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task", wait=True)
+    manager._events.clear()
+
+    events = await manager.get_run_events(run.run_id)
+
+    assert events[0]["event"] == "background_run_queued"
+    assert events[-1]["event"] == "background_run_completed"
+
+
+@pytest.mark.asyncio
+async def test_background_event_replay_uses_complete_workspace_over_partial_router(tmp_path):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=DroppingEventRouter(),
+        workspace=workspace,
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task", wait=True)
+    manager._events.clear()
+
+    events = await manager.get_run_events(run.run_id)
+
+    assert events[-1]["event"] == "background_run_completed"
+    assert len(events) > len(await manager._read_event_router_events(run))
 
 
 @pytest.mark.asyncio

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,6 +4,7 @@ import pytest
 
 from omnicoreagent.core.events.base import (
     AgentMessagePayload,
+    BackgroundAgentStatusPayload,
     Event,
     EventType,
     FinalAnswerPayload,
@@ -24,6 +25,26 @@ def test_event_payloads_keep_model_dump_compatibility():
     assert payload.model_dump() == {"message": "hello"}
     assert payload.dict() == {"message": "hello"}
     assert payload.json() == '{"message": "hello"}'
+
+
+def test_background_status_payload_keeps_positional_compatibility():
+    payload = BackgroundAgentStatusPayload(
+        "agent",
+        "background_run_completed",
+        "2026-05-12T00:00:00+00:00",
+        "session",
+        "run_1",
+        3,
+        1,
+        "failed",
+    )
+
+    assert payload.last_run == "run_1"
+    assert payload.run_count == 3
+    assert payload.error_count == 1
+    assert payload.error == "failed"
+    assert payload.task_id is None
+    assert payload.run_id is None
 
 
 def test_event_serializes_and_parses_without_pydantic():


### PR DESCRIPTION
## Summary
- store full background run event context in EventRouter payloads
- make `get_run_events()` consider EventRouter, in-memory cache, and workspace JSONL, choosing the most complete terminal trace
- filter EventRouter replay by run id so same-session background runs do not mix
- preserve `BackgroundAgentStatusPayload` positional compatibility by appending new optional fields

## Verification
- `uv run ruff check src/omnicoreagent/background src/omnicoreagent/core/events tests/test_background_agent.py tests/test_events.py`
- `uv run pytest tests/test_background_agent.py tests/test_events.py tests/test_import_startup.py -q`
- `uv run pytest tests -q` -> 576 passed

## Reviewer
- Final evaluator returned no blocking/high findings after checking payload compatibility, EventRouter replay filtering, complete-trace selection, and terminal event coverage.