### PR TITLE
Finalize background backend coverage and docs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,6 +17,26 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.12
@@ -65,6 +85,18 @@ jobs:
     - name: Run unit tests with pytest
       run: |
         uv run pytest -v tests -m "not requires_api_key and not requires_network and not broken_upstream"
+      env:
+        OMNICOREAGENT_TEST_REDIS_URL: redis://localhost:6379/0
+        OMNICOREAGENT_TEST_MONGODB_URI: mongodb://localhost:27017
+        OMNICOREAGENT_TEST_MONGODB_DATABASE: omnicoreagent_test
+
+    - name: Run live background manager backend tests
+      run: |
+        uv run pytest -v tests/test_background_durable_manager_integration.py -rs
+      env:
+        OMNICOREAGENT_TEST_REDIS_URL: redis://localhost:6379/0
+        OMNICOREAGENT_TEST_MONGODB_URI: mongodb://localhost:27017
+        OMNICOREAGENT_TEST_MONGODB_DATABASE: omnicoreagent_test
 
     # TODO: Re-enable these test sections when API keys are configured in CI secrets
     # and broken_upstream tests are fixed to match current source code.

--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -94,6 +94,35 @@ manager = BackgroundAgentManager(
 Redis durable deployments need persistence enabled and a no-eviction policy for
 task-store keys. MongoDB task-store writes use majority write concern.
 
+Choose one durable backend per deployment. Use SQL/SQLite for local durability
+or simple single-node services. Use Redis when your deployment already operates
+Redis with persistence and no eviction for task-store keys. Use MongoDB when
+MongoDB is your durable operational store.
+
+Durable stores preserve queued runs across manager restarts. You can queue a
+manual run, stop the process, construct a new manager with the same task store,
+and complete the queued run from that new manager. The in-memory store does not
+provide that guarantee.
+
+OmniServe uses the same task-store settings through environment variables. Pick
+one backend:
+
+```bash
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=sql
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db
+```
+
+```bash
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=redis
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=redis://localhost:6379/0
+```
+
+```bash
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=mongodb
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=mongodb://localhost:27017
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent
+```
+
 ## Scheduled Runs
 
 Manual tasks run only when you call `run_now`. Scheduled tasks are dispatched by
@@ -198,6 +227,9 @@ history, event replay, and workspace inspection.
 ```bash
 curl http://localhost:8000/background/status
 curl http://localhost:8000/background/tasks/health_report/status
+curl http://localhost:8000/background/runs/$RUN_ID
+curl http://localhost:8000/background/runs/$RUN_ID/events
+curl http://localhost:8000/background/runs/$RUN_ID/workspace
 ```
 
 ## Task Configuration

--- a/docs/core-concepts/background-agents.mdx
+++ b/docs/core-concepts/background-agents.mdx
@@ -170,6 +170,14 @@ The background API includes manager status, task creation, task status, task
 listing, pause, resume, delete, manual run, cancellation, run status, attempt
 history, event replay, and workspace inspection.
 
+```bash
+curl http://localhost:8000/background/status
+curl http://localhost:8000/background/tasks/health_report/status
+curl http://localhost:8000/background/runs/$RUN_ID
+curl http://localhost:8000/background/runs/$RUN_ID/events
+curl http://localhost:8000/background/runs/$RUN_ID/workspace
+```
+
 ## Task Configuration
 
 | Field | Purpose |
@@ -201,6 +209,16 @@ and run event replay. Task, schedule, run, attempt, lease, retry, and
 cancellation state is restart-persistent when the task store is SQL, Redis, or
 MongoDB. Event history follows the replay rules above and needs either a
 replay-capable event router or the workspace `events.jsonl` mirror.
+
+Durable stores are tested at the manager boundary. A queued run can be created,
+the manager can shut down, and a new manager over the same SQL, Redis, or
+MongoDB task store can claim and complete that run. The in-memory store is only
+for local development, tests, and single-process experiments.
+
+Choose one durable backend per deployment. Use SQL/SQLite for local durability
+or simple single-node services. Use Redis when your deployment already operates
+Redis with persistence and no eviction for task-store keys. Use MongoDB when
+MongoDB is your durable operational store.
 
 Redis durable deployments need persistence enabled and a no-eviction policy for
 task-store keys. MongoDB task-store writes use majority write concern.

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -116,8 +116,34 @@ tasks, schedule cursors, runs, attempts, leases, heartbeats, retries, and
 cancellation flags. Defaults are intentionally light. Use `sql`, `redis`, or
 `mongodb` when background tasks must survive process restarts.
 
+Choose one durable backend per deployment. Use SQL/SQLite for local durability
+or simple single-node services. Use Redis when your deployment already operates
+Redis with persistence and no eviction for task-store keys. Use MongoDB when
+MongoDB is your durable operational store.
+
 For Redis durability, enable Redis persistence and keep task-store keys out of
 eviction. MongoDB task-store writes use majority write concern.
+
+Durable background examples. Pick one backend:
+
+```bash
+# Local SQLite durability
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=sql
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db
+```
+
+```bash
+# Redis durability
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=redis
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=redis://localhost:6379/0
+```
+
+```bash
+# MongoDB durability
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=mongodb
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=mongodb://localhost:27017
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent
+```
 
 ## 2. Agent Configuration
 

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -299,7 +299,24 @@ If auth is enabled with `--auth-token` or
 Each run stores operational state in the task store and writes lifecycle files
 into the configured workspace namespace. Use the default in-memory task store
 for local development, or choose `sql`, `redis`, or `mongodb` when runs must
-survive restarts.
+survive restarts. Durable stores preserve queued runs across server restarts:
+OmniServe can queue a run, stop, start again with the same task store, and the
+new manager can claim and complete that run.
+
+Choose one durable backend per deployment. Use SQL/SQLite for local durability
+or simple single-node services. Use Redis when your deployment already operates
+Redis with persistence and no eviction for task-store keys. Use MongoDB when
+MongoDB is your durable operational store.
+
+Common inspection endpoints:
+
+```bash
+curl http://localhost:8000/background/status
+curl http://localhost:8000/background/tasks/daily_report/status
+curl http://localhost:8000/background/runs/$RUN_ID
+curl http://localhost:8000/background/runs/$RUN_ID/events
+curl http://localhost:8000/background/runs/$RUN_ID/workspace
+```
 
 ---
 
@@ -370,6 +387,21 @@ export OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS=100
 export OMNICOREAGENT_SERVE_CORS_ORIGINS=https://myapp.com,https://api.myapp.com
 export OMNICOREAGENT_SERVE_CORS_METHODS=GET,POST,OPTIONS
 export OMNICOREAGENT_SERVE_CORS_HEADERS=Authorization,Content-Type
+
+# Optional durable background task store. Pick one backend.
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=sql
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db
+```
+
+```bash
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=redis
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=redis://localhost:6379/0
+```
+
+```bash
+export OMNICOREAGENT_BACKGROUND_TASK_STORE=mongodb
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=mongodb://localhost:27017
+export OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent
 ```
 
 ---

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -377,6 +377,13 @@ state is stateful by design. Moving from one backend to another requires an
 explicit export/import or transfer utility so task definitions, schedule state,
 run records, attempts, leases, and cancellation flags move together.
 
+Durable backend behavior is tested at the manager boundary, not only at the
+store boundary. The integration contract queues a run, shuts the manager down,
+constructs a new manager over the same task store, then executes the queued run
+through `BackgroundAgentManager.run_until_terminal()`. CI provides Redis and
+MongoDB service containers for this manager-level restart path; local developer
+runs may skip those live tests when the services are unavailable.
+
 ### Source Of Truth
 
 The task store is the source of truth for:
@@ -945,6 +952,8 @@ The background execution system is ready when:
 - every task is persisted through `AbstractTaskStore`
 - `in_memory` and `sql` conform to the same store tests
 - SQL backend supports local SQLite durability
+- Redis and MongoDB manager-level restart tests run against live backend
+  services in CI
 - enabled schedules survive manager restart on durable stores
 - schedule state stores next due, last due, dispatch cursor, and occurrence IDs
 - every run has a durable `run_id`

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -1159,6 +1159,8 @@ Run the same contract tests against every backend:
 
 - in-memory end-to-end background run with fake agent
 - SQL SQLite end-to-end restart recovery
+- Redis manager-level restart recovery with a live Redis service
+- MongoDB manager-level restart recovery with a live MongoDB service
 - workspace lifecycle files and task outputs persist for local workspace when written
 - event trace can be built for a background run
 - cookbook background example runs with a short schedule and clean shutdown
@@ -1175,6 +1177,8 @@ The implementation satisfies this specification when:
 - `redis` supports durable Redis state through a serialized snapshot and backend lock.
 - `mongodb` supports durable MongoDB state through a serialized snapshot and lock document.
 - durable stores survive manager restart.
+- CI runs live Redis and MongoDB manager restart tests; backend-unavailable
+  skips are local-development behavior only and must fail in CI.
 - every run has a durable `run_id`.
 - every run has a durable `query_snapshot`.
 - every scheduled occurrence has a stable `occurrence_id`.

--- a/tests/test_background_durable_manager_integration.py
+++ b/tests/test_background_durable_manager_integration.py
@@ -19,6 +19,8 @@ DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 DEFAULT_MONGODB_URI = "mongodb://localhost:27017"
 DEFAULT_MONGODB_DATABASE = "omnicoreagent_test"
 
+pytestmark = pytest.mark.requires_network
+
 
 class RestartAgent:
     async def run(self, query: str, session_id: str | None = None):
@@ -136,7 +138,7 @@ async def require_redis_available(config: dict) -> None:
     try:
         from redis.asyncio import Redis
     except Exception as exc:
-        pytest.skip(redis_unavailable_message(config, exc))
+        skip_or_fail_unavailable(redis_unavailable_message(config, exc))
 
     client = Redis.from_url(
         config["url"],
@@ -146,7 +148,7 @@ async def require_redis_available(config: dict) -> None:
     try:
         await client.ping()
     except Exception as exc:
-        pytest.skip(redis_unavailable_message(config, exc))
+        skip_or_fail_unavailable(redis_unavailable_message(config, exc))
     finally:
         await client.aclose()
 
@@ -155,7 +157,7 @@ async def require_mongodb_available(config: dict) -> None:
     try:
         from motor.motor_asyncio import AsyncIOMotorClient
     except Exception as exc:
-        pytest.skip(mongodb_unavailable_message(config, exc))
+        skip_or_fail_unavailable(mongodb_unavailable_message(config, exc))
 
     client = AsyncIOMotorClient(
         config["uri"],
@@ -164,7 +166,7 @@ async def require_mongodb_available(config: dict) -> None:
     try:
         await client[config["database"]].command("ping")
     except Exception as exc:
-        pytest.skip(mongodb_unavailable_message(config, exc))
+        skip_or_fail_unavailable(mongodb_unavailable_message(config, exc))
     finally:
         client.close()
 
@@ -209,6 +211,12 @@ def _summarize_exception(exc: Exception) -> str:
     message = str(exc).splitlines()[0]
     message = message.split(", Topology Description:", 1)[0]
     return f"{type(exc).__name__}: {message[:240]}"
+
+
+def skip_or_fail_unavailable(message: str) -> None:
+    if os.getenv("CI", "").lower() == "true":
+        raise AssertionError(message)
+    pytest.skip(message)
 
 
 def redis_unavailable_message(config: dict, exc: Exception) -> str:

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -188,3 +188,98 @@ def test_background_cookbook_uses_typed_event_payload_access():
 
     assert 'event.payload["event"]' not in text
     assert "event.payload.event" in text
+
+
+def test_ci_enforces_live_background_task_store_backends():
+    workflow = Path(".github/workflows/python-app.yml").read_text(encoding="utf-8")
+
+    for expected in {
+        "redis:7-alpine",
+        "mongo:7",
+        "OMNICOREAGENT_TEST_REDIS_URL",
+        "OMNICOREAGENT_TEST_MONGODB_URI",
+        "OMNICOREAGENT_TEST_MONGODB_DATABASE",
+        "Run live background manager backend tests",
+        "tests/test_background_durable_manager_integration.py",
+    }:
+        assert expected in workflow
+
+
+def test_background_docs_explain_durable_restart_behavior():
+    docs = [
+        Path("docs/core-concepts/background-agents.mdx"),
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert "queued run" in text
+        assert "same task store" in text or (
+            "same SQL, Redis, or" in text and "MongoDB task store" in text
+        )
+        assert "in-memory" in text.lower()
+
+
+def test_background_docs_show_public_status_and_run_endpoints():
+    docs = [
+        Path("docs/core-concepts/background-agents.mdx"),
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+    ]
+    endpoints = {
+        "/background/status",
+        "/background/tasks/",
+        "/background/runs/$RUN_ID",
+        "/background/runs/$RUN_ID/events",
+        "/background/runs/$RUN_ID/workspace",
+    }
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        missing = sorted(endpoint for endpoint in endpoints if endpoint not in text)
+        assert not missing, f"{path} is missing background endpoints: {missing}"
+        assert "curl http://localhost:8000/background/runs/{run_id}" not in text
+
+
+def test_background_task_store_env_examples_are_documented():
+    docs = [
+        Path("docs/how-to-guides/configuration.mdx"),
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+    ]
+    expected = {
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE=sql",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE=redis",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=redis://localhost:6379/0",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE=mongodb",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=mongodb://localhost:27017",
+        "OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent",
+    }
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        missing = sorted(name for name in expected if name not in text)
+        assert not missing, f"{path} is missing task-store env examples: {missing}"
+        assert "Pick one backend" in text or ("Pick" in text and "one backend" in text)
+
+
+def test_background_docs_include_durable_backend_selection_guidance():
+    docs = [
+        Path("docs/core-concepts/background-agents.mdx"),
+        Path("docs/how-to-guides/configuration.mdx"),
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("cookbook/background_agents/README.mdx"),
+    ]
+    expected = {
+        "Use SQL/SQLite for local durability",
+        "Use Redis when your deployment already operates",
+        "Use MongoDB when",
+        "MongoDB is your durable operational store",
+    }
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        missing = sorted(phrase for phrase in expected if phrase not in text)
+        assert not missing, f"{path} is missing backend selection guidance: {missing}"


### PR DESCRIPTION
## Summary
- add Redis and MongoDB service containers in CI for live background manager restart tests
- mark live durable manager tests as `requires_network`, then run them in a dedicated CI step with backend env vars
- make live backend availability fail in CI instead of silently skipping when Redis/MongoDB are unavailable
- align background architecture/spec docs with manager-level durable restart coverage for SQL, Redis, and MongoDB
- update public background docs, configuration docs, OmniServe docs, and cookbook examples for task-store env vars, status/run endpoints, durable restart behavior, and in-memory vs durable behavior
- add docs-claim tests for CI enforcement, durable restart wording, backend selection guidance, endpoint examples, and task-store env examples

## Reviewer pass
- CI/backend reviewer found duplicate CI execution of the live manager file; fixed by marking the file `requires_network` and keeping the dedicated live backend step
- docs/spec reviewer found no blocking issues
- DX reviewer found copy-paste risks in backend env snippets, missing backend selection guidance, and `{run_id}` curl placeholders; fixed with “pick one backend” examples, SQL/Redis/MongoDB selection guidance, and `$RUN_ID` curl examples

## Verification
- `uv run ruff check tests/test_background_durable_manager_integration.py tests/test_docs_claims.py`
- `uv run pytest tests/test_docs_claims.py tests/test_background_durable_manager_integration.py -q -rs` -> `13 passed, 1 skipped` locally; MongoDB skipped because no local MongoDB server is running
- `uv run pytest tests/test_background_durable_manager_integration.py tests/test_background_task_store_contract.py tests/test_background_agent.py tests/test_omniserve_background.py tests/test_background_cookbook.py -q -rs` -> `136 passed, 8 skipped` locally; MongoDB skipped because no local MongoDB server is running
- `uv run pytest -q` -> `672 passed, 8 skipped`
- `git diff --check`
