### PR TITLE
Refactor background manager services

### DIFF
--- a/docs/core-concepts/events.mdx
+++ b/docs/core-concepts/events.mdx
@@ -20,10 +20,6 @@ Runtime event streaming supports two event stores:
 - `in_memory` for local development, tests, and single-process apps
 - `redis_stream` for production or multi-process live streaming
 
-SQL and MongoDB are not event-stream backends. Use them for memory or
-background task state; use Redis Streams when live events need to cross process
-boundaries.
-
 Redis Streams require the Redis extra:
 
 ```bash

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -214,8 +214,7 @@ agent = OmniCoreAgent(
 )
 ```
 
-Event streaming supports `in_memory` and `redis_stream`. SQL and MongoDB are
-for memory or background task state, not live runtime event streams.
+Event streaming supports `in_memory` and `redis_stream`.
 
 ---
 

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -62,7 +62,7 @@ execution layer around the agent harness.
 | Durable state first | Task, schedule, run, attempt, cancellation, and lease state live in a task store |
 | Schedule dispatch is store-driven | Due work is read from task-store schedule state; no external scheduler owns execution |
 | Supervisor owns execution | Retry, timeout, cancellation, heartbeat, leases, and terminal status are handled outside the model loop |
-| Workspace is mandatory | Every background run gets a workspace namespace for durable outputs |
+| Workspace namespace is mandatory | Every background run gets a workspace namespace for durable outputs; lifecycle file writes are best-effort visibility and must not block execution |
 | Memory is separate | Conversation/session memory stays in `MemoryRouter`; operational state stays in the task store |
 | Events are visibility, not truth | Events describe lifecycle transitions; the task store is the source of truth |
 | Storage is pluggable | `AbstractTaskStore` supports the shipped `in_memory`, `sql`, `redis`, and `mongodb` stores behind the same interface |
@@ -79,7 +79,7 @@ User / OmniServe / Application
         v
 BackgroundAgentManager
         |
-        +--> AgentRegistry
+        +--> agent_specs
         +--> TaskStoreRouter
         |       |
         |       v
@@ -90,9 +90,10 @@ BackgroundAgentManager
         |       +--> redis
         |       +--> mongodb
         |
-        +--> ScheduleDispatcher
-        +--> RunQueue
-        +--> BackgroundSupervisor
+        +--> run_helpers
+        +--> BackgroundEventLog
+        +--> BackgroundWorkspaceIO
+        +--> schedule/queue/supervisor methods
                 |
                 v
           OmniCoreAgent.run()
@@ -103,10 +104,13 @@ BackgroundAgentManager
                 +--> Tools / MCP / Subagents / Guardrails
 ```
 
-The manager owns orchestration. The store owns operational truth. Schedule
-helpers compute due times from task specs. The supervisor owns execution lifecycle.
-`OmniCoreAgent` owns reasoning, tool calls, workspace tools, memory, context
-management, guardrails, and final response generation.
+The manager owns the public facade and orchestration flow. The store owns
+operational truth. `run_helpers` owns pure run construction and retry helpers.
+`BackgroundEventLog` owns lifecycle event ordering, workspace event persistence,
+and event-router fanout. `BackgroundWorkspaceIO` owns background workspace file
+access. The supervisor path owns execution lifecycle. `OmniCoreAgent` owns
+reasoning, tool calls, workspace tools, memory, context management, guardrails,
+and final response generation.
 
 ---
 
@@ -130,9 +134,15 @@ Responsibilities:
 - expose inspection operations
 - enforce background runtime defaults
 
-### `AgentRegistry`
+It must not become the dump yard for every background concern. If a change only
+knows about agent spec reconstruction, run construction, workspace IO, event
+replay, or backend storage, it belongs in the smaller module that owns that
+concern.
 
-Holds process-local agent objects and serializable agent specs.
+### `agent_specs`
+
+Converts runtime agents into durable `BackgroundAgentSpec` records and resolves
+registered agents from either process-local objects or durable specs.
 
 Two registration modes exist:
 
@@ -140,6 +150,57 @@ Two registration modes exist:
   themselves
 - serializable spec registration for durable agents that can be reconstructed
   by workers
+
+This module is also the lazy import boundary for `OmniCoreAgent` reconstruction,
+so importing background execution stays light.
+
+### `run_helpers`
+
+Pure helpers for run construction and deterministic lifecycle calculations.
+
+Responsibilities:
+
+- construct `BackgroundRun` records
+- build the prompt prefix passed to `OmniCoreAgent.run()`
+- calculate retry delays
+- calculate inline wait sleep windows
+- produce lease-release patches
+- create safe result previews
+
+These helpers do not touch the task store, workspace, event router, or model.
+
+### `BackgroundEventLog`
+
+Owns background lifecycle visibility.
+
+Responsibilities:
+
+- assign per-run lifecycle event sequence numbers
+- keep the process-local event cache
+- persist lifecycle events to workspace `events.jsonl`
+- write run snapshots to workspace `run.json`
+- append lifecycle events into `EventRouter`
+- replay the strongest complete event source for a run
+- tolerate workspace or event-router visibility failures without blocking task
+  execution
+
+Events are still visibility, not source of truth. Task-store state remains the
+authority for run lifecycle.
+
+### `BackgroundWorkspaceIO`
+
+Owns the background workspace file boundary.
+
+Responsibilities:
+
+- resolve the configured workspace lazily
+- list visible files for a run workspace namespace
+- read lifecycle `events.jsonl`
+- write `run.json`
+- append lifecycle events
+
+Workspace IO failures are intentionally contained so background execution can
+continue when the visibility surface is temporarily unavailable.
 
 ### `TaskStoreRouter`
 
@@ -187,9 +248,11 @@ Conversation memory belongs to `MemoryRouter`. Files and artifacts belong to
 workspace storage. Events belong to `EventRouter`. The task store owns
 operational state.
 
-### `ScheduleDispatcher`
+### Schedule Dispatch Methods
 
-Converts due tasks into run records.
+Schedule dispatch is currently implemented inside `BackgroundAgentManager`.
+Those methods convert due tasks into run records. A future extraction may move
+this into a dedicated `ScheduleDispatcher`, but that class does not exist today.
 
 Responsibilities:
 
@@ -202,9 +265,11 @@ Responsibilities:
 - make the queued run claimable through the task store
 - emit queued or skipped lifecycle events
 
-### `RunQueue`
+### Run Queue Methods
 
-Provides the boundary between due work and execution.
+Run claiming is currently implemented through `BackgroundAgentManager` methods
+backed by `AbstractTaskStore`. A future extraction may move this into a
+dedicated `RunQueue`, but that class does not exist today.
 
 Responsibilities:
 
@@ -219,9 +284,12 @@ it, and queued runs remain claimable after process restart. A process-local
 queue can exist only as an optimization over the store-backed queue; it must not
 be the source of truth.
 
-### `BackgroundSupervisor`
+### Supervisor Methods
 
-Executes queued runs under operational control.
+Run supervision is currently implemented inside `BackgroundAgentManager`. These
+methods execute queued runs under operational control. A future extraction may
+move this into a dedicated `BackgroundSupervisor`, but that class does not exist
+today.
 
 Responsibilities:
 
@@ -675,7 +743,7 @@ Use run-level sessions for isolated batch jobs.
 
 ## Workspace Contract
 
-Workspace is mandatory for background runs.
+A workspace namespace is mandatory for background runs.
 
 Default run namespace:
 
@@ -695,13 +763,15 @@ subagents/
 scratchpad/
 ```
 
-The supervisor binds the run workspace before calling the agent and injects a
-short run-context instruction into the request. The agent writes durable task
-output through workspace tools. Events can also be mirrored to `events.jsonl`
-for easy inspection, while `EventRouter` remains the event service.
+The supervisor injects a short run-context instruction into the request with the
+run workspace namespace. The agent writes durable task output through workspace
+tools. Lifecycle files such as `run.json` and `events.jsonl` are best-effort
+visibility artifacts and must not stop execution if workspace IO is temporarily
+unavailable. `EventRouter` remains the runtime event service.
 
 The final response returned by `OmniCoreAgent.run()` is stored as
-`result_preview`. The durable result of background work is the workspace output.
+`result_preview`. The durable result of background work should live in the run
+workspace when the task writes files.
 
 Workspace storage can be local, S3, or R2 through the existing workspace
 architecture. Background execution does not create a separate file-storage
@@ -860,7 +930,7 @@ The background execution system is ready when:
 - expired leases can be recovered deterministically
 - queued runs remain claimable after restart
 - cancellation, timeout, retry, and overlap policies are tested
-- every background run writes workspace output
+- every background run has a workspace namespace
 - run status can be inspected without reading event streams
 - lifecycle events can reconstruct the run trajectory
 - optional dependencies do not load during root or background-package import

--- a/engineering/architecture/events.md
+++ b/engineering/architecture/events.md
@@ -123,10 +123,6 @@ Runtime event stores are intentionally limited to:
 - `in_memory` for local development, tests, and single-process applications
 - `redis_stream` for multi-process or production live streaming
 
-SQL and MongoDB are not event-stream backends. They are useful for durable state
-records, but live event fan-out should not depend on polling a document or row
-store.
-
 Current guarantees:
 
 - events are isolated by store key (`session_id`)

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -363,8 +363,10 @@ Fields:
 | `write_run_json` | `bool` | `true` |
 | `write_events_jsonl` | `bool` | `true` |
 
-Background runs always require workspace output. If no workspace is configured,
-the manager uses the default local workspace.
+Background runs always require a workspace namespace. If no workspace is
+configured, the manager uses the default local workspace. Lifecycle files such
+as `run.json` and `events.jsonl` are visibility artifacts: failed writes or
+failed workspace listing must not stop, fail, or block the background run.
 
 ### `BackgroundScheduleState`
 
@@ -778,11 +780,9 @@ result = await agent.run(
 )
 ```
 
-Before execution, the supervisor binds the run workspace and injects the
-background run context into the request. The context contains `run_id`,
-`task_id`, `workspace_path`, and output-file guidance. The mechanism can be a
-runtime context object or request augmentation, but it must be explicit in the
-implementation and covered by tests.
+Before execution, the supervisor injects the background run context into the
+request. The context contains `run_id`, `task_id`, `workspace_path`, and
+output-file guidance. The current mechanism is request augmentation.
 
 Requirements:
 
@@ -791,7 +791,7 @@ Requirements:
 - enforce timeout with async timeout control.
 - refresh heartbeat while active.
 - every heartbeat, attempt update, and terminal write verifies `lease_token`.
-- preserve partial workspace output on failure.
+- preserve partial workspace output on failure when workspace IO is available.
 - create an attempt record before each attempt.
 - update attempt status after each attempt.
 - apply retry policy outside scheduler.
@@ -1057,7 +1057,7 @@ Run the same contract tests against every backend:
 - closes abandoned attempt on recovery
 - requeues recovered runs through the normal claim path
 - executes `query_snapshot`, not mutable task query
-- binds workspace and injects run context before execution
+- injects run context before execution
 - writes run metadata to workspace
 - emits lifecycle events
 - mirrors run events to `events.jsonl` when enabled
@@ -1085,7 +1085,7 @@ Run the same contract tests against every backend:
 
 - in-memory end-to-end background run with fake agent
 - SQL SQLite end-to-end restart recovery
-- workspace output persists for local workspace
+- workspace lifecycle files and task outputs persist for local workspace when written
 - event trace can be built for a background run
 - cookbook background example runs with a short schedule and clean shutdown
 
@@ -1110,7 +1110,7 @@ The implementation satisfies this specification when:
 - expired leases are recoverable.
 - queued runs remain claimable after restart.
 - run status is inspectable without event replay.
-- workspace output is written for every background run.
+- every background run has a workspace namespace.
 - cancellation, timeout, retry, overlap, and recovery behavior are tested.
 - root and background-package imports remain lightweight.
 - public docs and cookbook examples match the implemented API.

--- a/engineering/specifications/events.md
+++ b/engineering/specifications/events.md
@@ -115,9 +115,8 @@ Rules:
 - Redis import failures fall back to `in_memory`.
 - Switching event stores selects a new backing store.
 - Switching stores does not migrate previously stored events.
-- SQL and MongoDB are not valid runtime event stream backends.
-- Use SQL, Redis, or MongoDB task stores for background task state; use
-  `redis_stream` when runtime events must stream across processes.
+- Runtime event stores are `in_memory` and `redis_stream`.
+- Use `redis_stream` when runtime events must stream across processes.
 
 ---
 

--- a/src/omnicoreagent/__init__.py
+++ b/src/omnicoreagent/__init__.py
@@ -40,6 +40,8 @@ __all__ = [
     "TaskStoreRouter",
     "InMemoryTaskStore",
     "SqlTaskStore",
+    "RedisTaskStore",
+    "MongoDbTaskStore",
     "ParallelAgent",
     "SequentialAgent",
     "RouterAgent",
@@ -87,6 +89,8 @@ _EXPORTS = {
     "TaskStoreRouter": ("omnicoreagent.background", "TaskStoreRouter"),
     "InMemoryTaskStore": ("omnicoreagent.background", "InMemoryTaskStore"),
     "SqlTaskStore": ("omnicoreagent.background", "SqlTaskStore"),
+    "RedisTaskStore": ("omnicoreagent.background", "RedisTaskStore"),
+    "MongoDbTaskStore": ("omnicoreagent.background", "MongoDbTaskStore"),
 }
 
 _OPTIONAL_EXPORTS = {

--- a/src/omnicoreagent/background/agent_specs.py
+++ b/src/omnicoreagent/background/agent_specs.py
@@ -1,0 +1,96 @@
+"""Agent spec helpers for background execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.background.models import BackgroundAgentSpec
+from omnicoreagent.background.store.base import AbstractTaskStore
+
+
+def spec_from_agent(agent_id: str, agent: Any) -> BackgroundAgentSpec:
+    """Create a durable background agent spec from a runtime agent object."""
+    return BackgroundAgentSpec(
+        agent_id=agent_id,
+        name=getattr(agent, "name", agent_id),
+        system_instruction=getattr(agent, "system_instruction", None),
+        model_config=_safe_model_config(agent),
+        agent_config=_safe_dict(getattr(agent, "agent_config", {})),
+        mcp_tools=_safe_list(getattr(agent, "mcp_tools", [])),
+        workspace_config=_safe_workspace_config(agent),
+    )
+
+
+async def resolve_agent(
+    *,
+    agent_id: str,
+    agents: dict[str, Any],
+    task_store: AbstractTaskStore,
+    memory_router: Any,
+    event_router: Any,
+) -> Any | None:
+    """Resolve a registered runtime agent, reconstructing from spec when possible."""
+    agent = agents.get(agent_id)
+    if agent is not None:
+        return agent
+
+    spec = await task_store.get_agent(agent_id)
+    if not spec or not spec.llm_model_config:
+        return None
+
+    from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent
+
+    agent = OmniCoreAgent(
+        name=spec.name or spec.agent_id,
+        system_instruction=spec.system_instruction or "",
+        model_config=spec.llm_model_config,
+        mcp_tools=spec.mcp_tools,
+        agent_config={
+            **spec.agent_config,
+            **({"workspace_config": spec.workspace_config} if spec.workspace_config else {}),
+        },
+        memory_router=memory_router,
+        event_router=event_router,
+    )
+    agents[agent_id] = agent
+    return agent
+
+
+def _safe_model_config(agent: Any) -> dict[str, Any] | None:
+    value = getattr(agent, "model_config", None)
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    return value if isinstance(value, dict) else None
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        safe_values = []
+        for item in value:
+            if hasattr(item, "model_dump"):
+                safe_values.append(item.model_dump())
+            elif isinstance(item, dict):
+                safe_values.append(item)
+        return safe_values
+    return []
+
+
+def _safe_workspace_config(agent: Any) -> dict[str, Any] | None:
+    config = getattr(agent, "agent_config", None)
+    if hasattr(config, "model_dump"):
+        config = config.model_dump()
+    if isinstance(config, dict):
+        workspace_config = config.get("workspace_config")
+        if hasattr(workspace_config, "model_dump"):
+            return workspace_config.model_dump()
+        if isinstance(workspace_config, dict):
+            return workspace_config
+    return None

--- a/src/omnicoreagent/background/event_log.py
+++ b/src/omnicoreagent/background/event_log.py
@@ -1,0 +1,328 @@
+"""Background run event persistence and runtime event routing."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+from omnicoreagent.background.models import (
+    INITIAL_EVENT_NAMES,
+    TERMINAL_EVENT_NAMES,
+    BackgroundRun,
+)
+from omnicoreagent.background.store.base import AbstractTaskStore
+from omnicoreagent.background.workspace_io import BackgroundWorkspaceIO
+
+
+class BackgroundEventLog:
+    """Owns background lifecycle event ordering, storage, and event-router fanout."""
+
+    def __init__(
+        self,
+        *,
+        task_store: AbstractTaskStore,
+        workspace_io: BackgroundWorkspaceIO,
+        event_router: Any = None,
+        replay_timeout_seconds: float = 2.0,
+        append_timeout_seconds: float = 2.0,
+    ) -> None:
+        self.task_store = task_store
+        self.workspace_io = workspace_io
+        self.event_router = event_router
+        self.replay_timeout_seconds = replay_timeout_seconds
+        self.append_timeout_seconds = append_timeout_seconds
+        self.local_events: dict[str, list[dict[str, Any]]] = {}
+        self.event_sequences: dict[str, int] = {}
+        self.router_tasks: set[asyncio.Task] = set()
+
+    async def emit_run(
+        self, event_name: str, run: BackgroundRun, **extra_payload: Any
+    ) -> None:
+        try:
+            await self.emit(
+                event_name,
+                agent_id=run.agent_id,
+                task_id=run.task_id,
+                run_id=run.run_id,
+                session_id=run.session_id,
+                status=run.status.value,
+                attempt=run.attempt,
+                workspace_path=run.workspace_path,
+                worker_id=run.lease_owner,
+                lease_generation=run.lease_generation,
+                heartbeat_at=run.heartbeat_at.isoformat() if run.heartbeat_at else None,
+                lease_expires_at=(
+                    run.lease_expires_at.isoformat() if run.lease_expires_at else None
+                ),
+                occurrence_id=run.occurrence_id,
+                due_at=run.due_at.isoformat() if run.due_at else None,
+                **extra_payload,
+            )
+        except Exception:
+            pass
+        if event_name != "background_run_heartbeat":
+            try:
+                await self.write_run_snapshot(run)
+            except Exception:
+                pass
+
+    async def emit(self, event_name: str, **payload: Any) -> None:
+        run_id = payload.get("run_id")
+        event = {
+            "event": event_name,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **payload,
+        }
+        if not run_id:
+            return
+
+        events = self.local_events.setdefault(run_id, [])
+        event["sequence"] = await self.next_run_event_sequence(
+            run_id, event_name, events
+        )
+        events.append(event)
+        if event_name in INITIAL_EVENT_NAMES:
+            try:
+                await self.write_run_event(event)
+            except Exception:
+                pass
+            if self.event_router is not None:
+                self.schedule_router_task(self.append_event_router(event), event)
+            return
+        self.schedule_router_task(self.write_and_route_event(event), event)
+
+    async def get_run_events(self, run: BackgroundRun | None) -> list[dict[str, Any]]:
+        if not run:
+            return []
+        await self.drain_router_tasks(run.run_id)
+        events = self.prepare_event_trace(self.local_events.get(run.run_id) or [])
+        workspace_events = self.prepare_event_trace(
+            self.workspace_io.read_events(run.workspace_path)
+        )
+        router_events = self.prepare_event_trace(
+            await self.read_event_router_events(run)
+        )
+        candidates = [router_events, events, workspace_events]
+        complete = [
+            candidate
+            for candidate in candidates
+            if candidate and candidate[-1].get("event") in TERMINAL_EVENT_NAMES
+        ]
+        if complete:
+            return max(complete, key=len)
+        if router_events:
+            return router_events
+        if events:
+            return events
+        return workspace_events
+
+    async def write_and_route_event(self, event: dict[str, Any]) -> None:
+        try:
+            await self.write_run_event(event)
+        except Exception:
+            pass
+        await self.append_event_router(event)
+
+    def schedule_router_task(self, coroutine, event: dict[str, Any]) -> None:
+        task = asyncio.create_task(coroutine)
+        task._omnicoreagent_run_id = event.get("run_id")  # type: ignore[attr-defined]
+        self.router_tasks.add(task)
+        task.add_done_callback(self.router_tasks.discard)
+
+    async def drain_router_tasks(self, run_id: str) -> None:
+        pending = [
+            task
+            for task in self.router_tasks
+            if not task.done()
+            and getattr(task, "_omnicoreagent_run_id", None) == run_id
+        ]
+        if not pending:
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(asyncio.gather(*pending, return_exceptions=True)),
+                timeout=self.replay_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            return
+
+    async def cancel_router_tasks(self) -> None:
+        pending = [task for task in self.router_tasks if not task.done()]
+        if not pending:
+            self.router_tasks.clear()
+            return
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        self.router_tasks.clear()
+
+    async def next_run_event_sequence(
+        self, run_id: str, event_name: str, local_events: list[dict[str, Any]]
+    ) -> int:
+        cached = self.event_sequences.get(run_id)
+        if cached is not None:
+            self.event_sequences[run_id] = cached + 1
+            return cached + 1
+        sequences = [
+            int(event["sequence"])
+            for event in local_events
+            if isinstance(event.get("sequence"), int)
+        ]
+        if sequences:
+            next_sequence = max(sequences) + 1
+            self.event_sequences[run_id] = next_sequence
+            return next_sequence
+        if event_name in INITIAL_EVENT_NAMES:
+            self.event_sequences[run_id] = 1
+            return 1
+
+        run = await self.task_store.get_run(run_id)
+        if run:
+            for source in (
+                await self.read_event_router_events(run),
+                self.workspace_io.read_events(run.workspace_path),
+            ):
+                sequences.extend(
+                    int(event["sequence"])
+                    for event in source
+                    if isinstance(event.get("sequence"), int)
+                )
+        next_sequence = (max(sequences) if sequences else 0) + 1
+        self.event_sequences[run_id] = next_sequence
+        return next_sequence
+
+    async def write_run_snapshot(self, run: BackgroundRun) -> None:
+        task = await self.task_store.get_task(run.task_id)
+        if task and not task.workspace_policy.write_run_json:
+            return
+        self.workspace_io.write_run_snapshot(run)
+
+    async def write_run_event(self, event: dict[str, Any]) -> None:
+        task_id = event.get("task_id")
+        if task_id:
+            task = await self.task_store.get_task(task_id)
+            if task and not task.workspace_policy.write_events_jsonl:
+                return
+        self.workspace_io.append_event(event)
+
+    async def append_event_router(self, event: dict[str, Any]) -> None:
+        if self.event_router is None:
+            return
+        try:
+            from omnicoreagent.core.events.base import Event, EventType
+
+            await asyncio.wait_for(
+                self.event_router.append(
+                    session_id=event.get("session_id") or event.get("run_id"),
+                    event=Event(
+                        type=EventType.BACKGROUND_AGENT_STATUS,
+                        payload={
+                            "agent_id": event.get("agent_id") or "background",
+                            "status": event["event"],
+                            "event": event["event"],
+                            "timestamp": event["timestamp"],
+                            "session_id": event.get("session_id"),
+                            "task_id": event.get("task_id"),
+                            "run_id": event.get("run_id"),
+                            "run_status": event.get("status"),
+                            "attempt": event.get("attempt"),
+                            "sequence": event.get("sequence"),
+                            "workspace_path": event.get("workspace_path"),
+                            "last_run": event.get("run_id"),
+                            "run_count": event.get("sequence"),
+                            "error": event.get("error"),
+                            "worker_id": event.get("worker_id"),
+                            "lease_generation": event.get("lease_generation"),
+                            "heartbeat_at": event.get("heartbeat_at"),
+                            "lease_expires_at": event.get("lease_expires_at"),
+                            "occurrence_id": event.get("occurrence_id"),
+                            "due_at": event.get("due_at"),
+                        },
+                        agent_name=event.get("agent_id") or "background",
+                    ),
+                ),
+                timeout=self.append_timeout_seconds,
+            )
+        except Exception:
+            return
+
+    async def read_event_router_events(self, run: BackgroundRun) -> list[dict[str, Any]]:
+        if self.event_router is None:
+            return []
+        try:
+            router_events = await asyncio.wait_for(
+                self.event_router.get_events(session_id=run.session_id),
+                timeout=self.replay_timeout_seconds,
+            )
+        except Exception:
+            return []
+
+        events: list[dict[str, Any]] = []
+        for item in router_events:
+            raw = item.model_dump() if hasattr(item, "model_dump") else dict(item)
+            payload = raw.get("payload", {})
+            if hasattr(payload, "model_dump"):
+                payload = payload.model_dump()
+            if payload.get("run_id") != run.run_id and payload.get("last_run") != run.run_id:
+                continue
+            event = {
+                "event": payload.get("event") or payload.get("status"),
+                "timestamp": payload.get("timestamp") or raw.get("timestamp"),
+                "agent_id": payload.get("agent_id"),
+                "task_id": payload.get("task_id"),
+                "run_id": payload.get("run_id") or payload.get("last_run"),
+                "session_id": payload.get("session_id"),
+                "status": payload.get("run_status"),
+                "attempt": payload.get("attempt"),
+                "sequence": payload.get("sequence") or payload.get("run_count"),
+                "workspace_path": payload.get("workspace_path"),
+                "worker_id": payload.get("worker_id"),
+                "lease_generation": payload.get("lease_generation"),
+                "heartbeat_at": payload.get("heartbeat_at"),
+                "lease_expires_at": payload.get("lease_expires_at"),
+                "occurrence_id": payload.get("occurrence_id"),
+                "due_at": payload.get("due_at"),
+            }
+            if payload.get("error"):
+                event["error"] = payload["error"]
+            events.append({key: value for key, value in event.items() if value is not None})
+
+        return sorted(
+            events,
+            key=lambda event: (
+                event.get("sequence", 0),
+                event.get("timestamp", ""),
+            ),
+        )
+
+    @staticmethod
+    def prepare_event_trace(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not events:
+            return []
+
+        normalized: list[dict[str, Any]] = []
+        seen_sequences: set[int] = set()
+        for event in events:
+            sequence = event.get("sequence")
+            if isinstance(sequence, bool) or not isinstance(sequence, int):
+                return []
+            if sequence < 1 or sequence in seen_sequences:
+                return []
+            seen_sequences.add(sequence)
+            normalized_event = dict(event)
+            normalized_event["sequence"] = sequence
+            normalized.append(normalized_event)
+
+        normalized = sorted(
+            normalized,
+            key=lambda event: (
+                event.get("sequence", 0),
+                event.get("timestamp", ""),
+            ),
+        )
+        if [event["sequence"] for event in normalized] != list(
+            range(1, len(normalized) + 1)
+        ):
+            return []
+        return normalized

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
-import json
+from datetime import timedelta
 from typing import Any
 from uuid import uuid4
 
 from omnicoreagent.core.events.base import reset_event_run_id, set_event_run_id
+from omnicoreagent.background.agent_specs import resolve_agent, spec_from_agent
 from omnicoreagent.background.errors import (
     AgentAlreadyRegisteredError,
     AgentNotFoundError,
@@ -19,27 +19,33 @@ from omnicoreagent.background.errors import (
 )
 from omnicoreagent.background.models import (
     TERMINAL_RUN_STATUSES,
-    INITIAL_EVENT_NAMES,
-    TERMINAL_EVENT_NAMES,
     AttemptReason,
     AttemptStatus,
     BackgroundAgentSpec,
     BackgroundAttempt,
     BackgroundRun,
     BackgroundTaskSpec,
-    BackoffPolicy,
     OverlapPolicy,
     RunStatus,
     ScheduleSpec,
     TriggerType,
-    build_session_id,
-    build_workspace_path,
     coerce_model,
     next_schedule_due,
     utc_now,
 )
+from omnicoreagent.background.event_log import BackgroundEventLog
+from omnicoreagent.background.run_helpers import (
+    build_run,
+    build_run_context,
+    is_run_due,
+    release_lease_patch,
+    result_preview,
+    retry_delay_seconds,
+    run_until_terminal_sleep_seconds,
+)
 from omnicoreagent.background.store.base import AbstractTaskStore
 from omnicoreagent.background.store.router import TaskStoreRouter
+from omnicoreagent.background.workspace_io import BackgroundWorkspaceIO
 
 
 _EVENT_REPLAY_TIMEOUT_SECONDS = 2.0
@@ -68,13 +74,21 @@ class BackgroundAgentManager:
         self._running = False
         self._worker_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
-        self._events: dict[str, list[dict[str, Any]]] = {}
-        self._event_sequences: dict[str, int] = {}
-        self._event_router_tasks: set[asyncio.Task] = set()
         self._inline_execution_tasks: dict[str, asyncio.Task] = {}
+        self._active_agent_tasks: dict[str, asyncio.Task] = {}
         self._event_replay_timeout_seconds = _EVENT_REPLAY_TIMEOUT_SECONDS
         self._event_append_timeout_seconds = _EVENT_APPEND_TIMEOUT_SECONDS
-        self._workspace = workspace
+        self._workspace_io = BackgroundWorkspaceIO(workspace)
+        self._event_log = BackgroundEventLog(
+            task_store=self.task_store,
+            workspace_io=self._workspace_io,
+            event_router=self.event_router,
+            replay_timeout_seconds=self._event_replay_timeout_seconds,
+            append_timeout_seconds=self._event_append_timeout_seconds,
+        )
+        self._events = self._event_log.local_events
+        self._event_sequences = self._event_log.event_sequences
+        self._event_router_tasks = self._event_log.router_tasks
         self._initialized = False
 
     async def register_agent(
@@ -84,18 +98,9 @@ class BackgroundAgentManager:
         if existing and not replace:
             raise AgentAlreadyRegisteredError(f"Agent already registered: {agent_id}")
 
-        spec = BackgroundAgentSpec(
-            agent_id=agent_id,
-            name=getattr(agent, "name", agent_id),
-            system_instruction=getattr(agent, "system_instruction", None),
-            model_config=self._safe_model_config(agent),
-            agent_config=self._safe_dict(getattr(agent, "agent_config", {})),
-            mcp_tools=self._safe_list(getattr(agent, "mcp_tools", [])),
-            workspace_config=self._safe_workspace_config(agent),
-        )
+        spec = spec_from_agent(agent_id, agent)
         self._agents[agent_id] = agent
         await self.task_store.save_agent(spec)
-        await self._emit("background_agent_registered", agent_id=agent_id)
         return spec
 
     async def register_agent_spec(
@@ -106,10 +111,9 @@ class BackgroundAgentManager:
         if existing and not replace:
             raise AgentAlreadyRegisteredError(
                 f"Agent already registered: {agent_spec.agent_id}"
-            )
+        )
         self._agents.pop(agent_spec.agent_id, None)
         await self.task_store.save_agent(agent_spec)
-        await self._emit("background_agent_registered", agent_id=agent_spec.agent_id)
         return agent_spec
 
     async def unregister_agent(self, agent_id: str, force: bool = False) -> None:
@@ -167,11 +171,6 @@ class BackgroundAgentManager:
         if await self.task_store.get_task(task.task_id) and not replace:
             raise TaskAlreadyRegisteredError(f"Task already registered: {task.task_id}")
         await self.task_store.save_task(task)
-        await self._emit(
-            "background_task_registered",
-            agent_id=task.agent_id,
-            task_id=task.task_id,
-        )
         return task
 
     async def update_task(self, task_id: str, patch: dict[str, Any]) -> BackgroundTaskSpec:
@@ -189,7 +188,6 @@ class BackgroundAgentManager:
         await self.task_store.delete_task(task_id)
         if delete_runs:
             await self.task_store.delete_runs_for_task(task_id)
-        await self._emit("background_task_deleted", task_id=task_id)
 
     async def get_task(self, task_id: str) -> BackgroundTaskSpec | None:
         return await self.task_store.get_task(task_id)
@@ -222,18 +220,17 @@ class BackgroundAgentManager:
             except asyncio.CancelledError:
                 pass
             self._worker_task = None
+        await self._cancel_active_agent_tasks()
         await self._cancel_inline_execution_tasks()
-        await self._cancel_event_router_tasks()
+        await self._event_log.cancel_router_tasks()
         await self.task_store.close()
         self._initialized = False
 
     async def pause_task(self, task_id: str) -> None:
         await self.task_store.set_schedule_paused(task_id, True)
-        await self._emit("background_task_paused", task_id=task_id)
 
     async def resume_task(self, task_id: str) -> None:
         await self.task_store.set_schedule_paused(task_id, False)
-        await self._emit("background_task_resumed", task_id=task_id)
 
     async def run_now(
         self,
@@ -245,7 +242,7 @@ class BackgroundAgentManager:
         task = await self.task_store.get_task(task_id)
         if not task or not task.enabled:
             raise TaskNotFoundError(f"Task not found: {task_id}")
-        run = self._build_run(task, TriggerType.MANUAL, query or task.query)
+        run = build_run(task, TriggerType.MANUAL, query or task.query)
         created = await self.task_store.create_run_with_overlap_guard(
             run, task.overlap_policy
         )
@@ -286,7 +283,7 @@ class BackgroundAgentManager:
             if latest.status in TERMINAL_RUN_STATUSES:
                 return latest
 
-            if latest.status == RunStatus.QUEUED and self._run_is_due(latest):
+            if latest.status == RunStatus.QUEUED and is_run_due(latest):
                 execution_task = self._get_or_start_inline_execution_task(run_id)
                 if deadline is None:
                     executed = await execution_task
@@ -317,10 +314,10 @@ class BackgroundAgentManager:
                 return latest
 
             await asyncio.sleep(
-                self._run_until_terminal_sleep_seconds(
-                    latest,
-                    deadline,
-                    poll_interval_seconds,
+                    run_until_terminal_sleep_seconds(
+                        latest,
+                        deadline,
+                        poll_interval_seconds,
                 )
             )
 
@@ -347,6 +344,16 @@ class BackgroundAgentManager:
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
         self._inline_execution_tasks.clear()
+
+    async def _cancel_active_agent_tasks(self) -> None:
+        pending = [task for task in self._active_agent_tasks.values() if not task.done()]
+        if not pending:
+            self._active_agent_tasks.clear()
+            return
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        self._active_agent_tasks.clear()
 
     async def wait_for_run(
         self,
@@ -376,26 +383,6 @@ class BackgroundAgentManager:
                 sleep_seconds = min(sleep_seconds, remaining)
             await asyncio.sleep(max(sleep_seconds, 0.001))
 
-    @staticmethod
-    def _run_is_due(run: BackgroundRun) -> bool:
-        return run.queued_at is None or run.queued_at <= utc_now()
-
-    @staticmethod
-    def _run_until_terminal_sleep_seconds(
-        run: BackgroundRun,
-        deadline: float | None,
-        poll_interval_seconds: float,
-    ) -> float:
-        interval = poll_interval_seconds
-        if run.queued_at is not None:
-            delay = (run.queued_at - utc_now()).total_seconds()
-            if delay > 0:
-                interval = min(interval, delay)
-        if deadline is not None:
-            remaining = deadline - asyncio.get_running_loop().time()
-            interval = min(interval, max(remaining, 0))
-        return max(interval, 0.001)
-
     async def cancel_run(self, run_id: str) -> None:
         run = await self.task_store.get_run(run_id)
         if not run:
@@ -411,6 +398,10 @@ class BackgroundAgentManager:
             and latest.lease_owner == self.worker_id
         ):
             await self._mark_terminal(latest, RunStatus.CANCELLED, "cancelled")
+        elif latest.status == RunStatus.RUNNING and latest.lease_owner == self.worker_id:
+            active_task = self._active_agent_tasks.get(run_id)
+            if active_task is not None and not active_task.done():
+                active_task.cancel()
 
     async def recover_expired_runs(self) -> None:
         expired = await self.task_store.list_expired_leases(utc_now())
@@ -452,7 +443,7 @@ class BackgroundAgentManager:
                 stolen.run_id,
                 {RunStatus.CLAIMED},
                 RunStatus.QUEUED,
-                self._release_lease_patch(),
+                release_lease_patch(),
                 self.worker_id,
                 stolen.lease_token,
             )
@@ -475,7 +466,7 @@ class BackgroundAgentManager:
                 retrying.run_id,
                 {RunStatus.RETRYING},
                 RunStatus.QUEUED,
-                self._release_lease_patch(),
+                release_lease_patch(),
                 self.worker_id,
                 retrying.lease_token,
             )
@@ -521,27 +512,8 @@ class BackgroundAgentManager:
         run = await self.task_store.get_run(run_id)
         if not run:
             return []
-        await self._drain_event_router_tasks(run_id)
-        events = self._prepare_event_trace(self._events.get(run_id) or [])
-        workspace_events = self._prepare_event_trace(
-            self._read_workspace_events(run.workspace_path)
-        )
-        router_events = self._prepare_event_trace(
-            await self._read_event_router_events(run)
-        )
-        candidates = [router_events, events, workspace_events]
-        complete = [
-            candidate
-            for candidate in candidates
-            if candidate and candidate[-1].get("event") in TERMINAL_EVENT_NAMES
-        ]
-        if complete:
-            return max(complete, key=len)
-        if router_events:
-            return router_events
-        if events:
-            return events
-        return workspace_events
+        self._sync_event_log_config()
+        return await self._event_log.get_run_events(run)
 
     async def get_run_workspace(self, run_id: str) -> dict[str, Any]:
         """Return the durable workspace location and visible files for a run."""
@@ -549,32 +521,19 @@ class BackgroundAgentManager:
         if not run:
             raise RunNotFoundError(f"Run not found: {run_id}")
 
-        workspace = self._resolve_workspace()
-        files = []
-        if workspace is not None:
-            for item in workspace.files.list_files(run.workspace_path):
-                files.append(
-                    {
-                        "path": item.path,
-                        "name": item.name,
-                        "modified_at": item.modified_at.isoformat(),
-                        "is_dir": item.is_dir,
-                    }
-                )
-
-        return {
-            "run_id": run.run_id,
-            "task_id": run.task_id,
-            "agent_id": run.agent_id,
-            "workspace_path": run.workspace_path,
-            "files": files,
-        }
+        return self._workspace_io.run_files(run)
 
     async def _worker_loop(self) -> None:
         while not self._stop_event.is_set():
-            await self.recover_expired_runs()
-            dispatched = await self._dispatch_due_schedules()
-            did_work = await self._execute_one()
+            try:
+                await self.recover_expired_runs()
+                dispatched = await self._dispatch_due_schedules()
+                did_work = await self._execute_one()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                dispatched = False
+                did_work = False
             if not dispatched and not did_work:
                 await asyncio.sleep(0.05)
 
@@ -585,7 +544,7 @@ class BackgroundAgentManager:
             if state.next_due_at is None:
                 continue
             trigger = TriggerType(task.schedule.type.value)
-            run = self._build_run(
+            run = build_run(
                 task,
                 trigger,
                 task.query,
@@ -664,7 +623,7 @@ class BackgroundAgentManager:
             latest.run_id,
             {RunStatus.CLAIMED},
             RunStatus.QUEUED,
-            self._release_lease_patch(),
+            release_lease_patch(),
             self.worker_id,
             latest.lease_token,
         )
@@ -675,7 +634,13 @@ class BackgroundAgentManager:
         if not task:
             await self._mark_terminal(claimed, RunStatus.FAILED, "task missing")
             return
-        agent = await self._resolve_agent(claimed.agent_id)
+        agent = await resolve_agent(
+            agent_id=claimed.agent_id,
+            agents=self._agents,
+            task_store=self.task_store,
+            memory_router=self.memory_router,
+            event_router=self.event_router,
+        )
         if agent is None:
             await self._mark_terminal(claimed, RunStatus.FAILED, "agent missing")
             return
@@ -696,6 +661,10 @@ class BackgroundAgentManager:
             self.worker_id,
             claimed.lease_token,
         )
+        if run.lease_token is not None:
+            if not await self._refresh_run_lease(run.run_id, run.lease_token):
+                return
+            run = await self.task_store.get_run(run.run_id) or run
         attempt = BackgroundAttempt(
             run_id=run.run_id,
             attempt_number=attempt_number,
@@ -704,6 +673,19 @@ class BackgroundAgentManager:
             lease_token=run.lease_token,
         )
         await self.task_store.create_attempt(attempt)
+        if await self.task_store.is_cancel_requested(run.run_id):
+            await self.task_store.update_attempt(
+                attempt.attempt_id,
+                {
+                    "status": AttemptStatus.CANCELLED,
+                    "finished_at": utc_now(),
+                    "error": "cancelled",
+                },
+                self.worker_id,
+                run.lease_token,
+            )
+            await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
+            return
         heartbeat_task = asyncio.create_task(
             self._heartbeat_until_finished(run.run_id, run.lease_token)
         )
@@ -711,19 +693,50 @@ class BackgroundAgentManager:
         await self._emit_run("background_run_started", run)
 
         try:
-            query = self._build_run_context(run)
-            result = await self._run_agent_with_event_context(
-                agent=agent,
-                query=query,
-                run=run,
-                timeout_seconds=task.timeout_seconds,
+            if await self.task_store.is_cancel_requested(run.run_id):
+                await self.task_store.update_attempt(
+                    attempt.attempt_id,
+                    {
+                        "status": AttemptStatus.CANCELLED,
+                        "finished_at": utc_now(),
+                        "error": "cancelled",
+                    },
+                    self.worker_id,
+                    run.lease_token,
+                )
+                await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
+                return
+            query = build_run_context(run)
+            agent_task = asyncio.create_task(
+                self._run_agent_with_event_context(
+                    agent=agent,
+                    query=query,
+                    run=run,
+                    timeout_seconds=task.timeout_seconds,
+                )
             )
+            self._active_agent_tasks[run.run_id] = agent_task
+            result = await agent_task
         except asyncio.CancelledError:
             try:
+                if await self.task_store.is_cancel_requested(run.run_id):
+                    await self.task_store.update_attempt(
+                        attempt.attempt_id,
+                        {
+                            "status": AttemptStatus.CANCELLED,
+                            "finished_at": utc_now(),
+                            "error": "cancelled",
+                        },
+                        self.worker_id,
+                        run.lease_token,
+                    )
+                    await self._mark_terminal(run, RunStatus.CANCELLED, "cancelled")
+                    return
                 await self._handle_attempt_failure(
                     task, run, attempt, "exception", RuntimeError("worker shutdown")
                 )
             finally:
+                self._active_agent_tasks.pop(run.run_id, None)
                 heartbeat_task.cancel()
                 await self._drain_cancelled_task(heartbeat_task)
             raise
@@ -731,6 +744,7 @@ class BackgroundAgentManager:
             try:
                 await self._handle_attempt_failure(task, run, attempt, "timeout", exc)
             finally:
+                self._active_agent_tasks.pop(run.run_id, None)
                 heartbeat_task.cancel()
                 await self._drain_cancelled_task(heartbeat_task)
             return
@@ -738,12 +752,13 @@ class BackgroundAgentManager:
             try:
                 await self._handle_attempt_failure(task, run, attempt, "exception", exc)
             finally:
+                self._active_agent_tasks.pop(run.run_id, None)
                 heartbeat_task.cancel()
                 await self._drain_cancelled_task(heartbeat_task)
             return
 
         try:
-            preview = self._result_preview(result)
+            preview = result_preview(result)
             if await self.task_store.is_cancel_requested(run.run_id):
                 if run.lease_token is not None:
                     if not await self._refresh_run_lease(run.run_id, run.lease_token):
@@ -782,6 +797,7 @@ class BackgroundAgentManager:
             )
             await self._emit_run("background_run_completed", completed)
         finally:
+            self._active_agent_tasks.pop(run.run_id, None)
             heartbeat_task.cancel()
             await self._drain_cancelled_task(heartbeat_task)
 
@@ -827,13 +843,13 @@ class BackgroundAgentManager:
             and run.attempt <= task.retry_policy.max_retries
         )
         if can_retry:
-            retry_delay_seconds = self._retry_delay_seconds(task, run.attempt)
+            retry_delay = retry_delay_seconds(task, run.attempt)
             if run.lease_token is not None:
                 if not await self._refresh_run_lease(run.run_id, run.lease_token):
                     return
             await self.task_store.update_attempt(
                 attempt.attempt_id,
-                {"retry_delay_seconds": retry_delay_seconds},
+                {"retry_delay_seconds": retry_delay},
                 self.worker_id,
                 run.lease_token,
             )
@@ -854,8 +870,8 @@ class BackgroundAgentManager:
                 {RunStatus.RETRYING},
                 RunStatus.QUEUED,
                 {
-                    **self._release_lease_patch(),
-                    "queued_at": utc_now() + timedelta(seconds=retry_delay_seconds),
+                    **release_lease_patch(),
+                    "queued_at": utc_now() + timedelta(seconds=retry_delay),
                 },
                 self.worker_id,
                 retrying.lease_token,
@@ -918,439 +934,58 @@ class BackgroundAgentManager:
         except asyncio.CancelledError:
             pass
 
-    def _retry_delay_seconds(self, task: BackgroundTaskSpec, attempt_number: int) -> int:
-        policy = task.retry_policy
-        if policy.max_retries <= 0:
-            return 0
-        if policy.backoff == BackoffPolicy.EXPONENTIAL:
-            delay = policy.initial_delay_seconds * (2 ** max(attempt_number - 1, 0))
-        else:
-            delay = policy.initial_delay_seconds
-        return min(delay, policy.max_delay_seconds)
-
-    @staticmethod
-    def _release_lease_patch() -> dict[str, Any]:
-        return {
-            "lease_owner": None,
-            "lease_token": None,
-            "lease_expires_at": None,
-        }
-
-    def _build_run(
-        self,
-        task: BackgroundTaskSpec,
-        trigger: TriggerType,
-        query: str,
-        due_at: datetime | None = None,
-        occurrence_id: str | None = None,
-    ) -> BackgroundRun:
-        run_id = f"run_{uuid4().hex}"
-        return BackgroundRun(
-            run_id=run_id,
-            task_id=task.task_id,
-            agent_id=task.agent_id,
-            max_attempts=task.retry_policy.max_retries + 1,
-            query_snapshot=query,
-            trigger_type=trigger,
-            due_at=due_at,
-            occurrence_id=occurrence_id,
-            session_id=build_session_id(task, run_id),
-            workspace_path=build_workspace_path(task, run_id),
-        )
-
-    def _build_run_context(self, run: BackgroundRun) -> str:
-        return (
-            "This is a background run.\n"
-            f"run_id: {run.run_id}\n"
-            f"task_id: {run.task_id}\n"
-            f"workspace_path: /workspace/{run.workspace_path}\n"
-            "Use output.md for the final durable result.\n\n"
-            f"{run.query_snapshot}"
-        )
-
     async def _resolve_agent(self, agent_id: str) -> Any | None:
-        agent = self._agents.get(agent_id)
-        if agent is not None:
-            return agent
-        spec = await self.task_store.get_agent(agent_id)
-        if not spec or not spec.llm_model_config:
-            return None
-
-        from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent
-
-        agent = OmniCoreAgent(
-            name=spec.name or spec.agent_id,
-            system_instruction=spec.system_instruction or "",
-            model_config=spec.llm_model_config,
-            mcp_tools=spec.mcp_tools,
-            agent_config={
-                **spec.agent_config,
-                **(
-                    {"workspace_config": spec.workspace_config}
-                    if spec.workspace_config
-                    else {}
-                ),
-            },
+        return await resolve_agent(
+            agent_id=agent_id,
+            agents=self._agents,
+            task_store=self.task_store,
             memory_router=self.memory_router,
             event_router=self.event_router,
         )
-        self._agents[agent_id] = agent
-        return agent
 
     async def _emit_run(
         self, event_name: str, run: BackgroundRun, **extra_payload: Any
     ) -> None:
-        try:
-            await self._emit(
-                event_name,
-                agent_id=run.agent_id,
-                task_id=run.task_id,
-                run_id=run.run_id,
-                session_id=run.session_id,
-                status=run.status.value,
-                attempt=run.attempt,
-                workspace_path=run.workspace_path,
-                worker_id=run.lease_owner,
-                lease_generation=run.lease_generation,
-                heartbeat_at=run.heartbeat_at.isoformat() if run.heartbeat_at else None,
-                lease_expires_at=(
-                    run.lease_expires_at.isoformat() if run.lease_expires_at else None
-                ),
-                occurrence_id=run.occurrence_id,
-                due_at=run.due_at.isoformat() if run.due_at else None,
-                **extra_payload,
-            )
-        except Exception:
-            pass
-        if event_name != "background_run_heartbeat":
-            try:
-                await self._write_run_snapshot(run)
-            except Exception:
-                pass
+        self._sync_event_log_config()
+        await self._event_log.emit_run(event_name, run, **extra_payload)
 
     async def _emit(self, event_name: str, **payload: Any) -> None:
-        run_id = payload.get("run_id")
-        event = {
-            "event": event_name,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            **payload,
-        }
-        if run_id:
-            events = self._events.setdefault(run_id, [])
-            event["sequence"] = await self._next_run_event_sequence(
-                run_id, event_name, events
-            )
-            events.append(event)
-            if event_name in INITIAL_EVENT_NAMES:
-                try:
-                    await self._write_run_event(event)
-                except Exception:
-                    pass
-                if self.event_router is not None:
-                    self._schedule_event_router_task(
-                        self._append_event_router(event), event
-                    )
-                return
-            self._schedule_event_router_task(self._write_and_route_event(event), event)
-
-    async def _write_and_route_event(self, event: dict[str, Any]) -> None:
-        try:
-            await self._write_run_event(event)
-        except Exception:
-            pass
-        await self._append_event_router(event)
-
-    def _schedule_event_router_task(
-        self, coroutine, event: dict[str, Any]
-    ) -> None:
-        task = asyncio.create_task(coroutine)
-        task._omnicoreagent_run_id = event.get("run_id")  # type: ignore[attr-defined]
-        self._event_router_tasks.add(task)
-        task.add_done_callback(self._event_router_tasks.discard)
+        self._sync_event_log_config()
+        await self._event_log.emit(event_name, **payload)
 
     async def _drain_event_router_tasks(self, run_id: str) -> None:
-        pending = [
-            task
-            for task in self._event_router_tasks
-            if not task.done()
-            and getattr(task, "_omnicoreagent_run_id", None) == run_id
-        ]
-        if not pending:
-            return
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*pending, return_exceptions=True),
-                timeout=self._event_replay_timeout_seconds,
-            )
-        except asyncio.TimeoutError:
-            return
+        self._sync_event_log_config()
+        await self._event_log.drain_router_tasks(run_id)
 
     async def _cancel_event_router_tasks(self) -> None:
-        pending = [task for task in self._event_router_tasks if not task.done()]
-        if not pending:
-            self._event_router_tasks.clear()
-            return
-        for task in pending:
-            task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
-        self._event_router_tasks.clear()
-
-    async def _next_run_event_sequence(
-        self, run_id: str, event_name: str, local_events: list[dict[str, Any]]
-    ) -> int:
-        cached = self._event_sequences.get(run_id)
-        if cached is not None:
-            self._event_sequences[run_id] = cached + 1
-            return cached + 1
-        sequences = [
-            int(event["sequence"])
-            for event in local_events
-            if isinstance(event.get("sequence"), int)
-        ]
-        if sequences:
-            next_sequence = max(sequences) + 1
-            self._event_sequences[run_id] = next_sequence
-            return next_sequence
-        if event_name in INITIAL_EVENT_NAMES:
-            self._event_sequences[run_id] = 1
-            return 1
-
-        run = await self.task_store.get_run(run_id)
-        if run:
-            for source in (
-                await self._read_event_router_events(run),
-                self._read_workspace_events(run.workspace_path),
-            ):
-                sequences.extend(
-                    int(event["sequence"])
-                    for event in source
-                    if isinstance(event.get("sequence"), int)
-                )
-        next_sequence = (max(sequences) if sequences else 0) + 1
-        self._event_sequences[run_id] = next_sequence
-        return next_sequence
+        self._sync_event_log_config()
+        await self._event_log.cancel_router_tasks()
 
     async def _write_run_snapshot(self, run: BackgroundRun) -> None:
-        task = await self.task_store.get_task(run.task_id)
-        if task and not task.workspace_policy.write_run_json:
-            return
-        workspace = self._resolve_workspace()
-        if workspace is None:
-            return
-        workspace.files.write_text(
-            f"{run.workspace_path}/run.json",
-            run.model_dump_json(indent=2),
-        )
+        await self._event_log.write_run_snapshot(run)
 
     async def _write_run_event(self, event: dict[str, Any]) -> None:
-        workspace_path = event.get("workspace_path")
-        if not workspace_path:
-            return
-        task_id = event.get("task_id")
-        if task_id:
-            task = await self.task_store.get_task(task_id)
-            if task and not task.workspace_policy.write_events_jsonl:
-                return
-        workspace = self._resolve_workspace()
-        if workspace is None:
-            return
-        workspace.files.append_text(
-            f"{workspace_path}/events.jsonl",
-            json.dumps(event, default=str),
-        )
+        await self._event_log.write_run_event(event)
 
     async def _append_event_router(self, event: dict[str, Any]) -> None:
-        if self.event_router is None:
-            return
-        try:
-            from omnicoreagent.core.events.base import Event, EventType
-
-            await asyncio.wait_for(
-                self.event_router.append(
-                    session_id=event.get("session_id") or event.get("run_id"),
-                    event=Event(
-                        type=EventType.BACKGROUND_AGENT_STATUS,
-                        payload={
-                            "agent_id": event.get("agent_id") or "background",
-                            "status": event["event"],
-                            "event": event["event"],
-                            "timestamp": event["timestamp"],
-                            "session_id": event.get("session_id"),
-                            "task_id": event.get("task_id"),
-                            "run_id": event.get("run_id"),
-                            "run_status": event.get("status"),
-                            "attempt": event.get("attempt"),
-                            "sequence": event.get("sequence"),
-                            "workspace_path": event.get("workspace_path"),
-                            "last_run": event.get("run_id"),
-                            "run_count": event.get("sequence"),
-                            "error": event.get("error"),
-                            "worker_id": event.get("worker_id"),
-                            "lease_generation": event.get("lease_generation"),
-                            "heartbeat_at": event.get("heartbeat_at"),
-                            "lease_expires_at": event.get("lease_expires_at"),
-                            "occurrence_id": event.get("occurrence_id"),
-                            "due_at": event.get("due_at"),
-                        },
-                        agent_name=event.get("agent_id") or "background",
-                    ),
-                ),
-                timeout=self._event_append_timeout_seconds,
-            )
-        except Exception:
-            return
+        self._sync_event_log_config()
+        await self._event_log.append_event_router(event)
 
     async def _read_event_router_events(self, run: BackgroundRun) -> list[dict[str, Any]]:
-        if self.event_router is None:
-            return []
-        try:
-            router_events = await asyncio.wait_for(
-                self.event_router.get_events(session_id=run.session_id),
-                timeout=self._event_replay_timeout_seconds,
-            )
-        except Exception:
-            return []
-
-        events: list[dict[str, Any]] = []
-        for item in router_events:
-            raw = item.model_dump() if hasattr(item, "model_dump") else dict(item)
-            payload = raw.get("payload", {})
-            if hasattr(payload, "model_dump"):
-                payload = payload.model_dump()
-            if payload.get("run_id") != run.run_id and payload.get("last_run") != run.run_id:
-                continue
-            event = {
-                "event": payload.get("event") or payload.get("status"),
-                "timestamp": payload.get("timestamp") or raw.get("timestamp"),
-                "agent_id": payload.get("agent_id"),
-                "task_id": payload.get("task_id"),
-                "run_id": payload.get("run_id") or payload.get("last_run"),
-                "session_id": payload.get("session_id"),
-                "status": payload.get("run_status"),
-                "attempt": payload.get("attempt"),
-                "sequence": payload.get("sequence") or payload.get("run_count"),
-                "workspace_path": payload.get("workspace_path"),
-                "worker_id": payload.get("worker_id"),
-                "lease_generation": payload.get("lease_generation"),
-                "heartbeat_at": payload.get("heartbeat_at"),
-                "lease_expires_at": payload.get("lease_expires_at"),
-                "occurrence_id": payload.get("occurrence_id"),
-                "due_at": payload.get("due_at"),
-            }
-            if payload.get("error"):
-                event["error"] = payload["error"]
-            events.append({key: value for key, value in event.items() if value is not None})
-
-        return sorted(
-            events,
-            key=lambda event: (
-                event.get("sequence", 0),
-                event.get("timestamp", ""),
-            ),
-        )
+        self._sync_event_log_config()
+        return await self._event_log.read_event_router_events(run)
 
     @staticmethod
     def _prepare_event_trace(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        if not events:
-            return []
-
-        normalized: list[dict[str, Any]] = []
-        seen_sequences: set[int] = set()
-        for event in events:
-            sequence = event.get("sequence")
-            if isinstance(sequence, bool) or not isinstance(sequence, int):
-                return []
-            if sequence < 1 or sequence in seen_sequences:
-                return []
-            seen_sequences.add(sequence)
-            normalized_event = dict(event)
-            normalized_event["sequence"] = sequence
-            normalized.append(normalized_event)
-
-        normalized = sorted(
-            normalized,
-            key=lambda event: (
-                event.get("sequence", 0),
-                event.get("timestamp", ""),
-            ),
-        )
-        if [event["sequence"] for event in normalized] != list(
-            range(1, len(normalized) + 1)
-        ):
-            return []
-        return normalized
+        return BackgroundEventLog.prepare_event_trace(events)
 
     def _resolve_workspace(self) -> Any | None:
-        if self._workspace is not None:
-            return self._workspace
-        try:
-            from omnicoreagent.core.workspace.manager import Workspace
-
-            self._workspace = Workspace.from_config().ensure()
-        except Exception:
-            self._workspace = None
-        return self._workspace
+        return self._workspace_io.resolve()
 
     def _read_workspace_events(self, workspace_path: str) -> list[dict[str, Any]]:
-        workspace = self._resolve_workspace()
-        if workspace is None:
-            return []
-        try:
-            content = workspace.files.read_text(f"{workspace_path}/events.jsonl")
-        except Exception:
-            return []
-        events: list[dict[str, Any]] = []
-        for line in content.splitlines():
-            if not line.strip():
-                continue
-            try:
-                events.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-        return events
+        return self._workspace_io.read_events(workspace_path)
 
-    @staticmethod
-    def _result_preview(result: Any) -> str:
-        if isinstance(result, dict) and "response" in result:
-            return str(result["response"])[:1000]
-        return str(result)[:1000]
-
-    @staticmethod
-    def _safe_model_config(agent: Any) -> dict[str, Any] | None:
-        value = getattr(agent, "model_config", None)
-        if hasattr(value, "model_dump"):
-            return value.model_dump()
-        return value if isinstance(value, dict) else None
-
-    @staticmethod
-    def _safe_dict(value: Any) -> dict[str, Any]:
-        if hasattr(value, "model_dump"):
-            return value.model_dump()
-        return value if isinstance(value, dict) else {}
-
-    @staticmethod
-    def _safe_list(value: Any) -> list[Any]:
-        if value is None:
-            return []
-        if isinstance(value, list):
-            safe_values = []
-            for item in value:
-                if hasattr(item, "model_dump"):
-                    safe_values.append(item.model_dump())
-                elif isinstance(item, dict):
-                    safe_values.append(item)
-            return safe_values
-        return []
-
-    @staticmethod
-    def _safe_workspace_config(agent: Any) -> dict[str, Any] | None:
-        config = getattr(agent, "agent_config", None)
-        if hasattr(config, "model_dump"):
-            config = config.model_dump()
-        if isinstance(config, dict):
-            workspace_config = config.get("workspace_config")
-            if hasattr(workspace_config, "model_dump"):
-                return workspace_config.model_dump()
-            if isinstance(workspace_config, dict):
-                return workspace_config
-        return None
+    def _sync_event_log_config(self) -> None:
+        self._event_log.event_router = self.event_router
+        self._event_log.replay_timeout_seconds = self._event_replay_timeout_seconds
+        self._event_log.append_timeout_seconds = self._event_append_timeout_seconds

--- a/src/omnicoreagent/background/run_helpers.py
+++ b/src/omnicoreagent/background/run_helpers.py
@@ -1,0 +1,96 @@
+"""Run construction and lifecycle helpers for background execution."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from omnicoreagent.background.models import (
+    BackgroundRun,
+    BackgroundTaskSpec,
+    BackoffPolicy,
+    TriggerType,
+    build_session_id,
+    build_workspace_path,
+    utc_now,
+)
+
+
+def build_run(
+    task: BackgroundTaskSpec,
+    trigger: TriggerType,
+    query: str,
+    due_at: datetime | None = None,
+    occurrence_id: str | None = None,
+) -> BackgroundRun:
+    run_id = f"run_{uuid4().hex}"
+    return BackgroundRun(
+        run_id=run_id,
+        task_id=task.task_id,
+        agent_id=task.agent_id,
+        max_attempts=task.retry_policy.max_retries + 1,
+        query_snapshot=query,
+        trigger_type=trigger,
+        due_at=due_at,
+        occurrence_id=occurrence_id,
+        session_id=build_session_id(task, run_id),
+        workspace_path=build_workspace_path(task, run_id),
+    )
+
+
+def build_run_context(run: BackgroundRun) -> str:
+    return (
+        "This is a background run.\n"
+        f"run_id: {run.run_id}\n"
+        f"task_id: {run.task_id}\n"
+        f"workspace_path: /workspace/{run.workspace_path}\n"
+        "Use output.md for the final durable result.\n\n"
+        f"{run.query_snapshot}"
+    )
+
+
+def is_run_due(run: BackgroundRun) -> bool:
+    return run.queued_at is None or run.queued_at <= utc_now()
+
+
+def run_until_terminal_sleep_seconds(
+    run: BackgroundRun,
+    deadline: float | None,
+    poll_interval_seconds: float,
+) -> float:
+    interval = poll_interval_seconds
+    if run.queued_at is not None:
+        delay = (run.queued_at - utc_now()).total_seconds()
+        if delay > 0:
+            interval = min(interval, delay)
+    if deadline is not None:
+        remaining = deadline - asyncio.get_running_loop().time()
+        interval = min(interval, max(remaining, 0))
+    return max(interval, 0.001)
+
+
+def retry_delay_seconds(task: BackgroundTaskSpec, attempt_number: int) -> int:
+    policy = task.retry_policy
+    if policy.max_retries <= 0:
+        return 0
+    if policy.backoff == BackoffPolicy.EXPONENTIAL:
+        delay = policy.initial_delay_seconds * (2 ** max(attempt_number - 1, 0))
+    else:
+        delay = policy.initial_delay_seconds
+    return min(delay, policy.max_delay_seconds)
+
+
+def release_lease_patch() -> dict[str, Any]:
+    return {
+        "lease_owner": None,
+        "lease_token": None,
+        "lease_expires_at": None,
+    }
+
+
+def result_preview(result: Any) -> str:
+    if isinstance(result, dict) and "response" in result:
+        return str(result["response"])[:1000]
+    return str(result)[:1000]

--- a/src/omnicoreagent/background/workspace_io.py
+++ b/src/omnicoreagent/background/workspace_io.py
@@ -1,0 +1,95 @@
+"""Workspace IO boundary for background execution."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from omnicoreagent.background.errors import RunNotFoundError
+from omnicoreagent.background.models import BackgroundRun
+
+
+class BackgroundWorkspaceIO:
+    """Small adapter around workspace storage used by background runs."""
+
+    def __init__(self, workspace: Any = None) -> None:
+        self._workspace = workspace
+
+    def resolve(self) -> Any | None:
+        if self._workspace is not None:
+            return self._workspace
+        try:
+            from omnicoreagent.core.workspace.manager import Workspace
+
+            self._workspace = Workspace.from_config().ensure()
+        except Exception:
+            self._workspace = None
+        return self._workspace
+
+    def run_files(self, run: BackgroundRun | None) -> dict[str, Any]:
+        if run is None:
+            raise RunNotFoundError("Run not found")
+
+        workspace = self.resolve()
+        files = []
+        if workspace is not None:
+            try:
+                workspace_files = workspace.files.list_files(run.workspace_path)
+            except Exception:
+                workspace_files = []
+            for item in workspace_files:
+                files.append(
+                    {
+                        "path": item.path,
+                        "name": item.name,
+                        "modified_at": item.modified_at.isoformat(),
+                        "is_dir": item.is_dir,
+                    }
+                )
+
+        return {
+            "run_id": run.run_id,
+            "task_id": run.task_id,
+            "agent_id": run.agent_id,
+            "workspace_path": run.workspace_path,
+            "files": files,
+        }
+
+    def read_events(self, workspace_path: str) -> list[dict[str, Any]]:
+        workspace = self.resolve()
+        if workspace is None:
+            return []
+        try:
+            content = workspace.files.read_text(f"{workspace_path}/events.jsonl")
+        except Exception:
+            return []
+        events: list[dict[str, Any]] = []
+        for line in content.splitlines():
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return events
+
+    def write_run_snapshot(self, run: BackgroundRun) -> None:
+        workspace = self.resolve()
+        if workspace is None:
+            return
+        workspace.files.write_text(
+            f"{run.workspace_path}/run.json",
+            run.model_dump_json(indent=2),
+        )
+
+    def append_event(self, event: dict[str, Any]) -> None:
+        workspace_path = event.get("workspace_path")
+        if not workspace_path:
+            return
+        workspace = self.resolve()
+        if workspace is None:
+            return
+        workspace.files.append_text(
+            f"{workspace_path}/events.jsonl",
+            json.dumps(event, default=str),
+        )

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -402,6 +402,19 @@ class CountingEventRouter(EventRouter):
         return await super().get_events(session_id)
 
 
+class CancellingAttemptStore(InMemoryTaskStore):
+    async def create_attempt(self, attempt):
+        await super().create_attempt(attempt)
+        await self.request_cancel(attempt.run_id)
+
+
+class CancelOnStartedManager(BackgroundAgentManager):
+    async def _emit_run(self, event_name, run, **extra_payload):
+        await super()._emit_run(event_name, run, **extra_payload)
+        if event_name == "background_run_started":
+            await self.cancel_run(run.run_id)
+
+
 async def wait_for(predicate, timeout=1.0):
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
@@ -1395,6 +1408,121 @@ async def test_long_running_background_run_emits_heartbeat_events():
     assert all(event["heartbeat_at"] for event in heartbeats)
     assert all(event["lease_expires_at"] for event in heartbeats)
     assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_same_worker_stops_active_agent_task():
+    manager = BackgroundAgentManager(task_store="in_memory", lease_seconds=1)
+    agent = FakeAgent(response="complete", delay=60)
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    await manager.start()
+    try:
+        queued = await manager.run_now("task")
+        running = await wait_for(
+            lambda: manager.get_run(queued.run_id),
+            timeout=1.0,
+        )
+        while running.status != RunStatus.RUNNING:
+            await asyncio.sleep(0.01)
+            running = await manager.get_run(queued.run_id)
+
+        await manager.cancel_run(queued.run_id)
+        terminal = await manager.wait_for_run(queued.run_id, timeout_seconds=1)
+        attempts = await manager.list_attempts(queued.run_id)
+
+        assert terminal.status == RunStatus.CANCELLED
+        assert attempts[-1].status == AttemptStatus.CANCELLED
+        assert queued.run_id not in manager._active_agent_tasks
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancel_requested_before_agent_task_starts_marks_cancelled():
+    store = CancellingAttemptStore()
+    manager = BackgroundAgentManager(task_store=store, lease_seconds=1)
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    queued = await manager.run_now("task")
+    did_work = await manager._execute_run(queued.run_id)
+    latest = await manager.get_run(queued.run_id)
+    attempts = await manager.list_attempts(queued.run_id)
+
+    assert did_work is True
+    assert latest.status == RunStatus.CANCELLED
+    assert attempts[-1].status == AttemptStatus.CANCELLED
+    assert agent.calls == []
+    assert queued.run_id not in manager._active_agent_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_start_event_before_agent_task_starts_marks_cancelled():
+    manager = CancelOnStartedManager(task_store="in_memory", lease_seconds=1)
+    agent = FakeAgent(response="complete")
+    await manager.register_agent("agent", agent)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    queued = await manager.run_now("task")
+    did_work = await manager._execute_run(queued.run_id)
+    latest = await manager.get_run(queued.run_id)
+    attempts = await manager.list_attempts(queued.run_id)
+
+    assert did_work is True
+    assert latest.status == RunStatus.CANCELLED
+    assert attempts[-1].status == AttemptStatus.CANCELLED
+    assert agent.calls == []
+    assert queued.run_id not in manager._active_agent_tasks
+
+
+@pytest.mark.asyncio
+async def test_worker_loop_survives_transient_iteration_failure():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    original_recover = manager.recover_expired_runs
+    failures_left = 1
+
+    async def flaky_recover():
+        nonlocal failures_left
+        if failures_left:
+            failures_left -= 1
+            raise RuntimeError("transient store failure")
+        await original_recover()
+
+    manager.recover_expired_runs = flaky_recover
+    await manager.start()
+    try:
+        queued = await manager.run_now("task")
+        completed = await manager.wait_for_run(queued.run_id, timeout_seconds=2)
+
+        assert completed.status == RunStatus.COMPLETED
+        assert manager._worker_task is not None
+        assert not manager._worker_task.done()
+    finally:
+        await manager.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/test_import_startup.py
+++ b/tests/test_import_startup.py
@@ -307,10 +307,14 @@ def test_background_import_does_not_load_backend_clients(tmp_path):
 import json
 import sys
 
-from omnicoreagent.background import TaskStoreRouter
+from omnicoreagent import MongoDbTaskStore, RedisTaskStore, TaskStoreRouter
+from omnicoreagent.background import TaskStoreRouter as BackgroundTaskStoreRouter
 
 print(json.dumps({
     "router": TaskStoreRouter.__name__,
+    "background_router": BackgroundTaskStoreRouter.__name__,
+    "redis_store": RedisTaskStore.__name__,
+    "mongodb_store": MongoDbTaskStore.__name__,
     "redis_loaded": "redis" in sys.modules or "redis.asyncio" in sys.modules,
     "motor_loaded": "motor" in sys.modules or "motor.motor_asyncio" in sys.modules,
     "pymongo_loaded": "pymongo" in sys.modules,
@@ -320,6 +324,9 @@ print(json.dumps({
 
     assert result == {
         "router": "TaskStoreRouter",
+        "background_router": "TaskStoreRouter",
+        "redis_store": "RedisTaskStore",
+        "mongodb_store": "MongoDbTaskStore",
         "redis_loaded": False,
         "motor_loaded": False,
         "pymongo_loaded": False,


### PR DESCRIPTION
## Summary
- split background manager concerns into focused services for agent specs, run helpers, lifecycle event logging, and workspace IO
- harden background execution with active same-worker cancellation, cancellation race checks before agent task start, worker-loop crash containment, non-destructive event drain, and failure-safe workspace listing
- align background architecture/spec docs with shipped behavior and simplify event backend wording
- expose RedisTaskStore and MongoDbTaskStore consistently from the root package without loading backend clients

## Verification
- uv run pytest -q => 622 passed
- uv run pytest tests/test_background_agent.py tests/test_omniserve_background.py tests/test_import_startup.py tests/test_events.py tests/test_omniserve_sse.py -q => 125 passed
- uv run pytest race/import targeted tests => 4 passed
- uv run ruff check src tests => All checks passed
- git diff --cached --check => passed

## Review
- Architecture, QA, and developer-experience subagents reviewed the work.
- Reviewer findings fixed: untracked service modules, no-op non-run emits, active cancellation race, worker-loop crash boundary, workspace IO failure handling, event drain cancellation, doc wording, and root export symmetry.
- Final staged-diff reviewer reported no blocking issues.