### PR TITLE
Harden OmniServe background run contract

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -136,7 +136,7 @@ limiting until you opt in.
 | GET | `/background/tasks` | Yes* | List background tasks |
 | GET | `/background/tasks/{task_id}` | Yes* | Inspect a task |
 | PATCH | `/background/tasks/{task_id}` | Yes* | Patch a task |
-| POST | `/background/tasks/{task_id}/run` | Yes* | Queue a manual run |
+| POST | `/background/tasks/{task_id}/run` | Yes* | Queue or synchronously execute a manual run |
 | POST | `/background/tasks/{task_id}/pause` | Yes* | Pause scheduled dispatch |
 | POST | `/background/tasks/{task_id}/resume` | Yes* | Resume scheduled dispatch |
 | DELETE | `/background/tasks/{task_id}` | Yes* | Delete a task |
@@ -148,6 +148,13 @@ limiting until you opt in.
 | GET | `/background/runs/{run_id}/workspace` | Yes* | Inspect run workspace files |
 
 *Auth required only if `OMNICOREAGENT_SERVE_AUTH_ENABLED=true` or `--auth-token` is set.
+
+`POST /background/tasks/{task_id}/run` accepts `{"wait": true}` when the client
+needs terminal run state in the response. With the worker enabled, OmniServe
+waits on the durable run record. With the worker disabled, OmniServe executes
+the run inline through the background manager execution path. If the run does
+not finish before the configured request timeout, the response is `504` and the
+run can still be inspected through `/background/runs/{run_id}`.
 
 ---
 

--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -153,8 +153,12 @@ limiting until you opt in.
 needs terminal run state in the response. With the worker enabled, OmniServe
 waits on the durable run record. With the worker disabled, OmniServe executes
 the run inline through the background manager execution path. If the run does
-not finish before the configured request timeout, the response is `504` and the
-run can still be inspected through `/background/runs/{run_id}`.
+not finish before the background wait budget, the response is `504`. The wait
+budget is derived from the configured request timeout and leaves a small margin
+for OmniServe to return the structured response before the outer HTTP timeout.
+The `detail` payload includes the `run_id`, latest `status`,
+`wait_timeout_seconds`, and `request_timeout_seconds` so the run can still be
+inspected through `/background/runs/{run_id}`.
 
 ---
 

--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -159,9 +159,12 @@ Use `{"wait": true}` when the HTTP request should wait for terminal run state.
 If the OmniServe worker is running, the API waits for that worker-owned run. If
 the worker is disabled, the API queues the run through the background manager
 and drives that run inline through the same execution contract. If the run does
-not finish before the configured
-request timeout, OmniServe returns `504` and the run remains inspectable through
-the background run endpoints.
+not finish before the background wait budget, OmniServe returns `504` and the
+run remains inspectable through the background run endpoints. The wait budget is
+derived from the configured request timeout and leaves a small margin for
+OmniServe to return the structured response before the outer HTTP timeout. The
+`504` response includes the `run_id`, `task_id`, latest `status`,
+`wait_timeout_seconds`, and `request_timeout_seconds` in `detail`.
 
 The background API includes task creation, task listing, pause, resume, delete,
 manual run, cancellation, run status, attempt history, event replay, and

--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -155,6 +155,14 @@ curl -X POST http://localhost:8000/background/tasks/health_report/run \
   -d '{"wait": false}'
 ```
 
+Use `{"wait": true}` when the HTTP request should wait for terminal run state.
+If the OmniServe worker is running, the API waits for that worker-owned run. If
+the worker is disabled, the API queues the run through the background manager
+and drives that run inline through the same execution contract. If the run does
+not finish before the configured
+request timeout, OmniServe returns `504` and the run remains inspectable through
+the background run endpoints.
+
 The background API includes task creation, task listing, pause, resume, delete,
 manual run, cancellation, run status, attempt history, event replay, and
 workspace inspection.

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -221,7 +221,7 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/background/tasks` | Yes* | List background tasks |
 | `GET` | `/background/tasks/{task_id}` | Yes* | Inspect a background task |
 | `PATCH` | `/background/tasks/{task_id}` | Yes* | Patch a background task |
-| `POST` | `/background/tasks/{task_id}/run` | Yes* | Queue a manual background run |
+| `POST` | `/background/tasks/{task_id}/run` | Yes* | Queue a manual background run, optionally waiting for terminal state |
 | `POST` | `/background/tasks/{task_id}/pause` | Yes* | Pause scheduled dispatch |
 | `POST` | `/background/tasks/{task_id}/resume` | Yes* | Resume scheduled dispatch |
 | `DELETE` | `/background/tasks/{task_id}` | Yes* | Delete a background task |
@@ -278,6 +278,12 @@ curl -X POST http://localhost:8000/background/tasks/daily_report/run \
   -H "Content-Type: application/json" \
   -d '{"wait": false}'
 ```
+
+Set `{"wait": true}` when the response should wait for terminal run state. If
+the run does not finish before the background wait budget, OmniServe returns
+`504` with the `run_id`, latest `status`, `wait_timeout_seconds`, and
+`request_timeout_seconds` in `detail`; use the `run_id` with
+`/background/runs/{run_id}` to inspect the run later.
 
 If auth is enabled with `--auth-token` or
 `OMNICOREAGENT_SERVE_AUTH_ENABLED=true`, add

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -831,8 +831,12 @@ the run finishes before the configured request timeout: when the OmniServe
 worker loop is running, the request waits on the durable run record owned by the
 worker; when the worker loop is disabled, the request calls
 `BackgroundAgentManager.run_now(wait=True, timeout_seconds=...)` and the manager
-drives that run inline so queue ordering and overlap policy still apply. Timeout
-returns `504` without removing the run from the task store.
+drives that run inline so queue ordering and overlap policy still apply. The
+manager receives a background wait budget derived from the configured request
+timeout with a small margin for OmniServe to return the structured response
+before the outer HTTP timeout. Wait timeout returns `504` without removing the
+run from the task store, and the response `detail` includes `run_id`, `task_id`,
+latest `status`, `wait_timeout_seconds`, and `request_timeout_seconds`.
 
 Delete endpoints return `404` for missing agents or tasks. Silent deletes hide
 control-plane mistakes and make production automation harder to debug.

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -825,6 +825,17 @@ GET    /background/runs/{run_id}/workspace
 ```
 
 The HTTP layer calls the same manager API used by Python applications.
+Manual run requests with `wait=false` return the queued or skipped run
+immediately. Manual run requests with `wait=true` return terminal run state if
+the run finishes before the configured request timeout: when the OmniServe
+worker loop is running, the request waits on the durable run record owned by the
+worker; when the worker loop is disabled, the request calls
+`BackgroundAgentManager.run_now(wait=True, timeout_seconds=...)` and the manager
+drives that run inline so queue ordering and overlap policy still apply. Timeout
+returns `504` without removing the run from the task store.
+
+Delete endpoints return `404` for missing agents or tasks. Silent deletes hide
+control-plane mistakes and make production automation harder to debug.
 
 ---
 

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -562,7 +562,8 @@ await manager.start()
 await manager.shutdown()
 await manager.pause_task(task_id: str)
 await manager.resume_task(task_id: str)
-await manager.run_now(task_id: str, query: str | None = None)
+await manager.run_now(task_id: str, query: str | None = None, wait: bool = False, timeout_seconds: float | None = None)
+await manager.run_until_terminal(run_id: str, timeout_seconds: float | None = None)
 await manager.cancel_run(run_id: str)
 await manager.recover_expired_runs()
 ```
@@ -575,8 +576,37 @@ Rules:
   policy.
 - `run_now()` creates a run for any registered enabled task, including manual
   tasks.
+- `run_now(wait=True)` executes a queued manual run through the manager and
+  returns terminal state if the run completes before `timeout_seconds`; if the
+  run cannot be claimed yet or the timeout expires, it returns the latest
+  non-terminal run state.
+- `run_until_terminal()` is the public manager-owned driver for inline
+  execution. HTTP adapters must use it through `run_now(wait=True)` or call it
+  directly after creating a run.
 - `cancel_run()` is idempotent.
 - `recover_expired_runs()` claims expired leases according to recovery policy.
+
+### OmniServe Runtime Contract
+
+OmniServe exposes the manager contract over HTTP. The HTTP layer must not own
+task-store or execution semantics.
+
+Rules:
+
+- `POST /background/tasks/{task_id}/run` with `wait=false` returns the queued
+  or skipped run immediately.
+- `POST /background/tasks/{task_id}/run` with `wait=true` returns terminal run
+  state only if the run finishes before the configured request timeout. If the
+  worker loop is active, OmniServe waits on the durable run record. If the
+  worker loop is disabled, OmniServe calls
+  `BackgroundAgentManager.run_now(wait=True, timeout_seconds=...)`; the manager
+  owns inline execution, queue ordering, and overlap-policy enforcement. Timeout
+  returns `504` and leaves the run inspectable through the run endpoints.
+- deleting a missing background agent returns `404`.
+- deleting a missing background task returns `404`.
+- run event replay responses preserve contiguous event sequence numbers and
+  lifecycle fields such as `worker_id`, `lease_generation`, `heartbeat_at`,
+  `lease_expires_at`, `occurrence_id`, and `due_at`.
 
 ### Inspection Operations
 

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -596,12 +596,16 @@ Rules:
 - `POST /background/tasks/{task_id}/run` with `wait=false` returns the queued
   or skipped run immediately.
 - `POST /background/tasks/{task_id}/run` with `wait=true` returns terminal run
-  state only if the run finishes before the configured request timeout. If the
-  worker loop is active, OmniServe waits on the durable run record. If the
-  worker loop is disabled, OmniServe calls
+  state only if the run finishes before the background wait budget. The wait
+  budget is derived from the configured request timeout with a small margin for
+  returning the structured HTTP response. If the worker loop is active,
+  OmniServe waits on the durable run record. If the worker loop is disabled,
+  OmniServe calls
   `BackgroundAgentManager.run_now(wait=True, timeout_seconds=...)`; the manager
   owns inline execution, queue ordering, and overlap-policy enforcement. Timeout
-  returns `504` and leaves the run inspectable through the run endpoints.
+  returns `504` with `run_id`, `task_id`, latest `status`,
+  `wait_timeout_seconds`, and `request_timeout_seconds` in `detail`, leaving
+  the run inspectable through the run endpoints.
 - deleting a missing background agent returns `404`.
 - deleting a missing background task returns `404`.
 - run event replay responses preserve contiguous event sequence numbers and

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -70,6 +70,7 @@ class BackgroundAgentManager:
         self._events: dict[str, list[dict[str, Any]]] = {}
         self._event_sequences: dict[str, int] = {}
         self._event_router_tasks: set[asyncio.Task] = set()
+        self._inline_execution_tasks: dict[str, asyncio.Task] = {}
         self._event_replay_timeout_seconds = _EVENT_REPLAY_TIMEOUT_SECONDS
         self._event_append_timeout_seconds = _EVENT_APPEND_TIMEOUT_SECONDS
         self._workspace = workspace
@@ -220,6 +221,7 @@ class BackgroundAgentManager:
             except asyncio.CancelledError:
                 pass
             self._worker_task = None
+        await self._cancel_inline_execution_tasks()
         await self._cancel_event_router_tasks()
         await self.task_store.close()
         self._initialized = False
@@ -253,6 +255,11 @@ class BackgroundAgentManager:
             created,
         )
         if wait and created.status == RunStatus.QUEUED:
+            if self._running:
+                return await self.wait_for_run(
+                    created.run_id,
+                    timeout_seconds=timeout_seconds,
+                )
             return await self.run_until_terminal(
                 created.run_id,
                 timeout_seconds=timeout_seconds,
@@ -278,12 +285,32 @@ class BackgroundAgentManager:
             if latest.status in TERMINAL_RUN_STATUSES:
                 return latest
 
-            did_work = False
             if latest.status == RunStatus.QUEUED and self._run_is_due(latest):
-                did_work = await self._execute_run(run_id)
-                if did_work:
+                execution_task = self._get_or_start_inline_execution_task(run_id)
+                if deadline is None:
+                    executed = await execution_task
+                    if not executed:
+                        return await self.task_store.get_run(run_id) or latest
                     continue
-            if not did_work and deadline is None:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    return latest
+                done, _ = await asyncio.wait(
+                    {execution_task},
+                    timeout=remaining,
+                )
+                if done:
+                    executed = execution_task.result()
+                    if not executed:
+                        if deadline is None:
+                            return await self.task_store.get_run(run_id) or latest
+                        latest = await self.task_store.get_run(run_id) or latest
+                    else:
+                        continue
+                else:
+                    return await self.task_store.get_run(run_id) or latest
+
+            if deadline is None:
                 return latest
 
             if deadline is not None and asyncio.get_running_loop().time() >= deadline:
@@ -296,6 +323,30 @@ class BackgroundAgentManager:
                     poll_interval_seconds,
                 )
             )
+
+    def _get_or_start_inline_execution_task(self, run_id: str) -> asyncio.Task:
+        existing = self._inline_execution_tasks.get(run_id)
+        if existing is not None and not existing.done():
+            return existing
+        task = asyncio.create_task(self._execute_run(run_id))
+        self._inline_execution_tasks[run_id] = task
+
+        def _forget(completed: asyncio.Task) -> None:
+            if self._inline_execution_tasks.get(run_id) is completed:
+                self._inline_execution_tasks.pop(run_id, None)
+
+        task.add_done_callback(_forget)
+        return task
+
+    async def _cancel_inline_execution_tasks(self) -> None:
+        pending = [task for task in self._inline_execution_tasks.values() if not task.done()]
+        if not pending:
+            self._inline_execution_tasks.clear()
+            return
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        self._inline_execution_tasks.clear()
 
     async def wait_for_run(
         self,
@@ -358,68 +409,74 @@ class BackgroundAgentManager:
     async def recover_expired_runs(self) -> None:
         expired = await self.task_store.list_expired_leases(utc_now())
         for run in expired:
-            stolen = await self.task_store.steal_expired_run(
-                run.run_id, self.worker_id, self.lease_seconds
+            try:
+                await self._recover_expired_run(run)
+            except RunLeaseError:
+                continue
+
+    async def _recover_expired_run(self, run: BackgroundRun) -> None:
+        stolen = await self.task_store.steal_expired_run(
+            run.run_id, self.worker_id, self.lease_seconds
+        )
+        if await self.task_store.is_cancel_requested(stolen.run_id):
+            await self._mark_terminal(stolen, RunStatus.CANCELLED, "cancelled")
+            return
+
+        attempts = await self.task_store.list_attempts(stolen.run_id)
+        running = [item for item in attempts if item.status == AttemptStatus.RUNNING]
+        for attempt in running:
+            await self.task_store.update_attempt(
+                attempt.attempt_id,
+                {
+                    "status": AttemptStatus.FAILED,
+                    "reason": AttemptReason.LEASE_EXPIRED,
+                    "finished_at": utc_now(),
+                    "error": "lease expired",
+                },
+                self.worker_id,
+                stolen.lease_token,
             )
-            if await self.task_store.is_cancel_requested(stolen.run_id):
-                await self._mark_terminal(stolen, RunStatus.CANCELLED, "cancelled")
-                continue
+        task = await self.task_store.get_task(stolen.task_id)
+        if not task:
+            await self._mark_terminal(stolen, RunStatus.FAILED, "task missing")
+            return
 
-            attempts = await self.task_store.list_attempts(stolen.run_id)
-            running = [item for item in attempts if item.status == AttemptStatus.RUNNING]
-            for attempt in running:
-                await self.task_store.update_attempt(
-                    attempt.attempt_id,
-                    {
-                        "status": AttemptStatus.FAILED,
-                        "reason": AttemptReason.LEASE_EXPIRED,
-                        "finished_at": utc_now(),
-                        "error": "lease expired",
-                    },
-                    self.worker_id,
-                    stolen.lease_token,
-                )
-            task = await self.task_store.get_task(stolen.task_id)
-            if not task:
-                await self._mark_terminal(stolen, RunStatus.FAILED, "task missing")
-                continue
+        if stolen.status == RunStatus.CLAIMED:
+            recovered = await self.task_store.transition_run(
+                stolen.run_id,
+                {RunStatus.CLAIMED},
+                RunStatus.QUEUED,
+                self._release_lease_patch(),
+                self.worker_id,
+                stolen.lease_token,
+            )
+            await self._emit_run("background_run_recovered", recovered)
+            return
 
-            if stolen.status == RunStatus.CLAIMED:
-                recovered = await self.task_store.transition_run(
+        can_retry = stolen.attempt <= task.retry_policy.max_retries
+        if can_retry:
+            retrying = stolen
+            if stolen.status == RunStatus.RUNNING:
+                retrying = await self.task_store.transition_run(
                     stolen.run_id,
-                    {RunStatus.CLAIMED},
-                    RunStatus.QUEUED,
-                    self._release_lease_patch(),
+                    {RunStatus.RUNNING},
+                    RunStatus.RETRYING,
+                    {"error": "lease expired"},
                     self.worker_id,
                     stolen.lease_token,
                 )
-                await self._emit_run("background_run_recovered", recovered)
-                continue
+            recovered = await self.task_store.transition_run(
+                retrying.run_id,
+                {RunStatus.RETRYING},
+                RunStatus.QUEUED,
+                self._release_lease_patch(),
+                self.worker_id,
+                retrying.lease_token,
+            )
+            await self._emit_run("background_run_recovered", recovered)
+            return
 
-            can_retry = stolen.attempt <= task.retry_policy.max_retries
-            if can_retry:
-                retrying = stolen
-                if stolen.status == RunStatus.RUNNING:
-                    retrying = await self.task_store.transition_run(
-                        stolen.run_id,
-                        {RunStatus.RUNNING},
-                        RunStatus.RETRYING,
-                        {"error": "lease expired"},
-                        self.worker_id,
-                        stolen.lease_token,
-                    )
-                recovered = await self.task_store.transition_run(
-                    retrying.run_id,
-                    {RunStatus.RETRYING},
-                    RunStatus.QUEUED,
-                    self._release_lease_patch(),
-                    self.worker_id,
-                    retrying.lease_token,
-                )
-                await self._emit_run("background_run_recovered", recovered)
-                continue
-
-            await self._mark_terminal(stolen, RunStatus.FAILED, "lease expired")
+        await self._mark_terminal(stolen, RunStatus.FAILED, "lease expired")
 
     async def get_run(self, run_id: str) -> BackgroundRun | None:
         return await self.task_store.get_run(run_id)
@@ -683,7 +740,8 @@ class BackgroundAgentManager:
             preview = self._result_preview(result)
             if await self.task_store.is_cancel_requested(run.run_id):
                 if run.lease_token is not None:
-                    await self._refresh_run_lease(run.run_id, run.lease_token)
+                    if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                        return
                 await self.task_store.update_attempt(
                     attempt.attempt_id,
                     {
@@ -697,7 +755,8 @@ class BackgroundAgentManager:
                 await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
                 return
             if run.lease_token is not None:
-                await self._refresh_run_lease(run.run_id, run.lease_token)
+                if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                    return
             await self.task_store.update_attempt(
                 attempt.attempt_id,
                 {"status": AttemptStatus.COMPLETED, "finished_at": utc_now()},
@@ -705,7 +764,8 @@ class BackgroundAgentManager:
                 run.lease_token,
             )
             if run.lease_token is not None:
-                await self._refresh_run_lease(run.run_id, run.lease_token)
+                if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                    return
             completed = await self.task_store.transition_run(
                 run.run_id,
                 {RunStatus.RUNNING},
@@ -729,7 +789,8 @@ class BackgroundAgentManager:
     ) -> None:
         status = AttemptStatus.TIMEOUT if reason == "timeout" else AttemptStatus.FAILED
         if run.lease_token is not None:
-            await self._refresh_run_lease(run.run_id, run.lease_token)
+            if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                return
         await self.task_store.update_attempt(
             attempt.attempt_id,
             {"status": status, "finished_at": utc_now(), "error": str(exc)},
@@ -743,7 +804,8 @@ class BackgroundAgentManager:
         if can_retry:
             retry_delay_seconds = self._retry_delay_seconds(task, run.attempt)
             if run.lease_token is not None:
-                await self._refresh_run_lease(run.run_id, run.lease_token)
+                if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                    return
             await self.task_store.update_attempt(
                 attempt.attempt_id,
                 {"retry_delay_seconds": retry_delay_seconds},
@@ -751,7 +813,8 @@ class BackgroundAgentManager:
                 run.lease_token,
             )
             if run.lease_token is not None:
-                await self._refresh_run_lease(run.run_id, run.lease_token)
+                if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                    return
             retrying = await self.task_store.transition_run(
                 run.run_id,
                 {RunStatus.RUNNING},
@@ -783,7 +846,8 @@ class BackgroundAgentManager:
         if not latest:
             return
         if latest.lease_token is not None:
-            await self._refresh_run_lease(latest.run_id, latest.lease_token)
+            if not await self._refresh_run_lease(latest.run_id, latest.lease_token):
+                return
             latest = await self.task_store.get_run(run.run_id) or latest
         terminal = await self.task_store.transition_run(
             latest.run_id,

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -69,6 +69,7 @@ class BackgroundAgentManager:
         self._stop_event = asyncio.Event()
         self._events: dict[str, list[dict[str, Any]]] = {}
         self._event_sequences: dict[str, int] = {}
+        self._event_router_tasks: set[asyncio.Task] = set()
         self._event_replay_timeout_seconds = _EVENT_REPLAY_TIMEOUT_SECONDS
         self._event_append_timeout_seconds = _EVENT_APPEND_TIMEOUT_SECONDS
         self._workspace = workspace
@@ -219,6 +220,7 @@ class BackgroundAgentManager:
             except asyncio.CancelledError:
                 pass
             self._worker_task = None
+        await self._cancel_event_router_tasks()
         await self.task_store.close()
         self._initialized = False
 
@@ -231,7 +233,11 @@ class BackgroundAgentManager:
         await self._emit("background_task_resumed", task_id=task_id)
 
     async def run_now(
-        self, task_id: str, query: str | None = None, wait: bool = False
+        self,
+        task_id: str,
+        query: str | None = None,
+        wait: bool = False,
+        timeout_seconds: float | None = None,
     ) -> BackgroundRun:
         task = await self.task_store.get_task(task_id)
         if not task or not task.enabled:
@@ -247,18 +253,49 @@ class BackgroundAgentManager:
             created,
         )
         if wait and created.status == RunStatus.QUEUED:
-            while True:
-                latest = await self.task_store.get_run(created.run_id)
-                if latest and latest.status in TERMINAL_RUN_STATUSES:
-                    return latest
-                did_work = (
-                    await self._execute_run(created.run_id)
-                    if latest and latest.status == RunStatus.QUEUED
-                    else False
-                )
-                if not did_work:
-                    return latest or created
+            return await self.run_until_terminal(
+                created.run_id,
+                timeout_seconds=timeout_seconds,
+            )
         return created
+
+    async def run_until_terminal(
+        self,
+        run_id: str,
+        timeout_seconds: float | None = None,
+        poll_interval_seconds: float = 0.05,
+    ) -> BackgroundRun:
+        """Drive a queued run until terminal state or timeout using manager semantics."""
+        deadline = (
+            asyncio.get_running_loop().time() + timeout_seconds
+            if timeout_seconds and timeout_seconds > 0
+            else None
+        )
+        while True:
+            latest = await self.task_store.get_run(run_id)
+            if not latest:
+                raise RunNotFoundError(f"Run not found: {run_id}")
+            if latest.status in TERMINAL_RUN_STATUSES:
+                return latest
+
+            did_work = False
+            if latest.status == RunStatus.QUEUED and self._run_is_due(latest):
+                did_work = await self._execute_run(run_id)
+                if did_work:
+                    continue
+            if not did_work and deadline is None:
+                return latest
+
+            if deadline is not None and asyncio.get_running_loop().time() >= deadline:
+                return latest
+
+            await asyncio.sleep(
+                self._run_until_terminal_sleep_seconds(
+                    latest,
+                    deadline,
+                    poll_interval_seconds,
+                )
+            )
 
     async def wait_for_run(
         self,
@@ -281,6 +318,26 @@ class BackgroundAgentManager:
             if deadline is not None and asyncio.get_running_loop().time() >= deadline:
                 return latest
             await asyncio.sleep(poll_interval_seconds)
+
+    @staticmethod
+    def _run_is_due(run: BackgroundRun) -> bool:
+        return run.queued_at is None or run.queued_at <= utc_now()
+
+    @staticmethod
+    def _run_until_terminal_sleep_seconds(
+        run: BackgroundRun,
+        deadline: float | None,
+        poll_interval_seconds: float,
+    ) -> float:
+        interval = poll_interval_seconds
+        if run.queued_at is not None:
+            delay = (run.queued_at - utc_now()).total_seconds()
+            if delay > 0:
+                interval = min(interval, delay)
+        if deadline is not None:
+            remaining = deadline - asyncio.get_running_loop().time()
+            interval = min(interval, max(remaining, 0))
+        return max(interval, 0.001)
 
     async def cancel_run(self, run_id: str) -> None:
         run = await self.task_store.get_run(run_id)
@@ -401,6 +458,7 @@ class BackgroundAgentManager:
         run = await self.task_store.get_run(run_id)
         if not run:
             return []
+        await self._drain_event_router_tasks(run_id)
         events = self._prepare_event_trace(self._events.get(run_id) or [])
         workspace_events = self._prepare_event_trace(
             self._read_workspace_events(run.workspace_path)
@@ -514,6 +572,9 @@ class BackgroundAgentManager:
             or (latest.queued_at is not None and latest.queued_at > utc_now())
         ):
             return False
+        claimable = await self.task_store.list_claimable_runs(limit=10_000)
+        if latest.run_id not in {run.run_id for run in claimable}:
+            return False
         try:
             claimed = await self.task_store.claim_run(
                 run_id, self.worker_id, self.lease_seconds
@@ -558,6 +619,10 @@ class BackgroundAgentManager:
         if await self.task_store.is_cancel_requested(claimed.run_id):
             await self._mark_terminal(claimed, RunStatus.CANCELLED, "cancelled")
             return
+
+        if claimed.lease_token is not None:
+            await self._refresh_run_lease(claimed.run_id, claimed.lease_token)
+            claimed = await self.task_store.get_run(claimed.run_id) or claimed
 
         attempt_number = claimed.attempt + 1
         run = await self.task_store.transition_run(
@@ -617,6 +682,8 @@ class BackgroundAgentManager:
         try:
             preview = self._result_preview(result)
             if await self.task_store.is_cancel_requested(run.run_id):
+                if run.lease_token is not None:
+                    await self._refresh_run_lease(run.run_id, run.lease_token)
                 await self.task_store.update_attempt(
                     attempt.attempt_id,
                     {
@@ -629,12 +696,16 @@ class BackgroundAgentManager:
                 )
                 await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
                 return
+            if run.lease_token is not None:
+                await self._refresh_run_lease(run.run_id, run.lease_token)
             await self.task_store.update_attempt(
                 attempt.attempt_id,
                 {"status": AttemptStatus.COMPLETED, "finished_at": utc_now()},
                 self.worker_id,
                 run.lease_token,
             )
+            if run.lease_token is not None:
+                await self._refresh_run_lease(run.run_id, run.lease_token)
             completed = await self.task_store.transition_run(
                 run.run_id,
                 {RunStatus.RUNNING},
@@ -657,6 +728,8 @@ class BackgroundAgentManager:
         exc: BaseException,
     ) -> None:
         status = AttemptStatus.TIMEOUT if reason == "timeout" else AttemptStatus.FAILED
+        if run.lease_token is not None:
+            await self._refresh_run_lease(run.run_id, run.lease_token)
         await self.task_store.update_attempt(
             attempt.attempt_id,
             {"status": status, "finished_at": utc_now(), "error": str(exc)},
@@ -669,12 +742,16 @@ class BackgroundAgentManager:
         )
         if can_retry:
             retry_delay_seconds = self._retry_delay_seconds(task, run.attempt)
+            if run.lease_token is not None:
+                await self._refresh_run_lease(run.run_id, run.lease_token)
             await self.task_store.update_attempt(
                 attempt.attempt_id,
                 {"retry_delay_seconds": retry_delay_seconds},
                 self.worker_id,
                 run.lease_token,
             )
+            if run.lease_token is not None:
+                await self._refresh_run_lease(run.run_id, run.lease_token)
             retrying = await self.task_store.transition_run(
                 run.run_id,
                 {RunStatus.RUNNING},
@@ -705,6 +782,9 @@ class BackgroundAgentManager:
         latest = await self.task_store.get_run(run.run_id)
         if not latest:
             return
+        if latest.lease_token is not None:
+            await self._refresh_run_lease(latest.run_id, latest.lease_token)
+            latest = await self.task_store.get_run(run.run_id) or latest
         terminal = await self.task_store.transition_run(
             latest.run_id,
             {latest.status},
@@ -721,13 +801,11 @@ class BackgroundAgentManager:
         if lease_token is None:
             return
         interval = max(0.01, self.lease_seconds / 4)
+        if not await self._refresh_run_lease(run_id, lease_token):
+            return
         while True:
             await asyncio.sleep(interval)
-            try:
-                await self.task_store.refresh_lease(
-                    run_id, self.worker_id, lease_token, self.lease_seconds
-                )
-            except Exception:
+            if not await self._refresh_run_lease(run_id, lease_token):
                 return
             try:
                 latest = await self.task_store.get_run(run_id)
@@ -735,6 +813,15 @@ class BackgroundAgentManager:
                     await self._emit_run("background_run_heartbeat", latest)
             except Exception:
                 continue
+
+    async def _refresh_run_lease(self, run_id: str, lease_token: str) -> bool:
+        try:
+            await self.task_store.refresh_lease(
+                run_id, self.worker_id, lease_token, self.lease_seconds
+            )
+            return True
+        except Exception:
+            return False
 
     async def _drain_cancelled_task(self, task: asyncio.Task) -> None:
         try:
@@ -865,14 +952,17 @@ class BackgroundAgentManager:
                 run_id, event_name, events
             )
             events.append(event)
-            if event_name == "background_run_heartbeat":
-                asyncio.create_task(self._write_and_route_event(event))
+            if event_name in INITIAL_EVENT_NAMES:
+                try:
+                    await self._write_run_event(event)
+                except Exception:
+                    pass
+                if self.event_router is not None:
+                    self._schedule_event_router_task(
+                        self._append_event_router(event), event
+                    )
                 return
-            try:
-                await self._write_run_event(event)
-            except Exception:
-                pass
-            await self._append_event_router(event)
+            self._schedule_event_router_task(self._write_and_route_event(event), event)
 
     async def _write_and_route_event(self, event: dict[str, Any]) -> None:
         try:
@@ -880,6 +970,41 @@ class BackgroundAgentManager:
         except Exception:
             pass
         await self._append_event_router(event)
+
+    def _schedule_event_router_task(
+        self, coroutine, event: dict[str, Any]
+    ) -> None:
+        task = asyncio.create_task(coroutine)
+        task._omnicoreagent_run_id = event.get("run_id")  # type: ignore[attr-defined]
+        self._event_router_tasks.add(task)
+        task.add_done_callback(self._event_router_tasks.discard)
+
+    async def _drain_event_router_tasks(self, run_id: str) -> None:
+        pending = [
+            task
+            for task in self._event_router_tasks
+            if not task.done()
+            and getattr(task, "_omnicoreagent_run_id", None) == run_id
+        ]
+        if not pending:
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=self._event_replay_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            return
+
+    async def _cancel_event_router_tasks(self) -> None:
+        pending = [task for task in self._event_router_tasks if not task.done()]
+        if not pending:
+            self._event_router_tasks.clear()
+            return
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        self._event_router_tasks.clear()
 
     async def _next_run_event_sequence(
         self, run_id: str, event_name: str, local_events: list[dict[str, Any]]

--- a/src/omnicoreagent/background/store/in_memory.py
+++ b/src/omnicoreagent/background/store/in_memory.py
@@ -377,6 +377,9 @@ class InMemoryTaskStore(AbstractTaskStore):
             run = self._require_run(run_id)
             if run.status != RunStatus.QUEUED:
                 raise RunLeaseError(f"Run {run_id} is not queued")
+            claimable_ids = {item.run_id for item in self._claimable_runs_locked()}
+            if run_id not in claimable_ids:
+                raise RunLeaseError(f"Run {run_id} is blocked by overlap policy")
             return _copy_model(self._claim_run_locked(run, worker_id, lease_seconds))
 
     async def steal_expired_run(
@@ -395,7 +398,7 @@ class InMemoryTaskStore(AbstractTaskStore):
     ) -> None:
         async with self._lock:
             run = self._require_run(run_id)
-            self._verify_lease_identity(run, worker_id, lease_token)
+            self._verify_lease(run, worker_id, lease_token)
             self._runs[run_id] = run.model_copy(
                 update={
                     "heartbeat_at": _now(),
@@ -486,7 +489,7 @@ class InMemoryTaskStore(AbstractTaskStore):
             if run.status == RunStatus.QUEUED
             and (run.queued_at is None or run.queued_at <= _now())
         ]
-        queued = self._sorted(queued, "queued_at")
+        queued = sorted(queued, key=self._run_order_key)
         claimable: list[BackgroundRun] = []
         for run in queued:
             task = self._tasks.get(run.task_id)
@@ -498,8 +501,13 @@ class InMemoryTaskStore(AbstractTaskStore):
                     for item in self._runs.values()
                     if item.task_id == run.task_id
                     and item.run_id != run.run_id
-                    and item.status in {RunStatus.CLAIMED, RunStatus.RUNNING, RunStatus.RETRYING}
-                    and (item.queued_at or _now()) <= (run.queued_at or _now())
+                    and item.status in {
+                        RunStatus.QUEUED,
+                        RunStatus.CLAIMED,
+                        RunStatus.RUNNING,
+                        RunStatus.RETRYING,
+                    }
+                    and self._run_order_key(item) < self._run_order_key(run)
                 ]
                 if earlier_active:
                     continue
@@ -589,3 +597,8 @@ class InMemoryTaskStore(AbstractTaskStore):
     @staticmethod
     def _sorted(items, field: str = "created_at"):
         return sorted(items, key=lambda item: getattr(item, field, None) or utc_now())
+
+    @staticmethod
+    def _run_order_key(run: BackgroundRun) -> tuple[datetime, datetime, str]:
+        queued_at = run.queued_at or run.triggered_at
+        return (queued_at, run.triggered_at, run.run_id)

--- a/src/omnicoreagent/background/store/in_memory.py
+++ b/src/omnicoreagent/background/store/in_memory.py
@@ -395,7 +395,7 @@ class InMemoryTaskStore(AbstractTaskStore):
     ) -> None:
         async with self._lock:
             run = self._require_run(run_id)
-            self._verify_lease(run, worker_id, lease_token)
+            self._verify_lease_identity(run, worker_id, lease_token)
             self._runs[run_id] = run.model_copy(
                 update={
                     "heartbeat_at": _now(),
@@ -565,12 +565,18 @@ class InMemoryTaskStore(AbstractTaskStore):
     def _verify_lease(
         self, run: BackgroundRun, worker_id: str | None, lease_token: str | None
     ) -> None:
+        self._verify_lease_identity(run, worker_id, lease_token)
+        if run.lease_expires_at is not None and run.lease_expires_at <= _now():
+            raise RunLeaseError("Run lease has expired")
+
+    @staticmethod
+    def _verify_lease_identity(
+        run: BackgroundRun, worker_id: str | None, lease_token: str | None
+    ) -> None:
         if not worker_id or not lease_token:
             raise RunLeaseError("worker_id and lease_token are required")
         if run.lease_owner != worker_id or run.lease_token != lease_token:
             raise RunLeaseError("Run lease token mismatch")
-        if run.lease_expires_at is not None and run.lease_expires_at <= _now():
-            raise RunLeaseError("Run lease has expired")
 
     @staticmethod
     def _ensure_utc(value: datetime | None) -> datetime | None:

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -82,7 +82,7 @@ class BackgroundTaskPatchRequest(BaseModel):
 
 
 class BackgroundTaskRunRequest(BaseModel):
-    """Queue a manual run for an existing task."""
+    """Queue a manual run, optionally waiting for terminal state."""
 
     query: str | None = Field(
         default=None,
@@ -226,6 +226,33 @@ class BackgroundRunWorkspaceResponse(BaseModel):
     agent_id: str
     workspace_path: str
     files: list[dict[str, Any]]
+
+
+class HttpErrorResponse(BaseModel):
+    """Response shape produced by FastAPI HTTPException."""
+
+    detail: Any = Field(..., description="Error detail")
+
+
+class BackgroundRunTimeoutDetail(BaseModel):
+    """Detail payload for a background run wait timeout."""
+
+    message: str = Field(..., description="Timeout message")
+    run_id: str = Field(..., description="Run that can be inspected later")
+    task_id: str = Field(..., description="Task that created the run")
+    status: str = Field(..., description="Latest run status")
+    wait_timeout_seconds: float | None = Field(
+        None, description="Background run wait budget applied to the request"
+    )
+    request_timeout_seconds: float | None = Field(
+        None, description="Outer HTTP request timeout"
+    )
+
+
+class BackgroundRunTimeoutResponse(BaseModel):
+    """HTTPException response for background run wait timeout."""
+
+    detail: BackgroundRunTimeoutDetail
 
 
 class ErrorResponse(BaseModel):

--- a/src/omnicoreagent/serve/routes/background.py
+++ b/src/omnicoreagent/serve/routes/background.py
@@ -91,7 +91,11 @@ def create_background_router() -> APIRouter:
         "/agents/{agent_id}",
         response_model=BackgroundStatusResponse,
         summary="Delete a background agent spec",
-        responses={409: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={
+            404: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+            503: {"model": ErrorResponse},
+        },
     )
     async def delete_background_agent(
         request: Request,
@@ -99,6 +103,8 @@ def create_background_router() -> APIRouter:
         force: bool = Query(default=False),
     ) -> BackgroundStatusResponse:
         manager = _require_background_manager(request)
+        if not await manager.get_agent(agent_id):
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
         try:
             await manager.unregister_agent(agent_id, force=force)
         except AgentAlreadyRegisteredError as exc:
@@ -185,8 +191,12 @@ def create_background_router() -> APIRouter:
     @router.post(
         "/tasks/{task_id}/run",
         response_model=BackgroundRun,
-        summary="Queue a manual task run",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        summary="Queue or wait for a manual task run",
+        responses={
+            404: {"model": ErrorResponse},
+            503: {"model": ErrorResponse},
+            504: {"description": "Run did not finish before request timeout"},
+        },
     )
     async def run_background_task(
         request: Request, task_id: str, body: BackgroundTaskRunRequest | None = None
@@ -195,6 +205,20 @@ def create_background_router() -> APIRouter:
         config = get_config(request)
         run_request = body or BackgroundTaskRunRequest()
         try:
+            if run_request.wait and not getattr(manager, "_running", False):
+                run = await manager.run_now(
+                    task_id,
+                    query=run_request.query,
+                    wait=True,
+                    timeout_seconds=config.request_timeout,
+                )
+                if run.status not in TERMINAL_RUN_STATUSES:
+                    raise HTTPException(
+                        status_code=504,
+                        detail=f"Background run did not finish within {config.request_timeout} seconds",
+                    )
+                return run
+
             run = await manager.run_now(
                 task_id,
                 query=run_request.query,
@@ -251,7 +275,7 @@ def create_background_router() -> APIRouter:
         "/tasks/{task_id}",
         response_model=BackgroundStatusResponse,
         summary="Delete a background task",
-        responses={503: {"model": ErrorResponse}},
+        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
     )
     async def delete_background_task(
         request: Request,
@@ -259,6 +283,8 @@ def create_background_router() -> APIRouter:
         delete_runs: bool = Query(default=False),
     ) -> BackgroundStatusResponse:
         manager = _require_background_manager(request)
+        if not await manager.get_task(task_id):
+            raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
         await manager.delete_task(task_id, delete_runs=delete_runs)
         return BackgroundStatusResponse(status="deleted")
 

--- a/src/omnicoreagent/serve/routes/background.py
+++ b/src/omnicoreagent/serve/routes/background.py
@@ -19,6 +19,7 @@ from ..models import (
     BackgroundAgentRegistrationRequest,
     BackgroundAgentsResponse,
     BackgroundRunEventsResponse,
+    BackgroundRunTimeoutResponse,
     BackgroundRunWorkspaceResponse,
     BackgroundRunsResponse,
     BackgroundStatusResponse,
@@ -26,9 +27,12 @@ from ..models import (
     BackgroundTaskPatchRequest,
     BackgroundTaskRunRequest,
     BackgroundTasksResponse,
-    ErrorResponse,
+    HttpErrorResponse,
 )
 from ..state import get_agent, get_background_manager, get_config
+
+
+_HTTP_ERROR = {"model": HttpErrorResponse}
 
 
 def create_background_router() -> APIRouter:
@@ -39,7 +43,7 @@ def create_background_router() -> APIRouter:
         "/agents",
         response_model=BackgroundAgentSpec,
         summary="Register a background agent",
-        responses={409: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={409: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def register_background_agent(
         request: Request, body: BackgroundAgentRegistrationRequest
@@ -78,7 +82,7 @@ def create_background_router() -> APIRouter:
         "/agents/{agent_id}",
         response_model=BackgroundAgentSpec,
         summary="Get a background agent spec",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def get_background_agent(request: Request, agent_id: str) -> BackgroundAgentSpec:
         manager = _require_background_manager(request)
@@ -92,9 +96,9 @@ def create_background_router() -> APIRouter:
         response_model=BackgroundStatusResponse,
         summary="Delete a background agent spec",
         responses={
-            404: {"model": ErrorResponse},
-            409: {"model": ErrorResponse},
-            503: {"model": ErrorResponse},
+            404: _HTTP_ERROR,
+            409: _HTTP_ERROR,
+            503: _HTTP_ERROR,
         },
     )
     async def delete_background_agent(
@@ -116,9 +120,9 @@ def create_background_router() -> APIRouter:
         response_model=BackgroundTaskSpec,
         summary="Create a background task",
         responses={
-            404: {"model": ErrorResponse},
-            409: {"model": ErrorResponse},
-            503: {"model": ErrorResponse},
+            404: _HTTP_ERROR,
+            409: _HTTP_ERROR,
+            503: _HTTP_ERROR,
         },
     )
     async def create_background_task(
@@ -163,7 +167,7 @@ def create_background_router() -> APIRouter:
         "/tasks/{task_id}",
         response_model=BackgroundTaskSpec,
         summary="Get a background task",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def get_background_task(request: Request, task_id: str) -> BackgroundTaskSpec:
         manager = _require_background_manager(request)
@@ -176,7 +180,7 @@ def create_background_router() -> APIRouter:
         "/tasks/{task_id}",
         response_model=BackgroundTaskSpec,
         summary="Patch a background task",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def patch_background_task(
         request: Request, task_id: str, body: BackgroundTaskPatchRequest
@@ -193,9 +197,12 @@ def create_background_router() -> APIRouter:
         response_model=BackgroundRun,
         summary="Queue or wait for a manual task run",
         responses={
-            404: {"model": ErrorResponse},
-            503: {"model": ErrorResponse},
-            504: {"description": "Run did not finish before request timeout"},
+            404: _HTTP_ERROR,
+            503: _HTTP_ERROR,
+            504: {
+                "model": BackgroundRunTimeoutResponse,
+                "description": "Run did not finish before request timeout",
+            },
         },
     )
     async def run_background_task(
@@ -204,38 +211,21 @@ def create_background_router() -> APIRouter:
         manager = _require_background_manager(request)
         config = get_config(request)
         run_request = body or BackgroundTaskRunRequest()
+        wait_timeout = _background_wait_timeout(config.request_timeout)
         try:
-            if run_request.wait and not getattr(manager, "_running", False):
-                run = await manager.run_now(
-                    task_id,
-                    query=run_request.query,
-                    wait=True,
-                    timeout_seconds=config.request_timeout,
-                )
-                if run.status not in TERMINAL_RUN_STATUSES:
-                    raise HTTPException(
-                        status_code=504,
-                        detail=f"Background run did not finish within {config.request_timeout} seconds",
-                    )
-                return run
-
             run = await manager.run_now(
                 task_id,
                 query=run_request.query,
-                wait=False,
+                wait=run_request.wait,
+                timeout_seconds=wait_timeout if run_request.wait else None,
             )
             if not run_request.wait:
                 return run
-            latest = await manager.wait_for_run(
-                run.run_id,
-                timeout_seconds=config.request_timeout,
-            )
-            if latest.status not in TERMINAL_RUN_STATUSES:
-                raise HTTPException(
-                    status_code=504,
-                    detail=f"Background run did not finish within {config.request_timeout} seconds",
-                )
-            return latest
+            if run.status not in TERMINAL_RUN_STATUSES:
+                if wait_timeout is None:
+                    return run
+                _raise_run_timeout(run, wait_timeout, config.request_timeout)
+            return run
         except TaskNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -243,7 +233,7 @@ def create_background_router() -> APIRouter:
         "/tasks/{task_id}/pause",
         response_model=BackgroundStatusResponse,
         summary="Pause scheduled dispatch for a task",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def pause_background_task(
         request: Request, task_id: str
@@ -259,7 +249,7 @@ def create_background_router() -> APIRouter:
         "/tasks/{task_id}/resume",
         response_model=BackgroundStatusResponse,
         summary="Resume scheduled dispatch for a task",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def resume_background_task(
         request: Request, task_id: str
@@ -275,7 +265,7 @@ def create_background_router() -> APIRouter:
         "/tasks/{task_id}",
         response_model=BackgroundStatusResponse,
         summary="Delete a background task",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def delete_background_task(
         request: Request,
@@ -292,7 +282,7 @@ def create_background_router() -> APIRouter:
         "/runs/{run_id}/cancel",
         response_model=BackgroundStatusResponse,
         summary="Cancel a queued or running background run",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def cancel_background_run(
         request: Request, run_id: str
@@ -308,7 +298,7 @@ def create_background_router() -> APIRouter:
         "/runs",
         response_model=BackgroundRunsResponse,
         summary="List background runs",
-        responses={503: {"model": ErrorResponse}},
+        responses={503: _HTTP_ERROR},
     )
     async def list_background_runs(
         request: Request,
@@ -326,7 +316,7 @@ def create_background_router() -> APIRouter:
         "/runs/{run_id}",
         response_model=BackgroundRun,
         summary="Get background run status",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def get_background_run(request: Request, run_id: str) -> BackgroundRun:
         manager = _require_background_manager(request)
@@ -339,7 +329,7 @@ def create_background_router() -> APIRouter:
         "/runs/{run_id}/attempts",
         response_model=list[BackgroundAttempt],
         summary="List background run attempts",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def list_background_run_attempts(request: Request, run_id: str):
         manager = _require_background_manager(request)
@@ -350,7 +340,7 @@ def create_background_router() -> APIRouter:
         "/runs/{run_id}/events",
         response_model=BackgroundRunEventsResponse,
         summary="Replay background run lifecycle events",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def list_background_run_events(
         request: Request, run_id: str
@@ -368,7 +358,7 @@ def create_background_router() -> APIRouter:
         "/runs/{run_id}/workspace",
         response_model=BackgroundRunWorkspaceResponse,
         summary="Inspect background run workspace files",
-        responses={404: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
     )
     async def get_background_run_workspace(
         request: Request, run_id: str
@@ -394,3 +384,30 @@ async def _require_run(manager, run_id: str) -> BackgroundRun:
     if not run:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
     return run
+
+
+def _raise_run_timeout(
+    run: BackgroundRun,
+    wait_timeout_seconds: float | None,
+    request_timeout_seconds: float | None,
+) -> None:
+    raise HTTPException(
+        status_code=504,
+        detail={
+            "message": (
+                "Background run did not finish within "
+                f"{wait_timeout_seconds} seconds"
+            ),
+            "run_id": run.run_id,
+            "task_id": run.task_id,
+            "status": run.status.value,
+            "wait_timeout_seconds": wait_timeout_seconds,
+            "request_timeout_seconds": request_timeout_seconds,
+        },
+    )
+
+
+def _background_wait_timeout(request_timeout: float | None) -> float | None:
+    if request_timeout is None or request_timeout <= 0:
+        return None
+    return max(request_timeout - 0.25, 0.001)

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -1009,6 +1009,27 @@ async def test_manager_run_now_wait_executes_only_created_run():
 
 
 @pytest.mark.asyncio
+async def test_manager_run_now_wait_respects_queue_next_active_run():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        overlap_policy=OverlapPolicy.QUEUE_NEXT,
+    )
+    first = await manager.run_now("task")
+    await manager.task_store.claim_run(first.run_id, "other_worker", 30)
+
+    second = await manager.run_now("task", wait=True)
+
+    assert second.status == RunStatus.QUEUED
+    assert agent.calls == []
+
+
+@pytest.mark.asyncio
 async def test_manager_run_now_missing_or_disabled_task_raises():
     manager = BackgroundAgentManager(task_store="in_memory")
     await manager.register_agent("agent", FakeAgent())

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import inspect
 import json
+import time
 
 import pytest
 
@@ -58,6 +59,14 @@ class FakeAgent:
         if self.fail_times:
             self.fail_times -= 1
             raise RuntimeError("planned failure")
+        return {"response": self.response, "session_id": session_id}
+
+
+class BlockingAgent(FakeAgent):
+    async def run(self, query: str, session_id: str):
+        self.calls.append({"query": query, "session_id": session_id})
+        if self.delay:
+            time.sleep(self.delay)
         return {"response": self.response, "session_id": session_id}
 
 
@@ -876,7 +885,7 @@ async def test_background_run_does_not_block_on_hanging_event_append(tmp_path):
         task_store="in_memory",
         event_router=HangingAppendEventRouter(),
         workspace=workspace,
-        lease_seconds=0.1,
+        lease_seconds=1,
     )
     manager._event_append_timeout_seconds = 0.01
     await manager.register_agent("agent", FakeAgent(response="complete"))
@@ -902,7 +911,7 @@ async def test_slow_claimed_event_append_does_not_expire_active_lease(tmp_path):
         task_store="in_memory",
         event_router=HangingClaimAppendEventRouter(),
         workspace=workspace,
-        lease_seconds=0.1,
+        lease_seconds=1,
     )
     manager._event_append_timeout_seconds = 0.2
     await manager.register_agent("agent", FakeAgent(response="complete"))
@@ -1027,6 +1036,160 @@ async def test_manager_run_now_wait_respects_queue_next_active_run():
 
     assert second.status == RunStatus.QUEUED
     assert agent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_manager_run_now_wait_respects_queue_next_earlier_queued_run():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        overlap_policy=OverlapPolicy.QUEUE_NEXT,
+    )
+    first = await manager.run_now("task")
+
+    second = await manager.run_now("task", wait=True)
+
+    assert first.status == RunStatus.QUEUED
+    assert second.status == RunStatus.QUEUED
+    assert agent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_manager_run_now_wait_timeout_polls_queue_next_blocker():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        overlap_policy=OverlapPolicy.QUEUE_NEXT,
+    )
+    first = await manager.run_now("task")
+
+    async def cancel_blocker():
+        await asyncio.sleep(0.05)
+        await manager.cancel_run(first.run_id)
+
+    cancel_task = asyncio.create_task(cancel_blocker())
+    try:
+        second = await manager.run_now("task", wait=True, timeout_seconds=0.5)
+    finally:
+        await cancel_task
+
+    assert second.status == RunStatus.COMPLETED
+    assert agent.calls
+
+
+@pytest.mark.asyncio
+async def test_queue_next_equal_queued_at_uses_stable_ordering():
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(task_store=store)
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        overlap_policy=OverlapPolicy.QUEUE_NEXT,
+    )
+    queued_at = datetime.now(timezone.utc)
+    run_a = await manager.run_now("task", wait=False)
+    run_b = await manager.run_now("task", wait=False)
+    async with store._lock:
+        store._runs[run_a.run_id] = store._runs[run_a.run_id].model_copy(
+            update={"queued_at": queued_at, "triggered_at": queued_at}
+        )
+        store._runs[run_b.run_id] = store._runs[run_b.run_id].model_copy(
+            update={"queued_at": queued_at, "triggered_at": queued_at}
+        )
+
+    claimable = await store.list_claimable_runs(limit=10)
+
+    assert [item.run_id for item in claimable] == [min(run_a.run_id, run_b.run_id)]
+
+
+@pytest.mark.asyncio
+async def test_manager_run_now_wait_timeout_does_not_block_on_running_agent():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    agent = FakeAgent(response="complete", delay=0.2)
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    started = asyncio.get_running_loop().time()
+    run = await manager.run_now("task", wait=True, timeout_seconds=0.01)
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert elapsed < 0.15
+    assert run.status in {RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.RUNNING}
+    completed = await wait_for(
+        lambda: manager.list_runs(status=RunStatus.COMPLETED),
+        timeout=0.5,
+    )
+    assert completed[0].run_id == run.run_id
+
+
+@pytest.mark.asyncio
+async def test_inline_timeout_shutdown_honors_retry_policy():
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(task_store=store)
+    agent = FakeAgent(response="complete", delay=0.2)
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    run = await manager.run_now("task", wait=True, timeout_seconds=0.01)
+    await wait_for(lambda: manager.list_attempts(run.run_id), timeout=0.5)
+    await manager.shutdown()
+
+    latest = await store.get_run(run.run_id)
+    attempts = await store.list_attempts(run.run_id)
+    assert latest.status == RunStatus.FAILED
+    assert attempts[0].status == AttemptStatus.FAILED
+    assert attempts[0].error == "worker shutdown"
+
+
+@pytest.mark.asyncio
+async def test_inline_timeout_shutdown_requeues_retryable_run():
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(task_store=store)
+    agent = FakeAgent(response="complete", delay=0.2)
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        retry_policy=RetryPolicy(max_retries=1, initial_delay_seconds=0),
+    )
+
+    run = await manager.run_now("task", wait=True, timeout_seconds=0.01)
+    await wait_for(lambda: manager.list_attempts(run.run_id), timeout=0.5)
+    await manager.shutdown()
+
+    latest = await store.get_run(run.run_id)
+    attempts = await store.list_attempts(run.run_id)
+    assert latest.status == RunStatus.QUEUED
+    assert latest.lease_owner is None
+    assert latest.lease_token is None
+    assert attempts[0].status == AttemptStatus.FAILED
+    assert attempts[0].retry_delay_seconds == 0
 
 
 @pytest.mark.asyncio
@@ -1287,8 +1450,8 @@ async def test_retry_delay_sets_future_queue_time_and_blocks_claim():
 @pytest.mark.asyncio
 async def test_long_running_attempt_refreshes_lease():
     store = CountingStore()
-    manager = BackgroundAgentManager(task_store=store, lease_seconds=0.1)
-    await manager.register_agent("agent", FakeAgent(response="ok", delay=0.25))
+    manager = BackgroundAgentManager(task_store=store, lease_seconds=0.5)
+    await manager.register_agent("agent", FakeAgent(response="ok", delay=0.7))
     await manager.register_task(
         task_id="task",
         agent_id="agent",
@@ -1300,6 +1463,33 @@ async def test_long_running_attempt_refreshes_lease():
 
     assert run.status == RunStatus.COMPLETED
     assert store.refresh_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_cannot_be_refreshed_by_stale_owner():
+    store = InMemoryTaskStore()
+    await store.save_agent(agent_spec())
+    await store.save_task(task_spec())
+    run = BackgroundRun(
+        task_id="task",
+        agent_id="agent",
+        query_snapshot="work",
+        trigger_type=TriggerType.MANUAL,
+        session_id="session",
+        workspace_path="workspace",
+    )
+    created = await store.create_run_with_overlap_guard(
+        run, OverlapPolicy.ALLOW_PARALLEL
+    )
+    claimed = await store.claim_run(created.run_id, "worker", lease_seconds=-1)
+
+    with pytest.raises(RunLeaseError):
+        await store.refresh_lease(
+            claimed.run_id,
+            "worker",
+            claimed.lease_token,
+            lease_seconds=30,
+        )
 
 
 @pytest.mark.asyncio
@@ -1405,6 +1595,52 @@ async def test_recover_expired_running_run_requeues_when_retry_available():
 
     assert recovered.status == RunStatus.QUEUED
     assert recovered.lease_token is None
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_during_completion_does_not_crash_worker():
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(
+        task_store=store,
+        worker_id="worker",
+        lease_seconds=0.01,
+    )
+    await manager.register_agent("agent", BlockingAgent(response="done", delay=0.05))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+        retry_policy=RetryPolicy(max_retries=1, initial_delay_seconds=0),
+    )
+    run = await manager.run_now("task", wait=False)
+
+    did_work = await manager._execute_one()
+    latest = await manager.get_run(run.run_id)
+    attempts = await manager.list_attempts(run.run_id)
+
+    assert did_work is True
+    assert latest.status == RunStatus.RUNNING
+    assert attempts[0].status == AttemptStatus.RUNNING
+
+    await manager.recover_expired_runs()
+    still_recoverable = await manager.get_run(run.run_id)
+    assert still_recoverable.status in {
+        RunStatus.RUNNING,
+        RunStatus.RETRYING,
+        RunStatus.QUEUED,
+    }
+
+    if still_recoverable.status != RunStatus.QUEUED:
+        manager.lease_seconds = 1
+        await manager.recover_expired_runs()
+    recovered = await manager.get_run(run.run_id)
+    recovered_attempts = await manager.list_attempts(run.run_id)
+
+    assert recovered.status == RunStatus.QUEUED
+    assert recovered.lease_token is None
+    assert recovered_attempts[0].status == AttemptStatus.FAILED
+    assert recovered_attempts[0].reason == AttemptReason.LEASE_EXPIRED
 
 
 @pytest.mark.asyncio

--- a/tests/test_omniserve_background.py
+++ b/tests/test_omniserve_background.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import os
+import threading
 
 from fastapi.testclient import TestClient
 import pytest
 
 from omnicoreagent import OmniServe, OmniServeConfig
 from omnicoreagent.background import BackgroundAgentManager
+from omnicoreagent.core.events.event_router import EventRouter
 from omnicoreagent.core.workspace.manager import Workspace
 
 
@@ -28,6 +31,10 @@ class ServedAgent:
         self.calls: list[dict] = []
         self.connected = False
         self.cleaned = False
+        self.delay_seconds = 0.0
+        self.fail_times = 0
+        self.wait_until: threading.Event | None = None
+        self.wait_timeout_seconds = 2.0
 
     async def connect_mcp_servers(self) -> None:
         self.connected = True
@@ -40,22 +47,89 @@ class ServedAgent:
 
     async def run(self, query: str, session_id: str | None = None) -> dict:
         self.calls.append({"query": query, "session_id": session_id})
+        if self.wait_until is not None:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + self.wait_timeout_seconds
+            while not self.wait_until.is_set() and loop.time() < deadline:
+                await asyncio.sleep(0.01)
+        if self.delay_seconds:
+            await asyncio.sleep(self.delay_seconds)
+        if self.fail_times:
+            self.fail_times -= 1
+            raise RuntimeError("planned failure")
         return {"response": f"completed:{session_id}:{query[-16:]}"}
 
 
-def make_background_manager(tmp_path):
+class HeartbeatEventRouter(EventRouter):
+    def __init__(self):
+        super().__init__()
+        self.heartbeat_seen = threading.Event()
+
+    async def append(self, session_id, event):
+        await super().append(session_id=session_id, event=event)
+        if getattr(event.payload, "status", None) == "background_run_heartbeat":
+            self.heartbeat_seen.set()
+
+
+class SpyBackgroundAgentManager(BackgroundAgentManager):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.run_now_wait_values: list[bool] = []
+        self.wait_for_run_called = False
+
+    async def run_now(
+        self,
+        task_id: str,
+        query: str | None = None,
+        wait: bool = False,
+        timeout_seconds: float | None = None,
+    ):
+        self.run_now_wait_values.append(wait)
+        return await super().run_now(
+            task_id,
+            query=query,
+            wait=wait,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def wait_for_run(
+        self,
+        run_id: str,
+        timeout_seconds: float | None = None,
+        poll_interval_seconds: float = 0.05,
+    ):
+        self.wait_for_run_called = True
+        return await super().wait_for_run(
+            run_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+
+def make_background_manager(tmp_path, *, lease_seconds=30, event_router=None):
     workspace = Workspace.from_config(
         {
             "workspace_backend": "local",
             "workspace_dir": str(tmp_path / "workspace"),
         }
     ).ensure()
-    return BackgroundAgentManager(task_store="in_memory", workspace=workspace)
+    return BackgroundAgentManager(
+        task_store="in_memory",
+        event_router=event_router,
+        workspace=workspace,
+        lease_seconds=lease_seconds,
+    )
 
 
 def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
     agent = ServedAgent()
-    manager = make_background_manager(tmp_path)
+    event_router = HeartbeatEventRouter()
+    agent.wait_until = event_router.heartbeat_seen
+    manager = make_background_manager(
+        tmp_path,
+        lease_seconds=1,
+        event_router=event_router,
+    )
     server = OmniServe(
         agent,
         OmniServeConfig(
@@ -121,9 +195,31 @@ def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
 
         events = client.get(f"/background/runs/{run['run_id']}/events")
         assert events.status_code == 200
-        event_names = [item["event"] for item in events.json()["events"]]
+        replayed_events = events.json()["events"]
+        event_names = [item["event"] for item in replayed_events]
+        assert events.json()["count"] == len(replayed_events)
+        assert [item["sequence"] for item in replayed_events] == list(
+            range(1, len(replayed_events) + 1)
+        )
+        assert event_names[:3] == [
+            "background_run_queued",
+            "background_run_claimed",
+            "background_run_started",
+        ]
         assert "background_run_started" in event_names
+        assert "background_run_heartbeat" in event_names
         assert "background_run_completed" in event_names
+        claimed = next(
+            item for item in replayed_events if item["event"] == "background_run_claimed"
+        )
+        assert claimed["worker_id"] == manager.worker_id
+        assert claimed["lease_generation"] == 1
+        assert claimed["lease_expires_at"]
+        heartbeat = next(
+            item for item in replayed_events if item["event"] == "background_run_heartbeat"
+        )
+        assert heartbeat["worker_id"] == manager.worker_id
+        assert heartbeat["heartbeat_at"]
         assert client.get("/background/runs/missing/events").status_code == 404
 
         workspace = client.get(f"/background/runs/{run['run_id']}/workspace")
@@ -133,12 +229,143 @@ def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
 
         deleted = client.delete("/background/tasks/daily_report", params={"delete_runs": True})
         assert deleted.status_code == 200
+        assert client.delete("/background/tasks/daily_report").status_code == 404
         assert client.delete("/background/agents/served").status_code == 200
+        assert client.delete("/background/agents/served").status_code == 404
 
     assert agent.connected is True
     assert agent.cleaned is True
     assert agent.calls
     assert agent.calls[0]["session_id"] == "background:served:daily_report"
+
+
+def test_background_api_wait_true_uses_worker_wait_path(tmp_path):
+    agent = ServedAgent()
+    agent.delay_seconds = 0.05
+    workspace = Workspace.from_config(
+        {
+            "workspace_backend": "local",
+            "workspace_dir": str(tmp_path / "workspace"),
+        }
+    ).ensure()
+    manager = SpyBackgroundAgentManager(task_store="in_memory", workspace=workspace)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=True,
+            request_timeout=2,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "worker_wait",
+                "query": "write with worker",
+                "schedule": {"type": "manual"},
+            },
+        )
+        assert created.status_code == 200
+
+        run_response = client.post(
+            "/background/tasks/worker_wait/run",
+            json={"wait": True},
+        )
+        assert run_response.status_code == 200
+        assert run_response.json()["status"] == "completed"
+
+    assert manager.run_now_wait_values == [False]
+    assert manager.wait_for_run_called is True
+
+
+def test_background_api_wait_true_executes_without_worker(tmp_path):
+    agent = ServedAgent()
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=False,
+            request_timeout=2,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "manual_sync",
+                "query": "write the synchronous result",
+                "schedule": {"type": "manual"},
+            },
+        )
+        assert created.status_code == 200
+
+        run_response = client.post(
+            "/background/tasks/manual_sync/run",
+            json={"wait": True},
+        )
+        assert run_response.status_code == 200
+        run = run_response.json()
+        assert run["status"] == "completed"
+
+        events = client.get(f"/background/runs/{run['run_id']}/events")
+        assert events.status_code == 200
+        assert [item["event"] for item in events.json()["events"]] == [
+            "background_run_queued",
+            "background_run_claimed",
+            "background_run_started",
+            "background_run_completed",
+        ]
+
+    assert len(agent.calls) == 1
+
+
+def test_background_api_wait_true_without_worker_times_out_on_delayed_retry(tmp_path):
+    agent = ServedAgent()
+    agent.fail_times = 1
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=False,
+            request_timeout=1,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "retry_later",
+                "query": "retry later",
+                "schedule": {"type": "manual"},
+                "retry_policy": {
+                    "max_retries": 1,
+                    "initial_delay_seconds": 5,
+                    "max_delay_seconds": 5,
+                },
+            },
+        )
+        assert created.status_code == 200
+
+        run_response = client.post(
+            "/background/tasks/retry_later/run",
+            json={"wait": True},
+        )
+        assert run_response.status_code == 504
+        runs = client.get("/background/runs", params={"task_id": "retry_later"})
+        assert runs.status_code == 200
+        assert runs.json()["total"] == 1
+        assert runs.json()["runs"][0]["status"] == "queued"
+
+    assert len(agent.calls) == 1
 
 
 def test_background_api_rejects_invalid_schedule_payload(tmp_path):

--- a/tests/test_omniserve_background.py
+++ b/tests/test_omniserve_background.py
@@ -277,7 +277,7 @@ def test_background_api_wait_true_uses_worker_wait_path(tmp_path):
         assert run_response.status_code == 200
         assert run_response.json()["status"] == "completed"
 
-    assert manager.run_now_wait_values == [False]
+    assert manager.run_now_wait_values == [True]
     assert manager.wait_for_run_called is True
 
 
@@ -360,10 +360,99 @@ def test_background_api_wait_true_without_worker_times_out_on_delayed_retry(tmp_
             json={"wait": True},
         )
         assert run_response.status_code == 504
+        timeout_detail = run_response.json()["detail"]
+        assert timeout_detail["task_id"] == "retry_later"
+        assert timeout_detail["status"] == "queued"
+        assert timeout_detail["run_id"].startswith("run_")
+        assert timeout_detail["wait_timeout_seconds"] == 0.75
+        assert timeout_detail["request_timeout_seconds"] == 1
         runs = client.get("/background/runs", params={"task_id": "retry_later"})
         assert runs.status_code == 200
         assert runs.json()["total"] == 1
         assert runs.json()["runs"][0]["status"] == "queued"
+        assert runs.json()["runs"][0]["run_id"] == timeout_detail["run_id"]
+
+    assert len(agent.calls) == 1
+
+
+def test_background_api_wait_true_without_request_timeout_returns_retry_state(tmp_path):
+    agent = ServedAgent()
+    agent.fail_times = 1
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=False,
+            request_timeout=0,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "retry_without_http_timeout",
+                "query": "retry later",
+                "schedule": {"type": "manual"},
+                "retry_policy": {
+                    "max_retries": 1,
+                    "initial_delay_seconds": 5,
+                    "max_delay_seconds": 5,
+                },
+            },
+        )
+        assert created.status_code == 200
+
+        run_response = client.post(
+            "/background/tasks/retry_without_http_timeout/run",
+            json={"wait": True},
+        )
+        assert run_response.status_code == 200
+        run = run_response.json()
+        assert run["status"] == "queued"
+        assert run["run_id"].startswith("run_")
+
+    assert len(agent.calls) == 1
+
+
+def test_background_api_wait_true_times_out_before_slow_inline_run_finishes(tmp_path):
+    agent = ServedAgent()
+    agent.delay_seconds = 2
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=False,
+            request_timeout=1,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "slow_inline",
+                "query": "slow inline",
+                "schedule": {"type": "manual"},
+            },
+        )
+        assert created.status_code == 200
+
+        run_response = client.post(
+            "/background/tasks/slow_inline/run",
+            json={"wait": True},
+        )
+        assert run_response.status_code == 504
+        timeout_detail = run_response.json()["detail"]
+        assert timeout_detail["task_id"] == "slow_inline"
+        assert timeout_detail["run_id"].startswith("run_")
+        assert timeout_detail["status"] in {"claimed", "running"}
+        assert timeout_detail["wait_timeout_seconds"] == 0.75
+        assert timeout_detail["request_timeout_seconds"] == 1
 
     assert len(agent.calls) == 1
 
@@ -431,3 +520,36 @@ def test_background_api_can_be_disabled():
 
     assert response.status_code == 503
     assert response.json()["detail"] == "Background execution is disabled"
+
+
+def test_background_openapi_matches_http_exception_response_shapes(tmp_path):
+    agent = ServedAgent()
+    manager = make_background_manager(tmp_path)
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="served",
+            background_start_worker=False,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        schema = client.get("/openapi.json").json()
+        delete_task_responses = schema["paths"]["/background/tasks/{task_id}"][
+            "delete"
+        ]["responses"]
+        run_responses = schema["paths"]["/background/tasks/{task_id}/run"][
+            "post"
+        ]["responses"]
+
+        assert (
+            delete_task_responses["404"]["content"]["application/json"]["schema"][
+                "$ref"
+            ]
+            == "#/components/schemas/HttpErrorResponse"
+        )
+        assert (
+            run_responses["504"]["content"]["application/json"]["schema"]["$ref"]
+            == "#/components/schemas/BackgroundRunTimeoutResponse"
+        )


### PR DESCRIPTION
## Summary
- add a manager-owned inline run driver for wait=true background runs, preserving queue ordering and overlap policy
- keep EventRouter visibility writes off the active execution lease path while preserving durable initial events
- tighten OmniServe background run/delete semantics and lifecycle replay coverage
- document wait=true timeout/504 behavior in docs, cookbook, architecture, and spec

## Verification
- PYTHONPATH=/home/abiorh/ai/omnirexflora-labs_dir/omnicoreagent/src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_background_agent.py tests/test_omniserve_background.py tests/test_omniserve_full.py tests/test_docs_claims.py -q
- PYTHONPATH=/home/abiorh/ai/omnirexflora-labs_dir/omnicoreagent/src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q

## Reviewer pass
- Spawned API/runtime, QA, and docs/DX evaluator agents.
- Fixed reported issues around private manager execution, queue_next bypass, delayed retry timeout behavior, flaky heartbeat assertions, and generated API 504 wording.