### PR TITLE
Expose background status inspection

### DIFF
--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -166,9 +166,9 @@ OmniServe to return the structured response before the outer HTTP timeout. The
 `504` response includes the `run_id`, `task_id`, latest `status`,
 `wait_timeout_seconds`, and `request_timeout_seconds` in `detail`.
 
-The background API includes task creation, task listing, pause, resume, delete,
-manual run, cancellation, run status, attempt history, event replay, and
-workspace inspection.
+The background API includes manager status, task creation, task status, task
+listing, pause, resume, delete, manual run, cancellation, run status, attempt
+history, event replay, and workspace inspection.
 
 ## Task Configuration
 

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -215,6 +215,7 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
+| `GET` | `/background/status` | Yes* | Inspect background manager counts and run status totals |
 | `POST` | `/background/agents` | Yes* | Register the served agent or an agent spec for background execution |
 | `GET` | `/background/agents` | Yes* | List registered background agents |
 | `GET` | `/background/agents/{agent_id}` | Yes* | Inspect a background agent spec |
@@ -222,6 +223,7 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `POST` | `/background/tasks` | Yes* | Create a background task |
 | `GET` | `/background/tasks` | Yes* | List background tasks |
 | `GET` | `/background/tasks/{task_id}` | Yes* | Inspect a background task |
+| `GET` | `/background/tasks/{task_id}/status` | Yes* | Inspect schedule state, run counts, and latest run |
 | `PATCH` | `/background/tasks/{task_id}` | Yes* | Patch a background task |
 | `POST` | `/background/tasks/{task_id}/run` | Yes* | Queue a manual background run, optionally waiting for terminal state |
 | `POST` | `/background/tasks/{task_id}/pause` | Yes* | Pause scheduled dispatch |

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -894,6 +894,8 @@ OmniServe exposes background execution through the runtime contract.
 API shape:
 
 ```text
+GET    /background/status
+
 POST   /background/agents
 GET    /background/agents
 GET    /background/agents/{agent_id}
@@ -902,6 +904,7 @@ DELETE /background/agents/{agent_id}
 POST   /background/tasks
 GET    /background/tasks
 GET    /background/tasks/{task_id}
+GET    /background/tasks/{task_id}/status
 PATCH  /background/tasks/{task_id}
 POST   /background/tasks/{task_id}/pause
 POST   /background/tasks/{task_id}/resume

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -642,6 +642,10 @@ task-store or execution semantics.
 
 Rules:
 
+- `GET /background/status` returns manager-level counts, active-run count,
+  worker identity, lease settings, and run status counts from the task store.
+- `GET /background/tasks/{task_id}/status` returns task-level schedule state,
+  run counts, status counts, and latest run metadata from the task store.
 - `POST /background/tasks/{task_id}/run` with `wait=false` returns the queued
   or skipped run immediately.
 - `POST /background/tasks/{task_id}/run` with `wait=true` returns terminal run

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -348,21 +348,45 @@ class BackgroundAgentManager:
         task = await self.task_store.get_task(task_id)
         if not task:
             raise TaskNotFoundError(f"Task not found: {task_id}")
+        schedule_state = await self.task_store.get_schedule_state(task_id)
         runs = await self.task_store.list_runs(task_id=task_id)
-        active = [run for run in runs if run.status not in {
-            RunStatus.COMPLETED,
-            RunStatus.FAILED,
-            RunStatus.CANCELLED,
-            RunStatus.TIMEOUT,
-            RunStatus.SKIPPED,
-        }]
-        return {"task_id": task_id, "enabled": task.enabled, "runs": len(runs), "active": len(active)}
+        active = [run for run in runs if run.status not in TERMINAL_RUN_STATUSES]
+        status_counts = {status.value: 0 for status in RunStatus}
+        for run in runs:
+            status_counts[run.status.value] += 1
+        latest_run = runs[-1] if runs else None
+        return {
+            "task_id": task_id,
+            "agent_id": task.agent_id,
+            "enabled": task.enabled,
+            "schedule": task.schedule.model_dump(mode="json"),
+            "schedule_state": (
+                schedule_state.model_dump(mode="json") if schedule_state else None
+            ),
+            "runs": len(runs),
+            "active_runs": len(active),
+            "status_counts": status_counts,
+            "latest_run": latest_run.model_dump(mode="json") if latest_run else None,
+        }
 
     async def get_manager_status(self) -> dict[str, Any]:
+        agents = await self.task_store.list_agents()
+        tasks = await self.task_store.list_tasks()
+        runs = await self.task_store.list_runs()
+        active = [run for run in runs if run.status not in TERMINAL_RUN_STATUSES]
+        status_counts = {status.value: 0 for status in RunStatus}
+        for run in runs:
+            status_counts[run.status.value] += 1
         return {
             "running": self._running,
-            "agents": len(await self.task_store.list_agents()),
-            "tasks": len(await self.task_store.list_tasks()),
+            "initialized": self._initialized,
+            "worker_id": self.worker_id,
+            "lease_seconds": self.lease_seconds,
+            "agents": len(agents),
+            "tasks": len(tasks),
+            "runs": len(runs),
+            "active_runs": len(active),
+            "status_counts": status_counts,
         }
 
     async def get_run_events(self, run_id: str) -> list[dict[str, Any]]:

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from omnicoreagent.background import (
     BackgroundAgentSpec,
     BackgroundRun,
+    BackgroundScheduleState,
     BackgroundTaskSpec,
     OverlapPolicy,
     RetryPolicy,
@@ -187,6 +188,34 @@ class BackgroundStatusResponse(BaseModel):
     """Simple status response for background control endpoints."""
 
     status: str = Field(..., description="Operation status")
+
+
+class BackgroundManagerStatusResponse(BaseModel):
+    """Inspectable background manager state."""
+
+    running: bool
+    initialized: bool
+    worker_id: str
+    lease_seconds: float
+    agents: int
+    tasks: int
+    runs: int
+    active_runs: int
+    status_counts: dict[str, int]
+
+
+class BackgroundTaskStatusResponse(BaseModel):
+    """Inspectable status for one background task."""
+
+    task_id: str
+    agent_id: str
+    enabled: bool
+    schedule: ScheduleSpec
+    schedule_state: BackgroundScheduleState | None
+    runs: int
+    active_runs: int
+    status_counts: dict[str, int]
+    latest_run: BackgroundRun | None
 
 
 class BackgroundAgentsResponse(BaseModel):

--- a/src/omnicoreagent/serve/routes/background.py
+++ b/src/omnicoreagent/serve/routes/background.py
@@ -22,10 +22,12 @@ from ..models import (
     BackgroundRunTimeoutResponse,
     BackgroundRunWorkspaceResponse,
     BackgroundRunsResponse,
+    BackgroundManagerStatusResponse,
     BackgroundStatusResponse,
     BackgroundTaskCreateRequest,
     BackgroundTaskPatchRequest,
     BackgroundTaskRunRequest,
+    BackgroundTaskStatusResponse,
     BackgroundTasksResponse,
     HttpErrorResponse,
 )
@@ -38,6 +40,16 @@ _HTTP_ERROR = {"model": HttpErrorResponse}
 def create_background_router() -> APIRouter:
     """Create durable background execution endpoints."""
     router = APIRouter(prefix="/background", tags=["Background"])
+
+    @router.get(
+        "/status",
+        response_model=BackgroundManagerStatusResponse,
+        summary="Inspect background manager status",
+        responses={503: _HTTP_ERROR},
+    )
+    async def get_background_status(request: Request) -> BackgroundManagerStatusResponse:
+        manager = _require_background_manager(request)
+        return BackgroundManagerStatusResponse(**await manager.get_manager_status())
 
     @router.post(
         "/agents",
@@ -175,6 +187,23 @@ def create_background_router() -> APIRouter:
         if not task:
             raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
         return task
+
+    @router.get(
+        "/tasks/{task_id}/status",
+        response_model=BackgroundTaskStatusResponse,
+        summary="Inspect background task status",
+        responses={404: _HTTP_ERROR, 503: _HTTP_ERROR},
+    )
+    async def get_background_task_status(
+        request: Request, task_id: str
+    ) -> BackgroundTaskStatusResponse:
+        manager = _require_background_manager(request)
+        try:
+            return BackgroundTaskStatusResponse(
+                **await manager.get_task_status(task_id)
+            )
+        except TaskNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     @router.patch(
         "/tasks/{task_id}",

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -1000,6 +1000,45 @@ async def test_manager_run_now_executes_agent_and_records_events():
 
 
 @pytest.mark.asyncio
+async def test_manager_status_payloads_are_inspectable_without_events():
+    manager = BackgroundAgentManager(task_store="in_memory", worker_id="worker")
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "interval", "seconds": 60},
+    )
+
+    before = await manager.get_task_status("task")
+    assert before["task_id"] == "task"
+    assert before["agent_id"] == "agent"
+    assert before["enabled"] is True
+    assert before["runs"] == 0
+    assert before["active_runs"] == 0
+    assert before["latest_run"] is None
+    assert before["schedule"]["type"] == "interval"
+    assert before["schedule_state"]["next_due_at"] is not None
+
+    run = await manager.run_now("task", wait=True)
+
+    task_status = await manager.get_task_status("task")
+    manager_status = await manager.get_manager_status()
+
+    assert task_status["runs"] == 1
+    assert task_status["active_runs"] == 0
+    assert task_status["status_counts"]["completed"] == 1
+    assert task_status["latest_run"]["run_id"] == run.run_id
+    assert task_status["latest_run"]["status"] == "completed"
+    assert manager_status["worker_id"] == "worker"
+    assert manager_status["agents"] == 1
+    assert manager_status["tasks"] == 1
+    assert manager_status["runs"] == 1
+    assert manager_status["active_runs"] == 0
+    assert manager_status["status_counts"]["completed"] == 1
+
+
+@pytest.mark.asyncio
 async def test_background_run_events_replay_from_event_router():
     event_router = EventRouter()
     manager = BackgroundAgentManager(task_store="in_memory", event_router=event_router)

--- a/tests/test_omniserve_background.py
+++ b/tests/test_omniserve_background.py
@@ -141,6 +141,13 @@ def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
     )
 
     with TestClient(server.app) as client:
+        status = client.get("/background/status")
+        assert status.status_code == 200
+        assert status.json()["agents"] == 1
+        assert status.json()["tasks"] == 0
+        assert status.json()["runs"] == 0
+        assert status.json()["active_runs"] == 0
+
         agents = client.get("/background/agents")
         assert agents.status_code == 200
         assert agents.json()["agents"][0]["agent_id"] == "served"
@@ -163,6 +170,13 @@ def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
         assert task.status_code == 200
         assert task.json()["enabled"] is False
 
+        task_status = client.get("/background/tasks/daily_report/status")
+        assert task_status.status_code == 200
+        assert task_status.json()["task_id"] == "daily_report"
+        assert task_status.json()["enabled"] is False
+        assert task_status.json()["runs"] == 0
+        assert task_status.json()["schedule_state"]["task_id"] == "daily_report"
+
         patched = client.patch(
             "/background/tasks/daily_report",
             json={"enabled": True, "metadata": {"owner": "ops"}},
@@ -183,6 +197,19 @@ def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
         latest = client.get(f"/background/runs/{run['run_id']}")
         assert latest.status_code == 200
         assert latest.json()["status"] == "completed"
+
+        task_status = client.get("/background/tasks/daily_report/status")
+        assert task_status.status_code == 200
+        assert task_status.json()["runs"] == 1
+        assert task_status.json()["active_runs"] == 0
+        assert task_status.json()["status_counts"]["completed"] == 1
+        assert task_status.json()["latest_run"]["run_id"] == run["run_id"]
+
+        status = client.get("/background/status")
+        assert status.status_code == 200
+        assert status.json()["tasks"] == 1
+        assert status.json()["runs"] == 1
+        assert status.json()["status_counts"]["completed"] == 1
 
         runs = client.get("/background/runs", params={"task_id": "daily_report"})
         assert runs.status_code == 200
@@ -226,6 +253,7 @@ def test_background_api_runs_task_and_exposes_events_and_workspace(tmp_path):
         assert workspace.status_code == 200
         workspace_files = {item["name"] for item in workspace.json()["files"]}
         assert {"run.json", "events.jsonl"}.issubset(workspace_files)
+        assert client.get("/background/tasks/missing/status").status_code == 404
 
         deleted = client.delete("/background/tasks/daily_report", params={"delete_runs": True})
         assert deleted.status_code == 200
@@ -542,6 +570,9 @@ def test_background_openapi_matches_http_exception_response_shapes(tmp_path):
         run_responses = schema["paths"]["/background/tasks/{task_id}/run"][
             "post"
         ]["responses"]
+        task_status_schema = schema["components"]["schemas"][
+            "BackgroundTaskStatusResponse"
+        ]["properties"]
 
         assert (
             delete_task_responses["404"]["content"]["application/json"]["schema"][
@@ -552,4 +583,13 @@ def test_background_openapi_matches_http_exception_response_shapes(tmp_path):
         assert (
             run_responses["504"]["content"]["application/json"]["schema"]["$ref"]
             == "#/components/schemas/BackgroundRunTimeoutResponse"
+        )
+        assert task_status_schema["schedule"]["$ref"] == "#/components/schemas/ScheduleSpec"
+        assert (
+            task_status_schema["schedule_state"]["anyOf"][0]["$ref"]
+            == "#/components/schemas/BackgroundScheduleState"
+        )
+        assert (
+            task_status_schema["latest_run"]["anyOf"][0]["$ref"]
+            == "#/components/schemas/BackgroundRun"
         )


### PR DESCRIPTION
## Summary
- add manager-wide `/background/status` and per-task `/background/tasks/{task_id}/status` OmniServe endpoints
- enrich manager/task status payloads with task-store run counts, active run counts, status counts, schedule state, and latest run metadata
- use typed response models for schedule, schedule state, and latest run so OpenAPI stays useful
- update internal specs and public docs to include the inspection endpoints

## Verification
- `uv run pytest tests/test_background_agent.py::test_manager_status_payloads_are_inspectable_without_events tests/test_omniserve_background.py::test_background_api_runs_task_and_exposes_events_and_workspace tests/test_omniserve_background.py::test_background_openapi_matches_http_exception_response_shapes -q` -> `3 passed`
- `uv run pytest tests/test_background_agent.py tests/test_omniserve_background.py tests/test_background_task_store_contract.py tests/test_docs_claims.py -q` -> `135 passed, 12 skipped`
- `uv run pytest -q` -> `664 passed, 7 skipped`

## Review notes
- DX review caught ambiguous `active`; renamed to `active_runs`
- QA review caught generic OpenAPI objects; switched to typed `ScheduleSpec`, `BackgroundScheduleState`, and `BackgroundRun` response fields
- Architecture review returned no findings
