### PR TITLE
Extract background run recovery service

### DIFF
--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -55,7 +55,8 @@ over smaller services:
 | `BackgroundEventLog` | Lifecycle event ordering, workspace persistence, event-router fanout, replay |
 | `BackgroundWorkspaceIO` | Background workspace file reads and writes |
 | `BackgroundScheduleDispatcher` | Convert due schedules into durable queued or skipped runs |
-| `BackgroundSupervisor` | Claim, attempt lifecycle, execution, heartbeat, cancel, retry, timeout, and recover runs |
+| `BackgroundSupervisor` | Claim, attempt lifecycle, execution, heartbeat, cancel, retry, and timeout runs |
+| `BackgroundRunRecovery` | Expired lease recovery, abandoned attempt closure, and recovery requeue/failure decisions |
 | `BackgroundRunTransitions` | Lease refresh, terminal writes, cancelled-attempt writes, and cancellation-aware progress transitions |
 | `AbstractTaskStore` | Durable operational state and lease fencing |
 

--- a/src/omnicoreagent/background/recovery.py
+++ b/src/omnicoreagent/background/recovery.py
@@ -1,0 +1,129 @@
+"""Expired lease recovery for background runs."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from omnicoreagent.background.errors import (
+    RunCancellationRequestedError,
+    RunLeaseError,
+)
+from omnicoreagent.background.models import (
+    AttemptReason,
+    AttemptStatus,
+    BackgroundRun,
+    RunStatus,
+    utc_now,
+)
+from omnicoreagent.background.run_helpers import release_lease_patch
+from omnicoreagent.background.store.base import AbstractTaskStore
+from omnicoreagent.background.transitions import BackgroundRunTransitions
+
+
+class BackgroundRunRecovery:
+    """Recovers runs whose worker lease expired before terminal completion."""
+
+    def __init__(
+        self,
+        *,
+        task_store: AbstractTaskStore,
+        transitions: BackgroundRunTransitions,
+        worker_id: str | Callable[[], str],
+        lease_seconds: int | Callable[[], int],
+        emit_run: Callable[..., Awaitable[None]],
+    ) -> None:
+        self.task_store = task_store
+        self.transitions = transitions
+        self._worker_id = worker_id if callable(worker_id) else lambda: worker_id
+        self._lease_seconds = (
+            lease_seconds if callable(lease_seconds) else lambda: lease_seconds
+        )
+        self.emit_run = emit_run
+
+    @property
+    def worker_id(self) -> str:
+        return self._worker_id()
+
+    @property
+    def lease_seconds(self) -> int:
+        return self._lease_seconds()
+
+    async def recover_expired_runs(self) -> None:
+        expired = await self.task_store.list_expired_leases(utc_now())
+        for run in expired:
+            try:
+                await self.recover_expired_run(run)
+            except (RunLeaseError, RunCancellationRequestedError):
+                continue
+
+    async def recover_expired_run(self, run: BackgroundRun) -> None:
+        stolen = await self.task_store.steal_expired_run(
+            run.run_id, self.worker_id, self.lease_seconds
+        )
+        if await self.task_store.is_cancel_requested(stolen.run_id):
+            await self.transitions.mark_terminal(
+                stolen, RunStatus.CANCELLED, "cancelled"
+            )
+            return
+
+        await self.fail_abandoned_attempts(stolen)
+        task = await self.task_store.get_task(stolen.task_id)
+        if not task:
+            await self.transitions.mark_terminal(stolen, RunStatus.FAILED, "task missing")
+            return
+
+        if stolen.status == RunStatus.CLAIMED:
+            recovered = await self.transitions.transition_or_cancel_without_attempt(
+                run=stolen,
+                expected={RunStatus.CLAIMED},
+                next_status=RunStatus.QUEUED,
+                patch=release_lease_patch(),
+            )
+            if recovered is None:
+                return
+            await self.emit_run("background_run_recovered", recovered)
+            return
+
+        can_retry = stolen.attempt <= task.retry_policy.max_retries
+        if can_retry:
+            await self.requeue_retryable_run(stolen)
+            return
+
+        await self.transitions.mark_terminal(stolen, RunStatus.FAILED, "lease expired")
+
+    async def fail_abandoned_attempts(self, run: BackgroundRun) -> None:
+        attempts = await self.task_store.list_attempts(run.run_id)
+        running = [item for item in attempts if item.status == AttemptStatus.RUNNING]
+        for attempt in running:
+            await self.task_store.update_attempt(
+                attempt.attempt_id,
+                {
+                    "status": AttemptStatus.FAILED,
+                    "reason": AttemptReason.LEASE_EXPIRED,
+                    "finished_at": utc_now(),
+                    "error": "lease expired",
+                },
+                self.worker_id,
+                run.lease_token,
+            )
+
+    async def requeue_retryable_run(self, run: BackgroundRun) -> None:
+        retrying = run
+        if run.status == RunStatus.RUNNING:
+            retrying = await self.transitions.transition_or_cancel_without_attempt(
+                run=run,
+                expected={RunStatus.RUNNING},
+                next_status=RunStatus.RETRYING,
+                patch={"error": "lease expired"},
+            )
+            if retrying is None:
+                return
+        recovered = await self.transitions.transition_or_cancel_without_attempt(
+            run=retrying,
+            expected={RunStatus.RETRYING},
+            next_status=RunStatus.QUEUED,
+            patch=release_lease_patch(),
+        )
+        if recovered is None:
+            return
+        await self.emit_run("background_run_recovered", recovered)

--- a/src/omnicoreagent/background/supervisor.py
+++ b/src/omnicoreagent/background/supervisor.py
@@ -10,11 +10,7 @@ from typing import Any
 
 from omnicoreagent.core.events.base import reset_event_run_id, set_event_run_id
 from omnicoreagent.background.agent_specs import resolve_agent
-from omnicoreagent.background.errors import (
-    RunCancellationRequestedError,
-    RunLeaseError,
-    RunNotFoundError,
-)
+from omnicoreagent.background.errors import RunLeaseError, RunNotFoundError
 from omnicoreagent.background.event_log import BackgroundEventLog
 from omnicoreagent.background.models import (
     TERMINAL_RUN_STATUSES,
@@ -26,6 +22,7 @@ from omnicoreagent.background.models import (
     RunStatus,
     utc_now,
 )
+from omnicoreagent.background.recovery import BackgroundRunRecovery
 from omnicoreagent.background.run_helpers import (
     build_run_context,
     is_run_due,
@@ -75,6 +72,13 @@ class BackgroundSupervisor:
         self._emit_run = emit_run
         self.transitions = BackgroundRunTransitions(
             task_store=self.task_store,
+            worker_id=lambda: self.worker_id,
+            lease_seconds=lambda: self.lease_seconds,
+            emit_run=self.emit_run,
+        )
+        self.recovery = BackgroundRunRecovery(
+            task_store=self.task_store,
+            transitions=self.transitions,
             worker_id=lambda: self.worker_id,
             lease_seconds=lambda: self.lease_seconds,
             emit_run=self.emit_run,
@@ -228,76 +232,10 @@ class BackgroundSupervisor:
                 active_task.cancel()
 
     async def recover_expired_runs(self) -> None:
-        expired = await self.task_store.list_expired_leases(utc_now())
-        for run in expired:
-            try:
-                await self.recover_expired_run(run)
-            except (RunLeaseError, RunCancellationRequestedError):
-                continue
+        await self.recovery.recover_expired_runs()
 
     async def recover_expired_run(self, run: BackgroundRun) -> None:
-        stolen = await self.task_store.steal_expired_run(
-            run.run_id, self.worker_id, self.lease_seconds
-        )
-        if await self.task_store.is_cancel_requested(stolen.run_id):
-            await self.mark_terminal(stolen, RunStatus.CANCELLED, "cancelled")
-            return
-
-        attempts = await self.task_store.list_attempts(stolen.run_id)
-        running = [item for item in attempts if item.status == AttemptStatus.RUNNING]
-        for attempt in running:
-            await self.task_store.update_attempt(
-                attempt.attempt_id,
-                {
-                    "status": AttemptStatus.FAILED,
-                    "reason": AttemptReason.LEASE_EXPIRED,
-                    "finished_at": utc_now(),
-                    "error": "lease expired",
-                },
-                self.worker_id,
-                stolen.lease_token,
-            )
-        task = await self.task_store.get_task(stolen.task_id)
-        if not task:
-            await self.mark_terminal(stolen, RunStatus.FAILED, "task missing")
-            return
-
-        if stolen.status == RunStatus.CLAIMED:
-            recovered = await self.transition_or_cancel_without_attempt(
-                run=stolen,
-                expected={RunStatus.CLAIMED},
-                next_status=RunStatus.QUEUED,
-                patch=release_lease_patch(),
-            )
-            if recovered is None:
-                return
-            await self.emit_run("background_run_recovered", recovered)
-            return
-
-        can_retry = stolen.attempt <= task.retry_policy.max_retries
-        if can_retry:
-            retrying = stolen
-            if stolen.status == RunStatus.RUNNING:
-                retrying = await self.transition_or_cancel_without_attempt(
-                    run=stolen,
-                    expected={RunStatus.RUNNING},
-                    next_status=RunStatus.RETRYING,
-                    patch={"error": "lease expired"},
-                )
-                if retrying is None:
-                    return
-            recovered = await self.transition_or_cancel_without_attempt(
-                run=retrying,
-                expected={RunStatus.RETRYING},
-                next_status=RunStatus.QUEUED,
-                patch=release_lease_patch(),
-            )
-            if recovered is None:
-                return
-            await self.emit_run("background_run_recovered", recovered)
-            return
-
-        await self.mark_terminal(stolen, RunStatus.FAILED, "lease expired")
+        await self.recovery.recover_expired_run(run)
 
     async def release_claimed_before_start(self, run_id: str) -> None:
         latest = await self.task_store.get_run(run_id)

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -40,6 +40,7 @@ from omnicoreagent.background.models import (
     build_workspace_path,
     next_cron_due,
 )
+from omnicoreagent.background.recovery import BackgroundRunRecovery
 from omnicoreagent.background.transitions import BackgroundRunTransitions
 
 
@@ -2219,6 +2220,74 @@ async def test_recover_expired_running_run_requeues_when_retry_available():
 
     assert recovered.status == RunStatus.QUEUED
     assert recovered.lease_token is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_service_requeues_expired_running_run_directly():
+    store = InMemoryTaskStore()
+    await store.save_agent(agent_spec())
+    await store.save_task(
+        task_spec(retry_policy=RetryPolicy(max_retries=1, initial_delay_seconds=0))
+    )
+    run = BackgroundRun(
+        task_id="task",
+        agent_id="agent",
+        query_snapshot="one",
+        trigger_type=TriggerType.MANUAL,
+        session_id="s1",
+        workspace_path="w1",
+    )
+    created = await store.create_run_with_overlap_guard(run, OverlapPolicy.ALLOW_PARALLEL)
+    claimed = await store.claim_run(created.run_id, "lost_worker", lease_seconds=30)
+    running = await store.transition_run(
+        claimed.run_id,
+        {RunStatus.CLAIMED},
+        RunStatus.RUNNING,
+        {"attempt": 1},
+        "lost_worker",
+        claimed.lease_token,
+    )
+    await store.create_attempt(
+        BackgroundAttempt(
+            run_id=running.run_id,
+            attempt_number=1,
+            worker_id="lost_worker",
+            lease_token=running.lease_token,
+        )
+    )
+    async with store._lock:
+        store._runs[run.run_id] = running.model_copy(
+            update={"lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+        )
+
+    emitted = []
+
+    async def emit_run(event_name, run, **extra):
+        emitted.append((event_name, run.status))
+
+    transitions = BackgroundRunTransitions(
+        task_store=store,
+        worker_id=lambda: "recovery",
+        lease_seconds=lambda: 30,
+        emit_run=emit_run,
+    )
+    recovery = BackgroundRunRecovery(
+        task_store=store,
+        transitions=transitions,
+        worker_id=lambda: "recovery",
+        lease_seconds=lambda: 30,
+        emit_run=emit_run,
+    )
+
+    await recovery.recover_expired_runs()
+
+    recovered = await store.get_run(run.run_id)
+    attempts = await store.list_attempts(run.run_id)
+    assert recovered.status == RunStatus.QUEUED
+    assert recovered.lease_token is None
+    assert attempts[0].status == AttemptStatus.FAILED
+    assert attempts[0].reason == AttemptReason.LEASE_EXPIRED
+    assert emitted == [("background_run_recovered", RunStatus.QUEUED)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extract expired lease recovery from BackgroundSupervisor into BackgroundRunRecovery
- keep recovery decisions using BackgroundRunTransitions for terminal writes and cancellation-aware progress transitions
- keep supervisor wrappers for existing internal call sites while narrowing supervisor ownership to execution flow
- update the internal background-agent spec to document the recovery service boundary
- add direct recovery-service coverage for expired RUNNING lease recovery, abandoned attempt closure, and recovered event emission

## Verification
- uv run ruff check src/omnicoreagent/background tests/test_background_agent.py
- uv run pytest tests/test_background_agent.py tests/test_omniserve_background.py tests/test_import_startup.py -q
- uv run pytest -q

## Evaluator review
- architecture, QA, implementation, and developer-experience evaluators reported no blocking issues
- direct recovery-service test added after DX review requested coverage beyond supervisor delegation