### PR TITLE
Clarify background run workspace context

### DIFF
--- a/src/omnicoreagent/background/run_helpers.py
+++ b/src/omnicoreagent/background/run_helpers.py
@@ -41,12 +41,19 @@ def build_run(
 
 
 def build_run_context(run: BackgroundRun) -> str:
+    workspace_root = f"/workspace/{run.workspace_path}"
     return (
         "This is a background run.\n"
         f"run_id: {run.run_id}\n"
         f"task_id: {run.task_id}\n"
-        f"workspace_path: /workspace/{run.workspace_path}\n"
-        "Use output.md for the final durable result.\n\n"
+        f"workspace_path: {workspace_root}\n"
+        "Write durable background output inside this workspace.\n"
+        f"- final result: {workspace_root}/output.md\n"
+        f"- progress, notes, todos, and resumable work: {workspace_root}/scratchpad/\n"
+        f"- logs: {workspace_root}/logs/\n"
+        f"- generated artifacts and data files: {workspace_root}/artifacts/\n"
+        f"- delegated subagent outputs: {workspace_root}/subagents/\n"
+        "Keep your final response concise; put durable detail in workspace files.\n\n"
         f"{run.query_snapshot}"
     )
 

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -985,7 +985,14 @@ async def test_manager_run_now_executes_agent_and_records_events():
     assert run.status == RunStatus.COMPLETED
     assert run.result_preview == "complete"
     assert agent.calls[0]["session_id"] == "background:agent:task"
-    assert "workspace_path: /workspace/background/agent/task/" in agent.calls[0]["query"]
+    query = agent.calls[0]["query"]
+    assert "workspace_path: /workspace/background/agent/task/" in query
+    assert "/output.md" in query
+    assert "/scratchpad/" in query
+    assert "/logs/" in query
+    assert "/artifacts/" in query
+    assert "/subagents/" in query
+    assert query.endswith("do work")
     events = await manager.get_run_events(run.run_id)
     assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
     assert events[-1]["event"] == "background_run_completed"


### PR DESCRIPTION
## Summary
- expand the injected background run context with concrete workspace destinations for final output, scratchpad, logs, artifacts, and subagent outputs
- keep the original task query appended unchanged after the run context
- tighten the wording so agents are told to keep the final response concise and put durable detail in workspace files

## Verification
- `uv run pytest tests/test_background_agent.py::test_manager_run_now_executes_agent_and_records_events tests/test_background_agent.py::test_background_run_writes_workspace_lifecycle_files tests/test_background_agent.py::test_workspace_policy_can_disable_lifecycle_files -q` -> `3 passed`
- `uv run pytest tests/test_background_agent.py tests/test_omniserve_background.py tests/test_background_task_store_contract.py -q` -> `132 passed, 7 skipped`
- `uv run pytest -q` -> `663 passed, 7 skipped`

## Review notes
- Architecture review: no findings
- QA review: no findings
- Developer-experience review found ambiguous “foreground response” wording; fixed to “final response” before commit
