### PR TITLE
Implement background schedule semantics

### DIFF
--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -467,6 +467,15 @@ Schedule state tracks:
 - jitter
 - enabled/paused state
 
+Misfire handling is deterministic:
+
+- `skip_missed` and `run_once` create at most one run per dispatcher pass for a
+  stale cursor and advance the next due time from the scheduler's current time.
+- `queue_all` creates due occurrences in order until the dispatcher limit is
+  reached, leaving the cursor due when more missed work remains.
+- `jitter_seconds` is a stable per-occurrence delay derived from schedule data
+  and due time, so restarted managers compute the same cursor.
+
 ### Schedule State
 
 `BackgroundScheduleState` records mutable scheduling progress for one task.

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -314,7 +314,7 @@ Fields:
 | `timezone` | `str` | no | Defaults to UTC |
 | `start_at` | `datetime | None` | no | Earliest due time |
 | `end_at` | `datetime | None` | no | Latest due time |
-| `jitter_seconds` | `int | None` | no | Random schedule jitter |
+| `jitter_seconds` | `int | None` | no | Deterministic per-occurrence jitter delay |
 | `misfire_policy` | `skip_missed | run_once | queue_all` | no | Missed trigger behavior |
 
 Validation:
@@ -325,6 +325,26 @@ Validation:
 - `manual` does not require scheduler fields.
 - `end_at` must be after `start_at` when both exist.
 - `jitter_seconds` must be non-negative when provided.
+
+Misfire behavior:
+
+- `skip_missed`: dispatch the currently due occurrence once, then advance the
+  next due cursor from the current scheduler time so older missed intervals are
+  skipped.
+- `run_once`: dispatch one run for a missed interval window, then advance the
+  next due cursor from the current scheduler time.
+- `queue_all`: dispatch each missed occurrence in due-time order up to the
+  dispatcher limit. If more missed occurrences remain after the limit, the
+  schedule cursor remains due so the next dispatcher pass continues from the
+  next undispatched occurrence.
+
+Jitter behavior:
+
+- `jitter_seconds` applies a deterministic delay between `0` and
+  `jitter_seconds` to computed due times.
+- The jitter value is derived from the schedule fields and due timestamp so
+  schedule cursors remain stable across process restarts.
+- Jitter never creates extra occurrences; it only delays a computed occurrence.
 
 ### `RetryPolicy`
 

--- a/src/omnicoreagent/background/models.py
+++ b/src/omnicoreagent/background/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+import hashlib
 import re
 from typing import Any
 from uuid import uuid4
@@ -303,7 +304,7 @@ def initial_schedule_due(schedule: ScheduleSpec, now: datetime | None = None) ->
         return None
     if schedule.end_at and due > schedule.end_at:
         return None
-    return due
+    return apply_schedule_jitter(schedule, due)
 
 
 def next_schedule_due(
@@ -313,7 +314,11 @@ def next_schedule_due(
 ) -> datetime | None:
     previous = ensure_utc(previous_due_at) or utc_now()
     reference = ensure_utc(now) or utc_now()
-    if schedule.misfire_policy == MisfirePolicy.SKIP_MISSED and previous < reference:
+    if (
+        schedule.misfire_policy
+        in {MisfirePolicy.SKIP_MISSED, MisfirePolicy.RUN_ONCE}
+        and previous < reference
+    ):
         previous = reference
     if schedule.type in {ScheduleType.MANUAL, ScheduleType.ONCE}:
         return None
@@ -327,7 +332,65 @@ def next_schedule_due(
         return None
     if schedule.end_at and due > schedule.end_at:
         return None
-    return due
+    return apply_schedule_jitter(schedule, due)
+
+
+def schedule_due_occurrences(
+    schedule: ScheduleSpec,
+    first_due_at: datetime | None,
+    now: datetime | None = None,
+    limit: int = 1,
+) -> tuple[list[datetime], datetime | None]:
+    """Return due occurrences to dispatch and the next schedule cursor."""
+    if first_due_at is None or limit <= 0:
+        return [], ensure_utc(first_due_at)
+    current_due = ensure_utc(first_due_at)
+    reference = ensure_utc(now) or utc_now()
+    if current_due is None or current_due > reference:
+        return [], current_due
+
+    occurrences = [current_due]
+    if schedule.type in {ScheduleType.MANUAL, ScheduleType.ONCE}:
+        return occurrences, None
+
+    if schedule.misfire_policy != MisfirePolicy.QUEUE_ALL:
+        return occurrences, next_schedule_due(schedule, current_due, reference)
+
+    next_due = next_schedule_due(schedule, current_due, current_due)
+    while next_due is not None and next_due <= reference and len(occurrences) < limit:
+        occurrences.append(next_due)
+        next_due = next_schedule_due(schedule, next_due, next_due)
+    return occurrences, next_due
+
+
+def apply_schedule_jitter(
+    schedule: ScheduleSpec, due_at: datetime | None
+) -> datetime | None:
+    due = ensure_utc(due_at)
+    if due is None or not schedule.jitter_seconds:
+        return due
+    offset = deterministic_jitter_seconds(schedule, due)
+    jittered = due + timedelta(seconds=offset)
+    if schedule.end_at and jittered > schedule.end_at:
+        return None
+    return jittered
+
+
+def deterministic_jitter_seconds(schedule: ScheduleSpec, due_at: datetime) -> int:
+    if not schedule.jitter_seconds:
+        return 0
+    due = ensure_utc(due_at) or utc_now()
+    key = "|".join(
+        [
+            schedule.type.value,
+            str(schedule.seconds),
+            str(schedule.expression),
+            schedule.timezone,
+            due.isoformat(),
+        ]
+    )
+    digest = hashlib.sha256(key.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % (schedule.jitter_seconds + 1)
 
 
 class BackgroundAgentSpec(StrictModel):

--- a/src/omnicoreagent/background/scheduler.py
+++ b/src/omnicoreagent/background/scheduler.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 
 from omnicoreagent.background.event_log import BackgroundEventLog
-from omnicoreagent.background.models import BackgroundRun
-from omnicoreagent.background.models import RunStatus, TriggerType, next_schedule_due, utc_now
+from omnicoreagent.background.models import (
+    BackgroundRun,
+    RunStatus,
+    TriggerType,
+    build_occurrence_id,
+    schedule_due_occurrences,
+    utc_now,
+)
 from omnicoreagent.background.run_helpers import build_run
 from omnicoreagent.background.store.base import AbstractTaskStore
 
@@ -33,36 +39,59 @@ class BackgroundScheduleDispatcher:
 
     async def dispatch_due_schedules(self, limit: int = 25) -> bool:
         dispatched_any = False
-        due_items = await self.task_store.get_due_schedules(utc_now(), limit=limit)
+        remaining = max(limit, 0)
+        now = utc_now()
+        due_items = await self.task_store.get_due_schedules(now, limit=remaining)
         for task, state, occurrence_id in due_items:
-            if state.next_due_at is None:
+            if remaining <= 0 or state.next_due_at is None:
                 continue
             trigger = TriggerType(task.schedule.type.value)
-            run = build_run(
-                task,
-                trigger,
-                task.query,
-                due_at=state.next_due_at,
-                occurrence_id=occurrence_id,
+            occurrences, final_next_due_at = schedule_due_occurrences(
+                task.schedule,
+                state.next_due_at,
+                now,
+                limit=remaining,
             )
-            existing_run_ids = {
-                item.run_id for item in await self.task_store.list_runs(task.task_id)
-            }
-            next_due_at = next_schedule_due(task.schedule, state.next_due_at, utc_now())
-            created = await self.task_store.dispatch_scheduled_run(
-                run,
-                task.overlap_policy,
-                state.schedule_revision,
-                next_due_at,
-            )
-            dispatched_any = True
-            if created.run_id in existing_run_ids:
+            if not occurrences:
                 continue
-            await self.emit_run("background_task_scheduled", created)
-            await self.emit_run(
-                "background_run_skipped"
-                if created.status == RunStatus.SKIPPED
-                else "background_run_queued",
-                created,
-            )
+            for index, due_at in enumerate(occurrences):
+                occurrence_for_due = (
+                    occurrence_id
+                    if index == 0
+                    else build_occurrence_id(
+                        task.schedule.type, state.schedule_revision, due_at
+                    )
+                )
+                run = build_run(
+                    task,
+                    trigger,
+                    task.query,
+                    due_at=due_at,
+                    occurrence_id=occurrence_for_due,
+                )
+                existing_run_ids = {
+                    item.run_id for item in await self.task_store.list_runs(task.task_id)
+                }
+                next_due_at = (
+                    occurrences[index + 1]
+                    if index + 1 < len(occurrences)
+                    else final_next_due_at
+                )
+                created = await self.task_store.dispatch_scheduled_run(
+                    run,
+                    task.overlap_policy,
+                    state.schedule_revision,
+                    next_due_at,
+                )
+                dispatched_any = True
+                remaining -= 1
+                if created.run_id in existing_run_ids:
+                    continue
+                await self.emit_run("background_task_scheduled", created)
+                await self.emit_run(
+                    "background_run_skipped"
+                    if created.status == RunStatus.SKIPPED
+                    else "background_run_queued",
+                    created,
+                )
         return dispatched_any

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -33,12 +33,16 @@ from omnicoreagent.background.models import (
     AttemptReason,
     AttemptStatus,
     BackoffPolicy,
+    MisfirePolicy,
     ScheduleType,
     TriggerType,
     build_occurrence_id,
     build_session_id,
     build_workspace_path,
+    deterministic_jitter_seconds,
+    initial_schedule_due,
     next_cron_due,
+    next_schedule_due,
 )
 from omnicoreagent.background.recovery import BackgroundRunRecovery
 from omnicoreagent.background.transitions import BackgroundRunTransitions
@@ -2967,6 +2971,120 @@ async def test_skip_missed_interval_advances_from_now_not_stale_due():
     updated = await manager.task_store.get_schedule_state("task")
 
     assert updated.next_due_at > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_run_once_misfire_dispatches_one_run_and_advances_from_now():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent())
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "interval", "seconds": 60, "misfire_policy": "run_once"},
+        overlap_policy=OverlapPolicy.ALLOW_PARALLEL,
+    )
+    stale_due = datetime.now(timezone.utc) - timedelta(hours=1)
+    state = await manager.task_store.get_schedule_state("task")
+    await manager.task_store.save_schedule_state(
+        state.model_copy(update={"next_due_at": stale_due})
+    )
+
+    await manager._dispatch_due_schedules()
+
+    runs = await manager.list_runs(task_id="task")
+    updated = await manager.task_store.get_schedule_state("task")
+    assert len(runs) == 1
+    assert runs[0].due_at == stale_due
+    assert updated.next_due_at > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_queue_all_misfire_dispatches_due_occurrences_until_limit():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent())
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "interval", "seconds": 60, "misfire_policy": "queue_all"},
+        overlap_policy=OverlapPolicy.ALLOW_PARALLEL,
+    )
+    now = datetime.now(timezone.utc)
+    first_due = now - timedelta(minutes=5)
+    state = await manager.task_store.get_schedule_state("task")
+    await manager.task_store.save_schedule_state(
+        state.model_copy(update={"next_due_at": first_due})
+    )
+
+    await manager._dispatch_due_schedules(limit=3)
+
+    runs = await manager.list_runs(task_id="task")
+    updated = await manager.task_store.get_schedule_state("task")
+    assert [run.due_at for run in runs] == [
+        first_due,
+        first_due + timedelta(seconds=60),
+        first_due + timedelta(seconds=120),
+    ]
+    assert updated.next_due_at == first_due + timedelta(seconds=180)
+    assert updated.next_due_at < datetime.now(timezone.utc)
+
+    await manager._dispatch_due_schedules(limit=10)
+
+    runs = await manager.list_runs(task_id="task")
+    assert len(runs) >= 6
+    assert len({run.occurrence_id for run in runs}) == len(runs)
+    assert (await manager.task_store.get_schedule_state("task")).next_due_at > (
+        datetime.now(timezone.utc) - timedelta(seconds=1)
+    )
+
+
+def test_schedule_jitter_is_bounded_and_stable():
+    base = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    schedule = ScheduleSpec(
+        type="interval",
+        seconds=60,
+        jitter_seconds=30,
+        misfire_policy=MisfirePolicy.RUN_ONCE,
+    )
+
+    initial_due = initial_schedule_due(schedule, base)
+    initial_offset = deterministic_jitter_seconds(
+        schedule, base + timedelta(seconds=60)
+    )
+    assert initial_due == base + timedelta(seconds=60 + initial_offset)
+    assert 0 <= initial_offset <= 30
+    assert initial_due == initial_schedule_due(schedule, base)
+
+    next_due = next_schedule_due(schedule, initial_due, initial_due)
+    next_offset = deterministic_jitter_seconds(
+        schedule, initial_due + timedelta(seconds=60)
+    )
+    assert next_due == initial_due + timedelta(seconds=60 + next_offset)
+
+
+def test_schedule_jitter_respects_end_at_boundary():
+    base = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    for seconds in range(1, 120):
+        schedule = ScheduleSpec(
+            type="interval",
+            seconds=seconds,
+            jitter_seconds=30,
+        )
+        raw_due = base + timedelta(seconds=seconds)
+        offset = deterministic_jitter_seconds(schedule, raw_due)
+        if offset <= 0:
+            continue
+        bounded = ScheduleSpec(
+            type="interval",
+            seconds=seconds,
+            jitter_seconds=30,
+            end_at=raw_due + timedelta(seconds=offset - 1),
+        )
+        assert initial_schedule_due(bounded, base) is None
+        assert next_schedule_due(bounded, base, base) is None
+        return
+    raise AssertionError("expected at least one deterministic jitter offset > 0")
 
 
 def test_cron_due_uses_configured_timezone():


### PR DESCRIPTION
## Summary
- implement declared background schedule semantics for `skip_missed`, `run_once`, and `queue_all`
- add deterministic per-occurrence jitter with stable restart behavior and `end_at` enforcement after jitter
- teach scheduled dispatch to queue multiple missed occurrences up to the dispatcher limit while preserving occurrence IDs and cursor advancement
- update internal architecture/spec docs to match the shipped schedule behavior

## Verification
- `uv run pytest tests/test_background_agent.py::test_skip_missed_interval_advances_from_now_not_stale_due tests/test_background_agent.py::test_run_once_misfire_dispatches_one_run_and_advances_from_now tests/test_background_agent.py::test_queue_all_misfire_dispatches_due_occurrences_until_limit tests/test_background_agent.py::test_schedule_jitter_is_bounded_and_stable tests/test_background_agent.py::test_schedule_jitter_respects_end_at_boundary -q` -> `5 passed`
- `uv run pytest tests/test_background_agent.py tests/test_background_task_store_contract.py tests/test_omniserve_background.py -q` -> `132 passed, 7 skipped`
- `uv run pytest -q` -> `663 passed, 7 skipped`

## Review notes
- Initial reviewer found `end_at` ambiguity after jitter and stale “random jitter” wording; both were fixed and covered by `test_schedule_jitter_respects_end_at_boundary`.
- Later reviewer agents stalled repeatedly, so they were closed after the full suite passed cleanly.
