### PR TITLE
Add background lifecycle events

### DIFF
--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -125,6 +125,10 @@ session do not mix their lifecycle events. Sources with malformed or duplicate
 run-local sequence numbers are ignored during replay selection. A valid source
 uses contiguous integer sequence numbers starting at `1`.
 
+Run-scoped lifecycle events include schedule dispatch, queueing, claiming,
+start, heartbeat, retry, terminal status, and recovery transitions when those
+transitions occur.
+
 Durable restart replay needs at least one durable event source. Use a
 replay-capable event router backend or keep workspace event mirroring enabled.
 If a process exits with only in-memory events and no workspace mirror, the task

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -711,26 +711,25 @@ system.
 
 ## Event Model
 
-Background lifecycle events are captured in the process cache and, when enabled,
-the run workspace `events.jsonl` mirror. If an `EventRouter` is configured, the
-manager also mirrors those events to the router on a best-effort bounded path.
+Run-scoped background lifecycle events are captured in the process cache and,
+when enabled, the run workspace `events.jsonl` mirror. If an `EventRouter` is
+configured, the manager also mirrors those run events to the router on a
+best-effort bounded path.
 
-Current emitted events:
+Current emitted run-scoped events:
 
-- `background_agent_registered`
-- `background_task_registered`
-- `background_task_paused`
-- `background_task_resumed`
-- `background_task_deleted`
+- `background_task_scheduled`
 - `background_run_queued`
+- `background_run_claimed`
 - `background_run_started`
+- `background_run_heartbeat`
 - `background_run_retrying`
 - `background_run_completed`
 - `background_run_failed`
 - `background_run_timeout`
 - `background_run_cancelled`
 - `background_run_skipped`
-- `background_run_recovered`
+- `background_run_recovered` for expired-lease recovery that requeues the run
 
 Events make the run observable. They do not replace the task store.
 

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -687,7 +687,8 @@ Scheduled behavior:
 3. Persist the run with `dispatch_scheduled_run()`, which atomically applies
    overlap policy, deduplicates `occurrence_id`, handles `cancel_previous`,
    and advances schedule state.
-4. Emit `background_run_queued` or `background_run_skipped`.
+4. Emit `background_task_scheduled`.
+5. Emit `background_run_queued` or `background_run_skipped`.
 
 Manual behavior:
 
@@ -779,10 +780,14 @@ For each expired run:
 - close the abandoned running attempt as `failed` with reason
   `lease_expired`.
 - if cancellation requested, mark cancelled with the new lease token.
+- if the run expired after claim but before start, requeue it for the normal
+  claim path with the new lease token released; emit `background_run_recovered`.
 - if attempts remain and retry policy allows recovery, mark retrying and then
-  queued for the normal claim path with the new lease token.
+  queued for the normal claim path with the new lease token; emit
+  `background_run_recovered`.
 - if attempts are exhausted, mark failed with the new lease token.
-- emit `background_run_recovered` when recovery changes state.
+- recovery paths that end in a terminal state emit the corresponding terminal
+  event instead of `background_run_recovered`.
 
 Recovery must use atomic store transitions so multiple supervisors do not
 recover the same run.
@@ -839,16 +844,14 @@ Use scratchpad files for progress, notes, todos, and resumable work.
 
 ## Event Contract
 
-Current emitted event names:
+Current emitted run-scoped event names:
 
 ```text
-background_agent_registered
-background_task_registered
-background_task_paused
-background_task_resumed
-background_task_deleted
+background_task_scheduled
 background_run_queued
+background_run_claimed
 background_run_started
+background_run_heartbeat
 background_run_retrying
 background_run_completed
 background_run_failed

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -240,7 +240,12 @@ class BackgroundAgentManager:
         created = await self.task_store.create_run_with_overlap_guard(
             run, task.overlap_policy
         )
-        await self._emit_run("background_run_queued", created)
+        await self._emit_run(
+            "background_run_skipped"
+            if created.status == RunStatus.SKIPPED
+            else "background_run_queued",
+            created,
+        )
         if wait and created.status == RunStatus.QUEUED:
             while True:
                 latest = await self.task_store.get_run(created.run_id)
@@ -466,6 +471,9 @@ class BackgroundAgentManager:
                 due_at=state.next_due_at,
                 occurrence_id=occurrence_id,
             )
+            existing_run_ids = {
+                item.run_id for item in await self.task_store.list_runs(task.task_id)
+            }
             next_due_at = next_schedule_due(task.schedule, state.next_due_at, utc_now())
             created = await self.task_store.dispatch_scheduled_run(
                 run,
@@ -474,6 +482,9 @@ class BackgroundAgentManager:
                 next_due_at,
             )
             dispatched_any = True
+            if created.run_id in existing_run_ids:
+                continue
+            await self._emit_run("background_task_scheduled", created)
             await self._emit_run(
                 "background_run_skipped"
                 if created.status == RunStatus.SKIPPED
@@ -525,7 +536,7 @@ class BackgroundAgentManager:
             or latest.lease_token is None
         ):
             return
-        await self.task_store.transition_run(
+        released = await self.task_store.transition_run(
             latest.run_id,
             {RunStatus.CLAIMED},
             RunStatus.QUEUED,
@@ -533,6 +544,7 @@ class BackgroundAgentManager:
             self.worker_id,
             latest.lease_token,
         )
+        await self._emit_run("background_run_queued", released)
 
     async def _run_claimed(self, claimed: BackgroundRun) -> None:
         task = await self.task_store.get_task(claimed.task_id)
@@ -564,10 +576,11 @@ class BackgroundAgentManager:
             lease_token=run.lease_token,
         )
         await self.task_store.create_attempt(attempt)
-        await self._emit_run("background_run_started", run)
         heartbeat_task = asyncio.create_task(
             self._heartbeat_until_finished(run.run_id, run.lease_token)
         )
+        await self._emit_run("background_run_claimed", claimed)
+        await self._emit_run("background_run_started", run)
 
         try:
             query = self._build_run_context(run)
@@ -716,6 +729,12 @@ class BackgroundAgentManager:
                 )
             except Exception:
                 return
+            try:
+                latest = await self.task_store.get_run(run_id)
+                if latest and latest.status in {RunStatus.RUNNING, RunStatus.RETRYING}:
+                    await self._emit_run("background_run_heartbeat", latest)
+            except Exception:
+                continue
 
     async def _drain_cancelled_task(self, task: asyncio.Task) -> None:
         try:
@@ -802,18 +821,36 @@ class BackgroundAgentManager:
         self._agents[agent_id] = agent
         return agent
 
-    async def _emit_run(self, event_name: str, run: BackgroundRun) -> None:
-        await self._emit(
-            event_name,
-            agent_id=run.agent_id,
-            task_id=run.task_id,
-            run_id=run.run_id,
-            session_id=run.session_id,
-            status=run.status.value,
-            attempt=run.attempt,
-            workspace_path=run.workspace_path,
-        )
-        await self._write_run_snapshot(run)
+    async def _emit_run(
+        self, event_name: str, run: BackgroundRun, **extra_payload: Any
+    ) -> None:
+        try:
+            await self._emit(
+                event_name,
+                agent_id=run.agent_id,
+                task_id=run.task_id,
+                run_id=run.run_id,
+                session_id=run.session_id,
+                status=run.status.value,
+                attempt=run.attempt,
+                workspace_path=run.workspace_path,
+                worker_id=run.lease_owner,
+                lease_generation=run.lease_generation,
+                heartbeat_at=run.heartbeat_at.isoformat() if run.heartbeat_at else None,
+                lease_expires_at=(
+                    run.lease_expires_at.isoformat() if run.lease_expires_at else None
+                ),
+                occurrence_id=run.occurrence_id,
+                due_at=run.due_at.isoformat() if run.due_at else None,
+                **extra_payload,
+            )
+        except Exception:
+            pass
+        if event_name != "background_run_heartbeat":
+            try:
+                await self._write_run_snapshot(run)
+            except Exception:
+                pass
 
     async def _emit(self, event_name: str, **payload: Any) -> None:
         run_id = payload.get("run_id")
@@ -828,8 +865,21 @@ class BackgroundAgentManager:
                 run_id, event_name, events
             )
             events.append(event)
-            await self._write_run_event(event)
+            if event_name == "background_run_heartbeat":
+                asyncio.create_task(self._write_and_route_event(event))
+                return
+            try:
+                await self._write_run_event(event)
+            except Exception:
+                pass
             await self._append_event_router(event)
+
+    async def _write_and_route_event(self, event: dict[str, Any]) -> None:
+        try:
+            await self._write_run_event(event)
+        except Exception:
+            pass
+        await self._append_event_router(event)
 
     async def _next_run_event_sequence(
         self, run_id: str, event_name: str, local_events: list[dict[str, Any]]
@@ -921,6 +971,12 @@ class BackgroundAgentManager:
                             "last_run": event.get("run_id"),
                             "run_count": event.get("sequence"),
                             "error": event.get("error"),
+                            "worker_id": event.get("worker_id"),
+                            "lease_generation": event.get("lease_generation"),
+                            "heartbeat_at": event.get("heartbeat_at"),
+                            "lease_expires_at": event.get("lease_expires_at"),
+                            "occurrence_id": event.get("occurrence_id"),
+                            "due_at": event.get("due_at"),
                         },
                         agent_name=event.get("agent_id") or "background",
                     ),
@@ -960,6 +1016,12 @@ class BackgroundAgentManager:
                 "attempt": payload.get("attempt"),
                 "sequence": payload.get("sequence") or payload.get("run_count"),
                 "workspace_path": payload.get("workspace_path"),
+                "worker_id": payload.get("worker_id"),
+                "lease_generation": payload.get("lease_generation"),
+                "heartbeat_at": payload.get("heartbeat_at"),
+                "lease_expires_at": payload.get("lease_expires_at"),
+                "occurrence_id": payload.get("occurrence_id"),
+                "due_at": payload.get("due_at"),
             }
             if payload.get("error"):
                 event["error"] = payload["error"]

--- a/src/omnicoreagent/background/models.py
+++ b/src/omnicoreagent/background/models.py
@@ -112,6 +112,7 @@ TERMINAL_EVENT_NAMES = {
 }
 
 INITIAL_EVENT_NAMES = {
+    "background_task_scheduled",
     "background_run_queued",
     "background_run_skipped",
 }

--- a/src/omnicoreagent/core/events/base.py
+++ b/src/omnicoreagent/core/events/base.py
@@ -150,6 +150,12 @@ class BackgroundAgentStatusPayload(SerializableRecord):
     attempt: int | None = None
     sequence: int | None = None
     workspace_path: str | None = None
+    worker_id: str | None = None
+    lease_generation: int | None = None
+    heartbeat_at: str | None = None
+    lease_expires_at: str | None = None
+    occurrence_id: str | None = None
+    due_at: str | None = None
 
 
 EventPayload = (

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -81,6 +81,24 @@ class CountingStore(InMemoryTaskStore):
         await super().refresh_lease(run_id, worker_id, lease_token, lease_seconds)
 
 
+class BrokenWorkspaceFiles:
+    def write_text(self, path, text):
+        raise RuntimeError("workspace write failed")
+
+    def append_text(self, path, text):
+        raise RuntimeError("workspace append failed")
+
+    def read_text(self, path):
+        raise RuntimeError("workspace read failed")
+
+    def list_files(self, path):
+        return []
+
+
+class BrokenWorkspace:
+    files = BrokenWorkspaceFiles()
+
+
 class FakeRedisClient:
     def __init__(self):
         self.values = {}
@@ -335,6 +353,18 @@ class HangingEventRouter:
 class HangingAppendEventRouter:
     async def append(self, session_id, event):
         await asyncio.sleep(60)
+
+    async def get_events(self, session_id):
+        return []
+
+
+class HangingClaimAppendEventRouter:
+    async def append(self, session_id, event):
+        if getattr(event.payload, "status", None) in {
+            "background_run_claimed",
+            "background_run_heartbeat",
+        }:
+            await asyncio.sleep(60)
 
     async def get_events(self, session_id):
         return []
@@ -652,6 +682,7 @@ async def test_manager_run_now_executes_agent_and_records_events():
     events = await manager.get_run_events(run.run_id)
     assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
     assert events[-1]["event"] == "background_run_completed"
+    assert "background_run_claimed" in {event["event"] for event in events}
 
 
 @pytest.mark.asyncio
@@ -774,8 +805,9 @@ async def test_background_event_replay_ignores_duplicate_sequence_sources(tmp_pa
 
     assert [(event["event"], event["sequence"]) for event in events] == [
         ("background_run_queued", 1),
-        ("background_run_started", 2),
-        ("background_run_completed", 3),
+        ("background_run_claimed", 2),
+        ("background_run_started", 3),
+        ("background_run_completed", 4),
     ]
 
 
@@ -807,8 +839,9 @@ async def test_background_event_replay_ignores_invalid_sequence_sources(
 
     assert [(event["event"], event["sequence"]) for event in events] == [
         ("background_run_queued", 1),
-        ("background_run_started", 2),
-        ("background_run_completed", 3),
+        ("background_run_claimed", 2),
+        ("background_run_started", 3),
+        ("background_run_completed", 4),
     ]
 
 
@@ -843,6 +876,7 @@ async def test_background_run_does_not_block_on_hanging_event_append(tmp_path):
         task_store="in_memory",
         event_router=HangingAppendEventRouter(),
         workspace=workspace,
+        lease_seconds=0.1,
     )
     manager._event_append_timeout_seconds = 0.01
     await manager.register_agent("agent", FakeAgent(response="complete"))
@@ -859,6 +893,29 @@ async def test_background_run_does_not_block_on_hanging_event_append(tmp_path):
     events = await manager.get_run_events(run.run_id)
     assert events[0]["event"] == "background_run_queued"
     assert events[-1]["event"] == "background_run_completed"
+
+
+@pytest.mark.asyncio
+async def test_slow_claimed_event_append_does_not_expire_active_lease(tmp_path):
+    workspace = Workspace.from_config(workspace_dir=tmp_path).ensure()
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=HangingClaimAppendEventRouter(),
+        workspace=workspace,
+        lease_seconds=0.1,
+    )
+    manager._event_append_timeout_seconds = 0.2
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    run = await asyncio.wait_for(manager.run_now("task", wait=True), timeout=1.0)
+
+    assert run.status == RunStatus.COMPLETED
 
 
 @pytest.mark.asyncio
@@ -918,8 +975,9 @@ async def test_background_event_sequence_continues_after_manager_restart(tmp_pat
 
     assert [(event["event"], event["sequence"]) for event in events] == [
         ("background_run_queued", 1),
-        ("background_run_started", 2),
-        ("background_run_completed", 3),
+        ("background_run_claimed", 2),
+        ("background_run_started", 3),
+        ("background_run_completed", 4),
     ]
 
 
@@ -1033,6 +1091,149 @@ async def test_manager_dispatches_due_schedule_from_worker_loop():
     assert len(completed) == 1
     assert completed[0].trigger_type == TriggerType.ONCE
     assert agent.calls
+    events = await manager.get_run_events(completed[0].run_id)
+    assert [event["event"] for event in events[:2]] == [
+        "background_task_scheduled",
+        "background_run_queued",
+    ]
+    assert events[0]["occurrence_id"] == completed[0].occurrence_id
+    assert events[0]["due_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_scheduled_dispatch_does_not_duplicate_run_events():
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(task_store=store)
+    await manager.register_agent("agent", FakeAgent(response="scheduled"))
+    due_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="scheduled work",
+        schedule={"type": "once", "run_at": due_at},
+        overlap_policy=OverlapPolicy.ALLOW_PARALLEL,
+    )
+
+    await manager._dispatch_due_schedules()
+    state = await store.get_schedule_state("task")
+    async with store._lock:
+        store._schedule_states["task"] = state.model_copy(
+            update={"next_due_at": due_at},
+            deep=True,
+        )
+    await manager._dispatch_due_schedules()
+    runs = await manager.list_runs(task_id="task")
+    events = await manager.get_run_events(runs[0].run_id)
+
+    assert len(runs) == 1
+    assert [event["event"] for event in events] == [
+        "background_task_scheduled",
+        "background_run_queued",
+    ]
+    assert [event["sequence"] for event in events] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_manual_overlap_skip_emits_skipped_event():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent(response="complete", delay=0.1))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        overlap_policy=OverlapPolicy.SKIP_IF_RUNNING,
+    )
+    first = await manager.run_now("task")
+    second = await manager.run_now("task")
+
+    events = await manager.get_run_events(second.run_id)
+
+    assert first.status == RunStatus.QUEUED
+    assert second.status == RunStatus.SKIPPED
+    assert events[-1]["event"] == "background_run_skipped"
+    assert events[-1]["status"] == RunStatus.SKIPPED.value
+
+
+@pytest.mark.asyncio
+async def test_long_running_background_run_emits_heartbeat_events():
+    manager = BackgroundAgentManager(task_store="in_memory", lease_seconds=1)
+    agent = FakeAgent(response="complete", delay=0.35)
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    run = await manager.run_now("task", wait=True)
+    events = await manager.get_run_events(run.run_id)
+    heartbeats = [
+        event for event in events if event["event"] == "background_run_heartbeat"
+    ]
+
+    assert run.status == RunStatus.COMPLETED
+    assert heartbeats
+    assert all(event["worker_id"] == manager.worker_id for event in heartbeats)
+    assert all(event["heartbeat_at"] for event in heartbeats)
+    assert all(event["lease_expires_at"] for event in heartbeats)
+    assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_visibility_failure_does_not_block_execution():
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        workspace=BrokenWorkspace(),
+    )
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    run = await manager.run_now("task", wait=True)
+    latest = await manager.get_run(run.run_id)
+
+    assert latest.status == RunStatus.COMPLETED
+    assert agent.calls
+    assert [event["event"] for event in manager._events[run.run_id]] == [
+        "background_run_queued",
+        "background_run_claimed",
+        "background_run_started",
+        "background_run_completed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_visibility_failure_does_not_stop_lease_refresh():
+    store = CountingStore()
+    manager = BackgroundAgentManager(
+        task_store=store,
+        workspace=BrokenWorkspace(),
+        lease_seconds=1,
+    )
+    agent = FakeAgent(response="complete", delay=0.35)
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    run = await manager.run_now("task", wait=True)
+
+    assert run.status == RunStatus.COMPLETED
+    assert store.refresh_count >= 1
+    assert any(
+        event["event"] == "background_run_heartbeat"
+        for event in manager._events[run.run_id]
+    )
 
 
 @pytest.mark.asyncio
@@ -1137,6 +1338,10 @@ async def test_execute_one_releases_claim_when_cancelled_before_run_starts():
     assert released.status == RunStatus.QUEUED
     assert released.lease_owner is None
     assert released.lease_token is None
+    assert [event["event"] for event in manager._events[run.run_id]] == [
+        "background_run_queued",
+        "background_run_queued",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add run-scoped scheduled, claimed, and heartbeat lifecycle events
- keep lifecycle visibility isolated from task-store truth and lease refresh paths
- preserve replay correctness for manual skipped runs and duplicate scheduled dispatches
- update background architecture/spec/docs for run-scoped lifecycle event behavior

## Tests
- uv run ruff check src/omnicoreagent/background src/omnicoreagent/core/events tests/test_background_agent.py
- uv run pytest tests/test_background_agent.py -q
- uv run pytest tests/test_events.py tests/test_docs_claims.py tests/test_import_startup.py -q
- uv run pytest tests -q
- uv run pytest tests/test_background_agent.py -k "manual_overlap_skip or duplicate_scheduled_dispatch or slow_claimed_event_append or releases_claim or visibility_failure or heartbeat or recover_expired" -q

Full suite: 589 passed.