### PR TITLE
Add scheduled background cookbook example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv/
 
 # ── Workspace (all agent runtime data) ──
 workspace/
+.omnicoreagent/
 
 .agents/skills/*
 omnistudio/web/node_modules/*

--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -125,11 +125,31 @@ finally:
         await agent.cleanup()
 ```
 
+The runnable scheduled example uses the same worker path without requiring an
+LLM API key:
+
+```bash
+python3 cookbook/background_agents/scheduled_task_example.py
+```
+
+It creates a due `once` task, starts the background worker, waits for the run to
+complete, then prints task status, manager status, lifecycle events, and the
+workspace files created for the run. By default it writes the demo workspace
+under your system temp directory. Set `OMNICOREAGENT_COOKBOOK_WORKSPACE_DIR` to
+choose a different location:
+
+```bash
+OMNICOREAGENT_COOKBOOK_WORKSPACE_DIR=/tmp/omnicoreagent-background-demo \
+  python3 cookbook/background_agents/scheduled_task_example.py
+```
+
 ## Runtime Controls
 
 ```python
 run = await manager.run_now("health_report", wait=True)
 status = await manager.get_run(run.run_id)
+task_status = await manager.get_task_status("health_report")
+manager_status = await manager.get_manager_status()
 attempts = await manager.list_attempts(run.run_id)
 events = await manager.get_run_events(run.run_id)
 workspace = await manager.get_run_workspace(run.run_id)
@@ -171,9 +191,14 @@ curl -X POST http://localhost:8000/background/tasks/health_report/run \
   -d '{"wait": true}'
 ```
 
-The background API includes task creation, task listing, pause, resume, delete,
-manual run, cancellation, run status, attempt history, event replay, and
-workspace inspection.
+The background API includes manager status, task creation, task status, task
+listing, pause, resume, delete, manual run, cancellation, run status, attempt
+history, event replay, and workspace inspection.
+
+```bash
+curl http://localhost:8000/background/status
+curl http://localhost:8000/background/tasks/health_report/status
+```
 
 ## Task Configuration
 

--- a/cookbook/background_agents/_bootstrap.py
+++ b/cookbook/background_agents/_bootstrap.py
@@ -1,0 +1,14 @@
+"""Import helpers for running background-agent examples as plain scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/cookbook/background_agents/scheduled_task_example.py
+++ b/cookbook/background_agents/scheduled_task_example.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Run a scheduled background task without requiring an LLM API key.
+
+Run:
+    python3 cookbook/background_agents/scheduled_task_example.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from _bootstrap import ROOT_DIR  # noqa: F401
+from omnicoreagent import BackgroundAgentManager
+from omnicoreagent.background import RunStatus
+from omnicoreagent.core.workspace.manager import Workspace
+from omnicoreagent.background.models import TERMINAL_RUN_STATUSES
+
+
+class ScheduledReportAgent:
+    """Small deterministic agent used to demonstrate background scheduling."""
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, query: str, session_id: str | None = None) -> dict[str, str]:
+        self.calls.append({"query": query, "session_id": session_id})
+        workspace_path = workspace_path_from_query(query)
+        self.workspace.files.write_text(
+            f"{workspace_path}/output.md",
+            "Scheduled report\n\n- status: complete\n- owner: background worker\n",
+        )
+        return {
+            "response": (
+                "scheduled report complete; "
+                f"session={session_id}; "
+                f"workspace_guidance={'/workspace/background/' in query}"
+            )
+        }
+
+
+def workspace_path_from_query(query: str) -> str:
+    for line in query.splitlines():
+        if line.startswith("workspace_path: /workspace/"):
+            return line.removeprefix("workspace_path: /workspace/")
+    raise ValueError("background run query did not include workspace_path guidance")
+
+
+async def wait_for_terminal_run(
+    manager: BackgroundAgentManager,
+    task_id: str,
+    *,
+    timeout_seconds: float = 3.0,
+) -> Any:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while asyncio.get_running_loop().time() < deadline:
+        runs = await manager.list_runs(task_id=task_id)
+        terminal = [run for run in runs if run.status in TERMINAL_RUN_STATUSES]
+        if terminal:
+            latest = terminal[-1]
+            if latest.status != RunStatus.COMPLETED:
+                raise RuntimeError(
+                    f"background task ended with {latest.status.value}: {latest.error}"
+                )
+            return latest
+        await asyncio.sleep(0.05)
+    raise TimeoutError(f"background task did not complete: {task_id}")
+
+
+async def run_scheduled_example(workspace_dir: str | Path | None = None) -> dict[str, Any]:
+    workspace_root = Path(
+        workspace_dir
+        or os.getenv(
+            "OMNICOREAGENT_COOKBOOK_WORKSPACE_DIR",
+            str(Path(tempfile.gettempdir()) / "omnicoreagent_cookbook_background_workspace"),
+        )
+    )
+    workspace = Workspace.from_config(workspace_dir=workspace_root).ensure()
+    agent = ScheduledReportAgent(workspace)
+    manager = BackgroundAgentManager(workspace=workspace, worker_id="cookbook_worker")
+
+    result: dict[str, Any] | None = None
+    try:
+        await manager.register_agent("scheduled_reporter", agent)
+        await manager.register_task(
+            task_id="daily_report",
+            agent_id="scheduled_reporter",
+            query="Write the scheduled operational report.",
+            schedule={
+                "type": "once",
+                "run_at": datetime.now(timezone.utc) - timedelta(seconds=1),
+            },
+            timeout_seconds=10,
+            retry_policy={"max_retries": 1, "initial_delay_seconds": 0},
+            overlap_policy="queue_next",
+        )
+
+        await manager.start()
+        run = await wait_for_terminal_run(manager, "daily_report")
+        events = await manager.get_run_events(run.run_id)
+        task_status = await manager.get_task_status("daily_report")
+        manager_status = await manager.get_manager_status()
+        workspace_state = await manager.get_run_workspace(run.run_id)
+
+        result = {
+            "run_id": run.run_id,
+            "status": run.status.value,
+            "result_preview": run.result_preview,
+            "task_status": task_status,
+            "manager_status": manager_status,
+            "events": [event["event"] for event in events],
+            "workspace_path": run.workspace_path,
+            "workspace_files": [item["name"] for item in workspace_state["files"]],
+            "agent_calls": agent.calls,
+        }
+    finally:
+        await manager.shutdown()
+    result["shutdown_status"] = await manager.get_manager_status()
+    return result
+
+
+async def main() -> None:
+    result = await run_scheduled_example()
+    print(f"run_id={result['run_id']}")
+    print(f"status={result['status']}")
+    print(f"runs={result['task_status']['runs']}")
+    print(f"active_runs={result['task_status']['active_runs']}")
+    print(f"completed={result['task_status']['status_counts']['completed']}")
+    print(f"manager_worker={result['manager_status']['worker_id']}")
+    print(f"manager_runs={result['manager_status']['runs']}")
+    print(f"manager_active_runs={result['manager_status']['active_runs']}")
+    print(f"workspace={result['workspace_path']}")
+    print(f"files={','.join(result['workspace_files'])}")
+    print(f"events={','.join(result['events'])}")
+    print(result["result_preview"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_background_cookbook.py
+++ b/tests/test_background_cookbook.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_PATH = ROOT / "cookbook" / "background_agents" / "scheduled_task_example.py"
+
+
+def load_scheduled_example_module():
+    script_dir = str(EXAMPLE_PATH.parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+    spec = importlib.util.spec_from_file_location(
+        "scheduled_task_example", EXAMPLE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_background_scheduled_cookbook_example_runs_end_to_end(tmp_path):
+    module = load_scheduled_example_module()
+
+    result = await module.run_scheduled_example(tmp_path)
+
+    assert result["status"] == "completed"
+    assert result["task_status"]["runs"] == 1
+    assert result["task_status"]["active_runs"] == 0
+    assert result["task_status"]["status_counts"]["completed"] == 1
+    assert result["manager_status"]["worker_id"] == "cookbook_worker"
+    assert result["manager_status"]["runs"] == 1
+    assert result["shutdown_status"]["running"] is False
+    assert result["shutdown_status"]["initialized"] is False
+    assert result["shutdown_status"]["runs"] == 1
+    assert "background_task_scheduled" in result["events"]
+    assert "background_run_completed" in result["events"]
+    assert {"output.md", "run.json", "events.jsonl"}.issubset(
+        set(result["workspace_files"])
+    )
+    assert (
+        result["agent_calls"][0]["session_id"]
+        == "background:scheduled_reporter:daily_report"
+    )
+    assert "/workspace/background/" in result["agent_calls"][0]["query"]
+
+
+def test_background_scheduled_cookbook_script_runs_as_plain_script(tmp_path):
+    env = os.environ.copy()
+    env["OMNICOREAGENT_COOKBOOK_WORKSPACE_DIR"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(EXAMPLE_PATH)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "status=completed" in result.stdout
+    assert "completed=1" in result.stdout
+    assert "manager_worker=cookbook_worker" in result.stdout
+    assert "manager_runs=1" in result.stdout
+    assert "manager_active_runs=0" in result.stdout
+    assert "background_task_scheduled" in result.stdout
+    assert "background_run_completed" in result.stdout
+    assert "output.md" in result.stdout
+    assert "run.json" in result.stdout
+    assert "events.jsonl" in result.stdout


### PR DESCRIPTION
## Summary
- add a runnable scheduled background-agent cookbook example that uses the real worker path without requiring an LLM key
- demonstrate task status, manager status, lifecycle events, workspace metadata files, and agent-produced `output.md`
- document the example command, temp workspace default, workspace override, and background status endpoints
- ignore local `.omnicoreagent/` runtime output

## Verification
- `uv run ruff check cookbook/background_agents/scheduled_task_example.py tests/test_background_cookbook.py` -> passed
- `uv run pytest tests/test_background_cookbook.py tests/test_docs_claims.py -q` -> `9 passed`
- `uv run pytest tests/test_background_cookbook.py tests/test_background_agent.py tests/test_omniserve_background.py tests/test_background_task_store_contract.py tests/test_docs_claims.py -q` -> `142 passed, 7 skipped`
- `uv run pytest -q` -> `666 passed, 7 skipped`
- `python3 cookbook/background_agents/scheduled_task_example.py` -> completed, printed status/events/workspace files

## Review notes
- Architecture/DX review caught stale manager-status output and `python` command wording; fixed by printing manager fields and using `python3`
- QA review caught weak shutdown/failure/workspace assertions; fixed with terminal failure surfacing, `output.md` creation, and post-shutdown status assertions
- Final DX review caught repo-local artifact output; fixed with temp-dir default, documented override, and `.omnicoreagent/` ignore
