### PR TITLE
Finalize background agent docs and event vocabulary

### DIFF
--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -1,7 +1,7 @@
-# Background Agents: Tracked Agent Tasks
+# Background Agents: Durable Agent Tasks
 
-Background Agents run OmniCoreAgent tasks outside the foreground request path.
-They are built around tracked runs, task-store state, retries, cancellation,
+Background Agents run OmniCoreAgent work outside the foreground request path.
+They are durable tracked tasks with schedules, retries, cancellation, leases,
 workspace output, and inspectable lifecycle events. Use the default in-memory
 store for local development, or `sql`, `redis`, or `mongodb` when runs must
 survive restarts.
@@ -11,12 +11,14 @@ survive restarts.
 * **BackgroundAgentManager**: Registers agents, tasks, runs, and lifecycle operations.
 * **Task store**: Operational state for agents, tasks, schedule state, runs, attempts, leases, retries, and cancellation flags. It defaults to in-memory and is separate from conversation memory.
 * **Run**: One concrete execution of a task. Runs have stable IDs, statuses, attempts, workspace paths, and event history.
-* **Workspace output**: Every background run gets a workspace namespace for output.
+* **Worker lifecycle**: A worker claims queued runs with leases, heartbeats while work is active, and recovers expired leases.
+* **Workspace output**: Every background run gets a workspace namespace for lifecycle files and agent output.
 
 You can run the background manager without storage configuration. Use
 `BackgroundAgentManager()` for the default zero-config in-memory task store. Use
 `task_store="sql"`, `task_store="redis"`, or `task_store="mongodb"` when task
-state must survive process restarts.
+state must survive process restarts. The task store is not conversation memory;
+it is the control plane for background work.
 
 Redis and MongoDB task stores use optional backend drivers:
 
@@ -37,40 +39,141 @@ async def main():
     agent = OmniCoreAgent(
         name="system_monitor",
         system_instruction="Check system health and write concise reports.",
-        model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        model_config={"provider": "openai", "model": "gpt-5.4-mini"},
     )
 
     manager = BackgroundAgentManager()
-    await manager.register_agent(agent_id="system_monitor", agent=agent)
-    await manager.register_task(
-        task_id="health_report",
-        agent_id="system_monitor",
-        query="Check system health and summarize anything that needs attention.",
-        schedule={"type": "manual"},
-        timeout_seconds=60,
-        retry_policy={"max_retries": 1, "initial_delay_seconds": 0},
-    )
+    try:
+        await manager.register_agent(agent_id="system_monitor", agent=agent)
+        await manager.register_task(
+            task_id="health_report",
+            agent_id="system_monitor",
+            query="Check system health and summarize anything that needs attention.",
+            schedule={"type": "manual"},
+            timeout_seconds=60,
+            retry_policy={"max_retries": 1, "initial_delay_seconds": 0},
+        )
 
-    run = await manager.run_now("health_report", wait=True)
-    print(run.status)
-    print(run.result_preview)
+        run = await manager.run_now("health_report", wait=True)
+        print(run.status)
+        print(run.result_preview)
+    finally:
+        await manager.shutdown()
 
 
 asyncio.run(main())
 ```
 
+## Durable Task Stores
+
+The default task store is in-memory. It needs no database and is right for local
+development, tests, and single-process experiments:
+
+```python
+manager = BackgroundAgentManager()
+```
+
+Use a durable task store when background runs must survive process restarts:
+
+```python
+manager = BackgroundAgentManager(task_store="sql")
+
+manager = BackgroundAgentManager(
+    task_store={"backend": "redis", "url": "redis://localhost:6379/0"}
+)
+
+manager = BackgroundAgentManager(
+    task_store={
+        "backend": "mongodb",
+        "uri": "mongodb://localhost:27017",
+        "database": "omnicoreagent",
+    }
+)
+```
+
+Redis durable deployments need persistence enabled and a no-eviction policy for
+task-store keys. MongoDB task-store writes use majority write concern.
+
+## Scheduled Runs
+
+Manual tasks run only when you call `run_now`. Scheduled tasks are dispatched by
+the manager worker after `start()` is called:
+
+```python
+await manager.register_task(
+    task_id="hourly_report",
+    agent_id="system_monitor",
+    query="Write the hourly operational report.",
+    schedule={"type": "interval", "seconds": 3600},
+    overlap_policy="queue_next",
+)
+
+await manager.start()
+```
+
+`start()` creates the manager worker and returns immediately. Keep the process
+alive while scheduled work should continue, and use `shutdown()` when the
+process exits so worker loops and active background resources close cleanly:
+
+```python
+try:
+    await manager.start()
+    await asyncio.Event().wait()
+finally:
+    await manager.shutdown()
+    if hasattr(agent, "cleanup"):
+        await agent.cleanup()
+```
+
 ## Runtime Controls
 
 ```python
-run = await manager.run_now("health_report")
+run = await manager.run_now("health_report", wait=True)
 status = await manager.get_run(run.run_id)
 attempts = await manager.list_attempts(run.run_id)
 events = await manager.get_run_events(run.run_id)
+workspace = await manager.get_run_workspace(run.run_id)
 
 await manager.cancel_run(run.run_id)
 await manager.pause_task("health_report")
 await manager.resume_task("health_report")
 ```
+
+`get_run_events(run_id)` returns ordered lifecycle events for that run. These
+events use run-local names such as `background_task_scheduled`,
+`background_run_queued`, `background_run_claimed`, `background_run_started`,
+`background_run_heartbeat`, `background_run_retrying`,
+`background_run_recovered`, `background_run_completed`,
+`background_run_failed`, `background_run_timeout`,
+`background_run_cancelled`, and `background_run_skipped`.
+
+When an `EventRouter` is attached, the background manager forwards lifecycle
+events as `background_agent_status` events. The specific lifecycle name is
+available as `event.payload.event` in Python, and as `payload.event` after JSON
+serialization.
+
+## OmniServe Endpoints
+
+OmniServe exposes the same background task lifecycle over HTTP:
+
+```bash
+curl -X POST http://localhost:8000/background/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task_id": "health_report",
+    "query": "Check system health and write the report.",
+    "schedule": {"type": "manual"},
+    "timeout_seconds": 60
+  }'
+
+curl -X POST http://localhost:8000/background/tasks/health_report/run \
+  -H "Content-Type: application/json" \
+  -d '{"wait": true}'
+```
+
+The background API includes task creation, task listing, pause, resume, delete,
+manual run, cancellation, run status, attempt history, event replay, and
+workspace inspection.
 
 ## Task Configuration
 
@@ -85,23 +188,4 @@ await manager.resume_task("health_report")
 | `overlap_policy` | `skip_if_running`, `queue_next`, `cancel_previous`, or `allow_parallel`. |
 | `session_policy` | `task`, `run`, or `fixed` memory-session behavior. |
 
-The current implementation includes the tracked run model, in-memory, SQL,
-Redis, and MongoDB task stores, manager lifecycle, manual and scheduled runs,
-retries with delay/backoff, lease fencing, expired-lease recovery, cancellation,
-workspace lifecycle files, and event history. State is restart-persistent when
-the task store is SQL, Redis, or MongoDB.
-
-Redis durable deployments need persistence enabled and a no-eviction policy for
-task-store keys. MongoDB task-store writes use majority write concern.
-
-```python
-BackgroundAgentManager(task_store="sql")
-BackgroundAgentManager(task_store={"backend": "redis", "url": "redis://localhost:6379/0"})
-BackgroundAgentManager(
-    task_store={
-        "backend": "mongodb",
-        "uri": "mongodb://localhost:27017",
-        "database": "omnicoreagent",
-    }
-)
-```
+State is restart-persistent when the task store is SQL, Redis, or MongoDB.

--- a/cookbook/background_agents/background_agent_example.py
+++ b/cookbook/background_agents/background_agent_example.py
@@ -14,25 +14,35 @@ async def main():
     agent = OmniCoreAgent(
         name="background_researcher",
         system_instruction="You write short background task reports.",
-        model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        model_config={"provider": "openai", "model": "gpt-5.4-mini"},
     )
 
     manager = BackgroundAgentManager()
-    await manager.register_agent(agent_id="background_researcher", agent=agent)
-    await manager.register_task(
-        task_id="daily_research_note",
-        agent_id="background_researcher",
-        query="Write a short research note about one practical AI agent reliability risk.",
-        schedule={"type": "manual"},
-        timeout_seconds=60,
-        retry_policy={"max_retries": 1, "initial_delay_seconds": 0},
-    )
+    try:
+        await manager.register_agent(agent_id="background_researcher", agent=agent)
+        await manager.register_task(
+            task_id="daily_research_note",
+            agent_id="background_researcher",
+            query="Write a short research note about one practical AI agent reliability risk.",
+            schedule={"type": "manual"},
+            timeout_seconds=60,
+            retry_policy={"max_retries": 1, "initial_delay_seconds": 0},
+        )
 
-    run = await manager.run_now("daily_research_note", wait=True)
-    print(f"run_id={run.run_id}")
-    print(f"status={run.status.value}")
-    print(f"workspace={run.workspace_path}")
-    print(run.result_preview)
+        run = await manager.run_now("daily_research_note", wait=True)
+        attempts = await manager.list_attempts(run.run_id)
+        events = await manager.get_run_events(run.run_id)
+
+        print(f"run_id={run.run_id}")
+        print(f"status={run.status.value}")
+        print(f"workspace={run.workspace_path}")
+        print(f"attempts={len(attempts)}")
+        print(f"events={[event['event'] for event in events]}")
+        print(run.result_preview)
+    finally:
+        await manager.shutdown()
+        if hasattr(agent, "cleanup"):
+            await agent.cleanup()
 
 
 if __name__ == "__main__":

--- a/docs/core-concepts/events.mdx
+++ b/docs/core-concepts/events.mdx
@@ -62,10 +62,7 @@ async for event in agent.stream_events(session_id):
 | `sub_agent_call_started` | Sub-agent delegation begins |
 | `sub_agent_call_result` | Sub-agent returns result |
 | `sub_agent_call_error` | Sub-agent encountered an error |
-| `background_task_started` | Background task begins |
-| `background_task_completed` | Background task completes |
-| `background_task_error` | Background task failed |
-| `background_agent_status` | Background agent status changed |
+| `background_agent_status` | Background run lifecycle event routed through the event system |
 
 ---
 
@@ -106,6 +103,35 @@ and debugging deterministic without requiring a full tracing system.
 final `complete` event. That keeps concurrent runs on the same session from
 mixing in one live response while the session event feed can still show the full
 session history.
+
+## Background Run Events
+
+Background agents have their own run-local lifecycle event names. These are
+stored in the background event log, mirrored to workspace `events.jsonl` when
+enabled, and forwarded through `EventRouter` as `background_agent_status`
+events with the lifecycle name in `payload.event`.
+
+Common background lifecycle names include:
+
+| Lifecycle Event | Meaning |
+|-----------------|---------|
+| `background_task_scheduled` | A scheduled occurrence created a run. |
+| `background_run_queued` | A run was created and queued. |
+| `background_run_claimed` | A worker claimed the run with a lease. |
+| `background_run_started` | Agent execution started. |
+| `background_run_heartbeat` | Active worker refreshed the run lease. |
+| `background_run_retrying` | Failed attempt entered retry state. |
+| `background_run_recovered` | Expired lease was recovered and requeued. |
+| `background_run_completed` | Run completed successfully. |
+| `background_run_failed` | Run failed terminally. |
+| `background_run_timeout` | Run exceeded its timeout. |
+| `background_run_cancelled` | Run was cancelled. |
+| `background_run_skipped` | Overlap policy skipped a scheduled run. |
+
+Use `BackgroundAgentManager.get_run_events(run_id)` or
+`GET /background/runs/{run_id}/events` in OmniServe to replay a run trajectory.
+Each returned event has a run-local integer `sequence`, `run_id`, `task_id`,
+`status`, and the lease/worker fields available for that transition.
 
 ---
 

--- a/src/omnicoreagent/core/events/base.py
+++ b/src/omnicoreagent/core/events/base.py
@@ -27,9 +27,6 @@ class EventType(str, Enum):
     SUB_AGENT_CALL_STARTED = "sub_agent_call_started"
     SUB_AGENT_CALL_RESULT = "sub_agent_call_result"
     SUB_AGENT_CALL_ERROR = "sub_agent_call_error"
-    BACKGROUND_TASK_STARTED = "background_task_started"
-    BACKGROUND_TASK_COMPLETED = "background_task_completed"
-    BACKGROUND_TASK_ERROR = "background_task_error"
     BACKGROUND_AGENT_STATUS = "background_agent_status"
 
 
@@ -113,33 +110,6 @@ class SubAgentCallErrorPayload(SerializableRecord):
 
 
 @dataclass
-class BackgroundTaskStartedPayload(SerializableRecord):
-    agent_id: str
-    session_id: str
-    timestamp: str
-    run_count: int
-    kwargs: dict[str, Any]
-
-
-@dataclass
-class BackgroundTaskCompletedPayload(SerializableRecord):
-    agent_id: str
-    session_id: str
-    timestamp: str
-    run_count: int
-    result: Any
-
-
-@dataclass
-class BackgroundTaskErrorPayload(SerializableRecord):
-    agent_id: str
-    session_id: str
-    timestamp: str
-    error: str
-    error_count: int
-
-
-@dataclass
 class BackgroundAgentStatusPayload(SerializableRecord):
     agent_id: str
     status: str
@@ -175,9 +145,6 @@ EventPayload = (
     | SubAgentCallStartedPayload
     | SubAgentCallResultPayload
     | SubAgentCallErrorPayload
-    | BackgroundTaskStartedPayload
-    | BackgroundTaskCompletedPayload
-    | BackgroundTaskErrorPayload
     | BackgroundAgentStatusPayload
 )
 
@@ -193,9 +160,6 @@ EVENT_PAYLOAD_MAP: dict[EventType, Type[Any]] = {
     EventType.SUB_AGENT_CALL_STARTED: SubAgentCallStartedPayload,
     EventType.SUB_AGENT_CALL_RESULT: SubAgentCallResultPayload,
     EventType.SUB_AGENT_CALL_ERROR: SubAgentCallErrorPayload,
-    EventType.BACKGROUND_TASK_STARTED: BackgroundTaskStartedPayload,
-    EventType.BACKGROUND_TASK_COMPLETED: BackgroundTaskCompletedPayload,
-    EventType.BACKGROUND_TASK_ERROR: BackgroundTaskErrorPayload,
     EventType.BACKGROUND_AGENT_STATUS: BackgroundAgentStatusPayload,
 }
 

--- a/src/omnicoreagent/core/events/trace.py
+++ b/src/omnicoreagent/core/events/trace.py
@@ -124,9 +124,18 @@ def _build_summary(session_id: str, events: list[Event]) -> TraceSummary:
         tool_errors=counts.get(EventType.TOOL_CALL_ERROR.value, 0),
         sub_agent_calls=counts.get(EventType.SUB_AGENT_CALL_STARTED.value, 0),
         sub_agent_errors=counts.get(EventType.SUB_AGENT_CALL_ERROR.value, 0),
-        background_errors=counts.get(EventType.BACKGROUND_TASK_ERROR.value, 0),
+        background_errors=sum(1 for event in events if _is_background_error(event)),
         final_answer=final_answer,
     )
+
+
+def _is_background_error(event: Event) -> bool:
+    if event.type != EventType.BACKGROUND_AGENT_STATUS:
+        return False
+    lifecycle_event = getattr(event.payload, "event", None) or getattr(
+        event.payload, "status", None
+    )
+    return lifecycle_event in {"background_run_failed", "background_run_timeout"}
 
 
 def _duration_ms(start: datetime, end: datetime) -> float:

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -2364,13 +2364,14 @@ async def test_expired_lease_during_completion_does_not_crash_worker():
     attempts = await manager.list_attempts(run.run_id)
 
     assert did_work is True
-    assert latest.status == RunStatus.RUNNING
+    assert latest.status in {RunStatus.CLAIMED, RunStatus.RUNNING}
     if attempts:
         assert attempts[0].status == AttemptStatus.RUNNING
 
     await manager.recover_expired_runs()
     still_recoverable = await manager.get_run(run.run_id)
     assert still_recoverable.status in {
+        RunStatus.CLAIMED,
         RunStatus.RUNNING,
         RunStatus.RETRYING,
         RunStatus.QUEUED,

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -144,3 +144,47 @@ def test_background_docs_show_optional_extras_for_remote_task_stores():
         text = path.read_text(encoding="utf-8")
         assert 'omnicoreagent[redis]' in text
         assert 'omnicoreagent[mongodb]' in text
+
+
+def test_background_docs_use_current_event_vocabulary():
+    stale_events = {
+        "background_task_started",
+        "background_task_completed",
+        "background_task_error",
+    }
+    docs = [
+        Path("docs/core-concepts/events.mdx"),
+        Path("docs/core-concepts/background-agents.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+    ]
+
+    offenders = []
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        found = sorted(event for event in stale_events if event in text)
+        if found:
+            offenders.append(f"{path}: {', '.join(found)}")
+
+    assert not offenders, (
+        "Background docs must use current run lifecycle events and "
+        "background_agent_status, not stale background task event names:\n"
+        + "\n".join(offenders)
+    )
+
+    events_doc = Path("docs/core-concepts/events.mdx").read_text(encoding="utf-8")
+    for expected in {
+        "background_agent_status",
+        "background_task_scheduled",
+        "background_run_queued",
+        "background_run_claimed",
+        "background_run_started",
+        "background_run_completed",
+    }:
+        assert expected in events_doc
+
+
+def test_background_cookbook_uses_typed_event_payload_access():
+    text = Path("cookbook/background_agents/README.mdx").read_text(encoding="utf-8")
+
+    assert 'event.payload["event"]' not in text
+    assert "event.payload.event" in text

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,6 +49,15 @@ def test_background_status_payload_keeps_positional_compatibility():
     assert payload.run_id is None
 
 
+def test_event_type_uses_current_background_status_event():
+    event_values = {event_type.value for event_type in EventType}
+
+    assert "background_agent_status" in event_values
+    assert "background_task_started" not in event_values
+    assert "background_task_completed" not in event_values
+    assert "background_task_error" not in event_values
+
+
 def test_event_serializes_and_parses_without_pydantic():
     event = Event(
         type=EventType.TOOL_CALL_STARTED,
@@ -156,6 +165,41 @@ def test_build_event_trace_orders_events_and_summarizes_runtime():
     assert trace.summary.sub_agent_errors == 1
     assert trace.summary.final_answer == "done"
     assert dumped["summary"]["event_counts"]["tool_call_error"] == 1
+
+
+def test_build_event_trace_counts_background_status_failures():
+    start = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+    events = [
+        Event(
+            type=EventType.BACKGROUND_AGENT_STATUS,
+            payload=BackgroundAgentStatusPayload(
+                agent_id="agent",
+                status="background_run_started",
+                timestamp=start.isoformat(),
+                run_id="run_1",
+                event="background_run_started",
+            ),
+            agent_name="agent",
+            timestamp=start,
+        ),
+        Event(
+            type=EventType.BACKGROUND_AGENT_STATUS,
+            payload=BackgroundAgentStatusPayload(
+                agent_id="agent",
+                status="background_run_failed",
+                timestamp=(start + timedelta(milliseconds=10)).isoformat(),
+                run_id="run_1",
+                event="background_run_failed",
+            ),
+            agent_name="agent",
+            timestamp=start + timedelta(milliseconds=10),
+        ),
+    ]
+
+    trace = build_event_trace(session_id="run_1", events=events)
+
+    assert trace.summary.event_counts["background_agent_status"] == 2
+    assert trace.summary.background_errors == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- harden background-agent cookbook guidance for durable task stores, scheduled workers, shutdown, run inspection, OmniServe endpoints, and lifecycle event replay
- remove stale background_task_started/completed/error event types in favor of background_agent_status with run lifecycle payloads
- update trace background error counting and docs claim tests to lock the current background event vocabulary
- stabilize the expired-lease recovery test around the real CLAIMED/RUNNING race contract

## Verification
- uv run pytest tests/test_docs_claims.py -q
- env LLM_API_KEY= uv run python cookbook/background_agents/background_agent_example.py
- uv run pytest tests/test_events.py tests/test_background_agent.py tests/test_omniserve_background.py tests/test_docs_claims.py -q
- uv run pytest -q