### PR TITLE
Harden OmniServe configuration and docs

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -169,8 +169,8 @@ inspected through `/background/runs/{run_id}`.
 omniserve generate-dockerfile --file cookbook/omniserve/cli_agent.py
 
 # Build and run
-docker build -t omniserver .
-docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver
+docker build -t omnicoreagent-serve .
+docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omnicoreagent-serve
 ```
 
 ### Cloud Deployment (Cloud Run, AWS Fargate, Railway)
@@ -188,5 +188,5 @@ docker run -p 8000:8000 \
   -e AWS_S3_BUCKET=my-bucket \
   -e AWS_ACCESS_KEY_ID=... \
   -e AWS_SECRET_ACCESS_KEY=... \
-  omniserver
+  omnicoreagent-serve
 ```

--- a/cookbook/omniserve/cli_agent.py
+++ b/cookbook/omniserve/cli_agent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-OmniServe v0.0.1 - CLI Agent Example
+OmniServe - CLI Agent Example
 
 =============================================================================
 HOW TO RUN (CLI)

--- a/cookbook/omniserve/python_api.py
+++ b/cookbook/omniserve/python_api.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-OmniServe v0.0.1 - Python API Example (Full Configuration)
+OmniServe - Python API Example (Full Configuration)
 
 =============================================================================
 HOW TO RUN
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     # Startup banner
     print()
     print("=" * 70)
-    print("🚀 OmniServe v0.0.1 - Python API Example")
+    print("🚀 OmniServe - Python API Example")
     print("=" * 70)
     print()
     print("ENDPOINTS:")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,8 @@
 #
 # Multi-stage build for smaller production image
 #
-# Build:  docker build -t omniserver:latest -f docker/Dockerfile .
-# Run:    docker run -p 8000:8000 -e LLM_API_KEY=xxx omniserver:latest
+# Build:  docker build -t omnicoreagent-serve:latest -f docker/Dockerfile .
+# Run:    docker run -p 8000:8000 -e LLM_API_KEY=xxx omnicoreagent-serve:latest
 
 FROM python:3.12-slim AS builder
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# OmniServe Docker Compose with Full Observability Stack
+# OmniServe Docker Compose with Prometheus/Grafana request metrics
 #
 # Quick start:
 #   1. Copy .env.example to .env and set your API keys
@@ -13,11 +13,11 @@ services:
   # =========================================================================
   # OmniServe - The AI Agent API Server
   # =========================================================================
-  omniserver:
+  omnicoreagent-serve:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    container_name: omniserver
+    container_name: omnicoreagent-serve
     ports:
       - "${OMNICOREAGENT_SERVE_PORT:-8000}:8000"
     environment:
@@ -97,7 +97,7 @@ services:
       start_period: 10s
     restart: unless-stopped
     networks:
-      - omniserver-net
+      - omnicoreagent-serve-net
     
     # Optional: Mount custom agent file
     # volumes:
@@ -111,7 +111,7 @@ services:
   # =========================================================================
   prometheus:
     image: prom/prometheus:v2.48.0
-    container_name: omniserver-prometheus
+    container_name: omnicoreagent-serve-prometheus
     ports:
       - "9090:9090"
     volumes:
@@ -128,9 +128,9 @@ services:
       retries: 3
     restart: unless-stopped
     networks:
-      - omniserver-net
+      - omnicoreagent-serve-net
     depends_on:
-      - omniserver
+      - omnicoreagent-serve
 
   # =========================================================================
   # Grafana - Metrics Visualization
@@ -138,7 +138,7 @@ services:
   # =========================================================================
   grafana:
     image: grafana/grafana:10.2.2
-    container_name: omniserver-grafana
+    container_name: omnicoreagent-serve-grafana
     ports:
       - "3000:3000"
     environment:
@@ -155,16 +155,16 @@ services:
       retries: 3
     restart: unless-stopped
     networks:
-      - omniserver-net
+      - omnicoreagent-serve-net
     depends_on:
       - prometheus
 
   # =========================================================================
-  # Redis (Optional) - For distributed rate limiting
+  # Redis (Optional) - For future durable integrations, not current rate limiting
   # =========================================================================
   # redis:
   #   image: redis:7-alpine
-  #   container_name: omniserver-redis
+  #   container_name: omnicoreagent-serve-redis
   #   ports:
   #     - "6379:6379"
   #   healthcheck:
@@ -173,13 +173,12 @@ services:
   #     timeout: 5s
   #     retries: 3
   #   networks:
-  #     - omniserver-net
+  #     - omnicoreagent-serve-net
 
 networks:
-  omniserver-net:
+  omnicoreagent-serve-net:
     driver: bridge
 
 volumes:
   prometheus-data:
   grafana-data:
-

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -8,9 +8,9 @@ global:
 
 scrape_configs:
   # OmniServe metrics
-  - job_name: "omniserver"
+  - job_name: "omnicoreagent-serve"
     static_configs:
-      - targets: ["omniserver:8000"]
+      - targets: ["omnicoreagent-serve:8000"]
     metrics_path: "/prometheus"
     scrape_interval: 10s
     scrape_timeout: 5s

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -207,7 +207,7 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/metrics` | Yes* | Agent usage metrics |
 | `GET` | `/events/{session_id}` | Yes* | Replay stored session events, then follow live events over SSE |
 | `GET` | `/events/{session_id}/list` | Yes* | Return stored session events as JSON |
-| `GET` | `/events/{session_id}/trace` | Yes* | Compact agent trace summary |
+| `GET` | `/events/{session_id}/trace` | Yes* | Compact session event summary |
 | `GET` | `/docs` | No | Swagger UI |
 | `GET` | `/redoc` | No | ReDoc UI |
 
@@ -417,8 +417,8 @@ omniserve generate-dockerfile --file my_agent.py
 ### Build and run
 
 ```bash
-docker build -t omniserver .
-docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver
+docker build -t omnicoreagent-serve .
+docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omnicoreagent-serve
 ```
 
 **Smart Configuration** — The generator inspects your agent and configures storage automatically:
@@ -432,7 +432,7 @@ docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver
 
 ```bash
 # Local workspace (ephemeral)
-docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver
+docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omnicoreagent-serve
 
 # AWS S3 workspace (persistent)
 docker run -p 8000:8000 \
@@ -442,7 +442,7 @@ docker run -p 8000:8000 \
   -e AWS_ACCESS_KEY_ID=... \
   -e AWS_SECRET_ACCESS_KEY=... \
   -e AWS_REGION=us-east-1 \
-  omniserver
+  omnicoreagent-serve
 
 # Cloudflare R2 workspace (persistent)
 docker run -p 8000:8000 \
@@ -452,7 +452,7 @@ docker run -p 8000:8000 \
   -e R2_ACCOUNT_ID=... \
   -e R2_ACCESS_KEY_ID=... \
   -e R2_SECRET_ACCESS_KEY=... \
-  omniserver
+  omnicoreagent-serve
 ```
 
 ---

--- a/engineering/README.md
+++ b/engineering/README.md
@@ -34,4 +34,5 @@ Current records:
 - `architecture/workspace.md`
 - `specifications/background-agents.md`
 - `specifications/events.md`
+- `specifications/omniserve.md`
 - `specifications/workspace.md`

--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -15,6 +15,7 @@ OmniServe exists to expose an agent over HTTP:
 - accept REST and SSE requests
 - call the configured agent
 - expose health, readiness, tools, session, event, and metrics endpoints
+- expose background task control endpoints when background execution is enabled
 - handle HTTP middleware concerns such as CORS, auth, request logging, rate
   limiting, timeout, and error responses
 - serialize runtime objects into stable API responses
@@ -74,6 +75,87 @@ serve/
 6. `lifespan.py` connects MCP servers on startup and calls agent cleanup on
    shutdown if those methods exist.
 
+## Configuration Boundary
+
+OmniServe configuration is owned by `OmniServeConfig`.
+
+Defaults must support a zero-server-config local start. Production settings are
+opt-in and must use explicit OmniCoreAgent-prefixed environment variables:
+
+- `OMNICOREAGENT_SERVE_*` for HTTP serving behavior
+- `OMNICOREAGENT_BACKGROUND_*` for background task serving behavior
+
+Generic process variables such as `REDIS_URL` and `MONGODB_URI` are not part of
+the OmniServe public contract. Background task stores may use Redis or MongoDB,
+but the serving layer must read those locations through the
+`OMNICOREAGENT_BACKGROUND_*` names so configuration stays explicit and docs stay
+accurate.
+
+Environment values should fail clearly when invalid. Silent ignore behavior is
+bad production behavior because it makes a server appear correctly configured
+while running with defaults.
+
+## Runtime Lifecycle Boundary
+
+OmniServe owns the HTTP lifespan around one served agent:
+
+1. store agent/config/background manager in app state.
+2. connect MCP servers when the served agent exposes `connect_mcp_servers`.
+3. initialize the background manager when background execution is enabled.
+4. register the served agent under `background_agent_id`.
+5. start the background worker when configured.
+6. on shutdown, stop the background manager before agent cleanup.
+7. call agent cleanup when the served agent exposes `cleanup`.
+
+Lifespan errors should fail startup or shutdown clearly. They should not leave a
+half-started server that reports readiness while core dependencies failed.
+
+## HTTP API Boundary
+
+OmniServe exposes one agent through a stable API surface:
+
+- `/health` and `/ready`
+- `/run` for SSE execution
+- `/run/sync` for JSON execution
+- `/events/{session_id}` for session event replay/follow streams
+- `/events/{session_id}/list` for stored session events
+- `/events/{session_id}/trace` for the current compact event summary exposed by
+  the agent runtime
+- `/sessions/{session_id}/history`
+- `/sessions/{session_id}` delete
+- `/tools`
+- `/metrics`
+- `/prometheus`
+- `/background/*` when background execution is enabled
+
+`api_prefix` applies to API routes mounted by the agent router. Global FastAPI
+documentation and Prometheus paths remain global unless a deliberate design
+changes that.
+
+## SSE Boundary
+
+SSE is a serving transport over runtime events.
+
+`/run` must:
+
+- create a fresh `run_id` for the request.
+- attach that `run_id` to runtime event emission.
+- stream only events matching that `run_id`.
+- include the route `session_id` in every event payload.
+- stream final `complete` with the same `run_id`.
+- emit a terminal session-ended chunk even after timeout or handled errors.
+- avoid waiting forever on catch-up replay after the agent run has completed.
+
+`/events/{session_id}` must:
+
+- replay stored events for that session.
+- follow live events for that session.
+- deduplicate events by `event_id` when available.
+- never mix events from another session.
+
+This is not the future trace system. It is the reliable live/replay event
+transport OmniServe owns today.
+
 ## Metrics Boundary
 
 OmniServe request metrics are per FastAPI app instance. They are exposed as
@@ -82,6 +164,42 @@ Prometheus text at `/prometheus`.
 This is not full observability. It is request counting, active requests, and
 request duration only. Agent-level usage remains available through
 `agent.get_metrics()` and the `/metrics` endpoint.
+
+Rate-limit state is also per FastAPI process. It is a serving guardrail for
+simple deployments, not a distributed quota system.
+
+## Middleware Boundary
+
+Middleware must be predictable and testable:
+
+- public auth bypass paths are explicit.
+- protected routes require bearer auth when auth is enabled.
+- rate limiting applies to protected routes when enabled.
+- request timeout is configured by `request_timeout`.
+- CORS behavior follows `OmniServeConfig`.
+- request logging adds process-time headers when enabled.
+- unhandled serving errors become stable JSON responses.
+
+Do not hide route-specific `HTTPException` responses behind generic `500`
+payloads.
+
+## Background Serving Boundary
+
+OmniServe may expose HTTP control for background execution, but
+`BackgroundAgentManager` remains the owner of task stores, scheduling, leases,
+retries, cancellation, run events, and workspace output.
+
+The serving layer is responsible for:
+
+- constructing or accepting a background manager.
+- registering the served agent.
+- mapping HTTP requests to manager calls.
+- preserving typed error/status responses.
+- applying the same middleware and `api_prefix` rules as the rest of the API.
+
+Background `wait=true` uses a serving wait budget derived from
+`request_timeout` so OmniServe can return a structured `504` before the outer
+HTTP timeout cancels response generation.
 
 ## Public Surface
 
@@ -109,3 +227,10 @@ of the production agent harness.
 - Public endpoints that intentionally bypass auth must be explicit and tested.
 - `request_timeout` must be enforced for agent run endpoints.
 - Docs and cookbooks must describe only shipped behavior.
+- OmniServe docs must use the single public model credential variable:
+  `LLM_API_KEY`.
+- OmniServe task-store docs must use `OMNICOREAGENT_BACKGROUND_*` variables.
+- CLI examples must not ask users to export mutually exclusive backends in one
+  copy-paste block.
+- CLI/cookbook output must use the OmniCoreAgent package version when a version
+  is shown. OmniServe does not have a separate version.

--- a/engineering/specifications/README.md
+++ b/engineering/specifications/README.md
@@ -20,4 +20,5 @@ Current specifications:
 
 - `background-agents.md`
 - `events.md`
+- `omniserve.md`
 - `workspace.md`

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -1,0 +1,464 @@
+# OmniServe Specification
+
+This is an internal specification. It defines the behavior OmniServe must
+implement and test. Public docs live under `docs/` and `cookbook/`.
+
+## Purpose
+
+OmniServe turns one existing `OmniCoreAgent` instance into a REST/SSE API.
+
+It owns the HTTP serving contract:
+
+- configuration
+- FastAPI app construction
+- route mounting
+- lifespan startup/shutdown
+- middleware
+- serialization
+- SSE transport
+- request metrics
+- background task HTTP control
+
+It does not own the agent reasoning loop, tool execution, memory, workspace,
+MCP protocol internals, background scheduling internals, trace, evals, policy,
+or sandboxing.
+
+## Public Exports
+
+The serving package exports:
+
+```python
+from omnicoreagent import OmniServe, OmniServeConfig
+```
+
+No additional serving internals are public API unless deliberately documented in
+a later specification.
+
+## Configuration Contract
+
+`OmniServeConfig` is the source of truth for serving configuration.
+
+Defaults:
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `host` | `0.0.0.0` | Bind address |
+| `port` | `8000` | Bind port |
+| `workers` | `1` | Uvicorn worker processes |
+| `api_prefix` | `""` | Prefix for agent API routes |
+| `enable_docs` | `true` | Enable `/docs` |
+| `enable_redoc` | `true` | Enable `/redoc` |
+| `cors_enabled` | `true` | Enable CORS middleware |
+| `cors_origins` | `["*"]` | Allowed origins |
+| `cors_methods` | `["*"]` | Allowed methods |
+| `cors_headers` | `["*"]` | Allowed headers |
+| `cors_credentials` | `true` | Allow credentials |
+| `auth_enabled` | `false` | Require bearer auth on protected routes |
+| `auth_token` | `None` | Bearer token |
+| `request_logging` | `true` | Log requests |
+| `log_level` | `INFO` | Uvicorn log level |
+| `request_timeout` | `300` | HTTP request timeout seconds |
+| `rate_limit_enabled` | `false` | Enable in-process rate limiting |
+| `rate_limit_requests` | `100` | Requests per window |
+| `rate_limit_window` | `60` | Rate limit window seconds |
+| `background_enabled` | `true` | Expose background routes |
+| `background_agent_id` | `default` | Served-agent id in background manager |
+| `background_task_store` | `in_memory` | Background task store backend |
+| `background_start_worker` | `true` | Start background scheduler/worker |
+
+Environment variables override code values:
+
+| Variable | Field |
+|----------|-------|
+| `OMNICOREAGENT_SERVE_HOST` | `host` |
+| `OMNICOREAGENT_SERVE_PORT` | `port` |
+| `OMNICOREAGENT_SERVE_WORKERS` | `workers` |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `api_prefix` |
+| `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `enable_docs` |
+| `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `enable_redoc` |
+| `OMNICOREAGENT_SERVE_CORS_ENABLED` | `cors_enabled` |
+| `OMNICOREAGENT_SERVE_CORS_ORIGINS` | `cors_origins` |
+| `OMNICOREAGENT_SERVE_CORS_METHODS` | `cors_methods` |
+| `OMNICOREAGENT_SERVE_CORS_HEADERS` | `cors_headers` |
+| `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `cors_credentials` |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `auth_enabled` |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | `auth_token` |
+| `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `request_logging` |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `log_level` |
+| `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `request_timeout` |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `rate_limit_enabled` |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `rate_limit_requests` |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `rate_limit_window` |
+| `OMNICOREAGENT_BACKGROUND_ENABLED` | `background_enabled` |
+| `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `background_agent_id` |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `background_task_store` |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` | SQL or Redis task-store URL |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_URI` | MongoDB task-store URI |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE` | MongoDB database |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX` | Redis key prefix |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX` | MongoDB collection prefix |
+| `OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT` | Backend connect timeout seconds |
+| `OMNICOREAGENT_BACKGROUND_START_WORKER` | `background_start_worker` |
+
+Invalid env values must fail clearly during configuration creation. They must
+not be silently ignored.
+
+Generic env fallbacks such as `REDIS_URL`, `MONGODB_URI`, `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GROQ_API_KEY` are not part of the
+OmniServe public configuration contract.
+
+## Background Task Store Normalization
+
+`OmniServeConfig.background_task_store_config()` returns the value passed to
+`BackgroundAgentManager`.
+
+Rules:
+
+- if `background_task_store` is a dict, return it unchanged.
+- if `OMNICOREAGENT_BACKGROUND_TASK_STORE_URI` or
+  `background_task_store_uri` is set, return a MongoDB config.
+- if a task-store URI is set with any backend other than unset, `in_memory`, or
+  `mongodb`, fail clearly.
+- if `OMNICOREAGENT_BACKGROUND_TASK_STORE_URL` or
+  `background_task_store_url` is set and `background_task_store` is unset or
+  `in_memory`, return a SQL config. URL-only means SQL.
+- if a task-store URL is set and `background_task_store == "redis"`, return a
+  Redis config.
+- if a task-store URL is set with any backend other than unset, `in_memory`,
+  `sql`, or `redis`, fail clearly.
+- if `background_task_store == "redis"` and no task-store URL is configured,
+  fail clearly before manager initialization. OmniServe must not read
+  `REDIS_URL`.
+- if `background_task_store == "mongodb"` and no task-store URI is configured,
+  fail clearly before manager initialization. OmniServe must not read
+  `MONGODB_URI`.
+- otherwise return the configured backend string.
+
+The serving layer must not read `REDIS_URL` or `MONGODB_URI` to fill missing
+task-store locations.
+
+## Route Contract
+
+The agent router exposes:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Liveness |
+| `GET` | `/ready` | Readiness |
+| `POST` | `/run` | Agent run with SSE stream |
+| `POST` | `/run/sync` | Agent run with JSON response |
+| `GET` | `/events/{session_id}` | Replay/follow session events over SSE |
+| `GET` | `/events/{session_id}/list` | List stored session events |
+| `GET` | `/events/{session_id}/trace` | Agent-provided compact event summary |
+| `GET` | `/sessions/{session_id}/history` | Session messages |
+| `DELETE` | `/sessions/{session_id}` | Clear session messages |
+| `GET` | `/tools` | List available tools |
+| `GET` | `/metrics` | Agent usage metrics |
+
+When `background_enabled` is true, background routes expose:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/background/status` | Manager status |
+| `POST` | `/background/agents` | Register served agent or agent spec |
+| `GET` | `/background/agents` | List background agents |
+| `GET` | `/background/agents/{agent_id}` | Inspect agent spec |
+| `DELETE` | `/background/agents/{agent_id}` | Delete agent spec |
+| `POST` | `/background/tasks` | Create task |
+| `GET` | `/background/tasks` | List tasks |
+| `GET` | `/background/tasks/{task_id}` | Inspect task |
+| `GET` | `/background/tasks/{task_id}/status` | Task status |
+| `PATCH` | `/background/tasks/{task_id}` | Patch task |
+| `POST` | `/background/tasks/{task_id}/run` | Queue/manual run |
+| `POST` | `/background/tasks/{task_id}/pause` | Pause scheduled dispatch |
+| `POST` | `/background/tasks/{task_id}/resume` | Resume scheduled dispatch |
+| `DELETE` | `/background/tasks/{task_id}` | Delete task |
+| `POST` | `/background/runs/{run_id}/cancel` | Cancel run |
+| `GET` | `/background/runs` | List runs |
+| `GET` | `/background/runs/{run_id}` | Inspect run |
+| `GET` | `/background/runs/{run_id}/attempts` | List run attempts |
+| `GET` | `/background/runs/{run_id}/events` | Replay run lifecycle events |
+| `GET` | `/background/runs/{run_id}/workspace` | Inspect run workspace files |
+
+`api_prefix` applies to these agent router paths.
+
+Global FastAPI routes are not mounted through the agent router:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/docs` | Swagger UI when enabled |
+| `GET` | `/redoc` | ReDoc UI when enabled |
+| `GET` | `/openapi.json` | OpenAPI schema |
+| `GET` | `/prometheus` | OmniServe HTTP metrics |
+
+These global paths are not prefixed by `api_prefix`.
+
+## Auth And Public Paths
+
+When auth is disabled, all routes are accessible.
+
+When auth is enabled:
+
+- `/health` and `/ready` bypass auth.
+- prefixed health/readiness paths bypass auth when `api_prefix` is set.
+- `/docs`, `/redoc`, `/openapi.json`, and `/prometheus` bypass auth.
+- every other route requires `Authorization: Bearer <token>`.
+- missing or invalid auth returns `401` JSON.
+
+Public bypass paths must stay explicit and tested.
+
+## Rate Limiting
+
+Rate limiting is in-process per FastAPI app instance.
+
+When enabled:
+
+- public auth-bypass paths are exempt.
+- protected routes are keyed by client IP.
+- `X-Forwarded-For` is used when present.
+- `X-Real-IP` is used when present and `X-Forwarded-For` is absent.
+- otherwise the ASGI client host is used.
+- denied requests return `429` JSON and rate-limit headers.
+- allowed requests include rate-limit headers.
+
+Distributed rate limiting is not part of this phase.
+
+## Timeout Contract
+
+`request_timeout <= 0` disables OmniServe request timeout behavior.
+
+`/run/sync`:
+
+- wraps `agent.run()` with `asyncio.wait_for` when timeout is positive.
+- returns `504` when the run exceeds the timeout.
+
+`/run` SSE:
+
+- passes `request_timeout` to the SSE run helper.
+- emits an `error` SSE chunk when the run exceeds the timeout.
+- emits a final session-ended SSE chunk after timeout handling.
+
+Background `wait=true`:
+
+- uses a wait budget derived from `request_timeout`.
+- returns the terminal run if it finishes inside the wait budget.
+- returns structured `504` if the run remains non-terminal after the wait
+  budget.
+- the `504` detail includes `message`, `run_id`, `task_id`, `status`,
+  `wait_timeout_seconds`, and `request_timeout_seconds`.
+- when `request_timeout <= 0`, OmniServe does not create its own HTTP wait
+  budget. The background manager decides whether the run completes inline or
+  returns the latest non-terminal state according to its `run_now(wait=True)`
+  contract.
+
+## SSE Contract
+
+`/run` SSE sequence:
+
+1. session-started event.
+2. zero or more runtime events for the current `run_id`.
+3. `complete` event with normalized run result and same `run_id`.
+4. session-ended event.
+
+On handled timeout/error:
+
+1. session-started event.
+2. `error` event with `session_id` and `run_id`.
+3. session-ended event.
+
+Every runtime event emitted through `/run` includes:
+
+- `session_id`
+- the request `run_id`
+- normalized event fields from the runtime event object
+
+Concurrent `/run` streams using the same `session_id` must not stream each
+other's runtime events.
+
+`/events/{session_id}`:
+
+- starts with a session-streaming event.
+- replays stored events for that session.
+- follows live events for that session.
+- deduplicates by `event_id` when available.
+- ends with a session-ended event when the client disconnects or the generator
+  closes.
+
+## Serialization Contract
+
+`agent.run()` responses normalize to:
+
+```python
+{
+    "response": str,
+    "agent_name": str,
+    "metric": dict | None,
+}
+```
+
+If the runtime returns a dict, OmniServe reads `response`, `agent_name`, and
+`metric`. If the runtime returns any other value, OmniServe stringifies it as
+`response`.
+
+Runtime events normalize to JSON-ready dictionaries using:
+
+- mappings
+- dataclasses
+- `to_dict()`
+- Pydantic `model_dump()`
+- legacy `dict()`
+- public `__dict__`
+- string fallback
+
+## Lifespan Contract
+
+Startup:
+
+1. set `app.state.start_time`.
+2. call `agent.connect_mcp_servers()` when present.
+3. initialize background manager when enabled.
+4. register the served agent under `background_agent_id`.
+5. start background worker when `background_start_worker` is true.
+
+Shutdown:
+
+1. shut down background manager when present.
+2. call `agent.cleanup()` when present.
+
+Startup failures must not report readiness as healthy.
+
+## Readiness Contract
+
+`/health` reports process liveness and uptime.
+
+`/ready` reports:
+
+- `ready`
+- `agent_name`
+- `initialized`
+- `mcp_connected`
+
+Readiness must remain cheap. It should not execute model calls, tool calls, or
+background work.
+
+## Error Contract
+
+Route-specific `HTTPException` responses must keep their intended status and
+detail payload.
+
+Unhandled serving errors return stable JSON:
+
+```json
+{
+  "error": "InternalServerError",
+  "message": "An internal server error occurred",
+  "detail": "..."
+}
+```
+
+Future hardening may hide `detail` behind a debug flag. Until then, docs must
+not promise sanitized production error bodies.
+
+## Metrics Contract
+
+`/prometheus` exposes per-app OmniServe HTTP metrics:
+
+- `omniserve_requests_total`
+- `omniserve_requests_success`
+- `omniserve_requests_error`
+- `omniserve_active_requests`
+- request duration summary fields
+- path-specific request counters
+
+Metrics are per process and per FastAPI app instance.
+
+`/metrics` exposes agent runtime usage metrics returned by `agent.get_metrics()`.
+
+## CLI Contract
+
+`omniserve run`:
+
+- loads a Python file containing `agent` or `create_agent()`.
+- builds `OmniServeConfig`.
+- starts `OmniServe`.
+
+`omniserve quickstart`:
+
+- creates a simple `OmniCoreAgent`.
+- starts `OmniServe`.
+
+`omniserve config --env-example`:
+
+- prints `LLM_API_KEY`.
+- prints optional `OMNICOREAGENT_SERVE_*` settings.
+- prints background durable task-store examples as mutually exclusive choices.
+- must not print stale `OMNISERVE_*`, generic provider key names, `REDIS_URL`,
+  or `MONGODB_URI`.
+
+CLI version/output uses the installed OmniCoreAgent package version. OmniServe
+does not have a separate version. Hard-coded stale `v0.0.1` strings are not
+acceptable.
+
+## Docker Generator Contract
+
+The Docker generator creates a Dockerfile for a provided agent file.
+
+It may set non-sensitive defaults such as:
+
+- `AGENT_PATH`
+- local workspace backend and directory
+
+It must not bake credentials into the image.
+
+Generated usage examples should use the same image tag consistently and should
+not introduce stale names that conflict with OmniServe or OmniCoreAgent docs.
+
+## Documentation Contract
+
+Public OmniServe docs and cookbook examples must:
+
+- use `LLM_API_KEY` as the model credential variable.
+- use `OMNICOREAGENT_SERVE_*` for serving config.
+- use `OMNICOREAGENT_BACKGROUND_*` for background serving config.
+- document in-memory as the zero-config default.
+- document SQL, Redis, and MongoDB as durable task-store choices.
+- say to choose one durable backend per deployment.
+- use `$RUN_ID` for copy-pasteable curl examples.
+- not claim full trace/eval/observability features in this phase.
+
+## Test Requirements
+
+The OmniServe hardening phase must maintain or add tests for:
+
+- import laziness for `omnicoreagent` and optional serve dependencies.
+- default config values.
+- env overrides.
+- invalid env values failing clearly.
+- task-store config normalization for in-memory, SQL, Redis, and MongoDB.
+- absence of generic `REDIS_URL`/`MONGODB_URI` dependency in OmniServe config.
+- CLI env example correctness.
+- auth middleware with and without `api_prefix`.
+- public bypass paths.
+- rate limiting allowed and denied paths.
+- request timeout for `/run/sync`.
+- SSE timeout/error sequence for `/run`.
+- concurrent same-session `/run` isolation by `run_id`.
+- `/events/{session_id}` replay/follow isolation by `session_id`.
+- lifecycle startup/shutdown order.
+- background API auth, prefix, disabled state, wait=true, timeout, event replay,
+  workspace inspection, and OpenAPI response shapes.
+- request metrics are per app instance.
+- docs tests asserting public docs use current env names and endpoint examples.
+
+## Acceptance Criteria
+
+OmniServe is production-hardened for this phase when:
+
+- configuration behavior is explicit, prefixed, documented, and tested.
+- serving lifecycle is deterministic and tested.
+- REST responses and SSE streams have stable contracts.
+- background task HTTP control remains aligned with `BackgroundAgentManager`.
+- middleware behavior is predictable with `api_prefix`.
+- docs and cookbook examples match the code.
+- full test suite passes.
+- reviewer/evaluator agents complete without blocking findings.

--- a/src/omnicoreagent/serve/__init__.py
+++ b/src/omnicoreagent/serve/__init__.py
@@ -8,7 +8,7 @@ Transforms an OmniCoreAgent into a REST/SSE API server with:
 - Metrics and tools listing
 - Configurable middleware (CORS, auth, logging, rate limiting)
 - Prometheus metrics endpoint
-- Agent event streaming and compact event trace summaries
+- Agent event streaming and compact event summaries
 - Proper lifecycle management
 
 Usage:

--- a/src/omnicoreagent/serve/app_factory.py
+++ b/src/omnicoreagent/serve/app_factory.py
@@ -1,6 +1,7 @@
 """FastAPI application factory for OmniServe."""
 
 import time
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI
@@ -32,7 +33,7 @@ def create_omniserve_app(
     app = FastAPI(
         title=title,
         description=description,
-        version="1.0.0",
+        version=_package_version(),
         lifespan=agent_lifespan,
         docs_url="/docs" if config.enable_docs else None,
         redoc_url="/redoc" if config.enable_redoc else None,
@@ -53,6 +54,13 @@ def create_omniserve_app(
 
     logger.info(f"OmniServe: Created FastAPI app for agent '{get_agent_name(agent)}'")
     return app
+
+
+def _package_version() -> str:
+    try:
+        return version("omnicoreagent")
+    except PackageNotFoundError:
+        return "0+unknown"
 
 
 def _build_background_manager(

--- a/src/omnicoreagent/serve/cli.py
+++ b/src/omnicoreagent/serve/cli.py
@@ -10,10 +10,18 @@ Usage:
 import os
 import sys
 import importlib.util
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Optional
 
 import click
+
+
+def _package_version() -> str:
+    try:
+        return version("omnicoreagent")
+    except PackageNotFoundError:
+        return "0+unknown"
 
 
 def _load_agent_from_file(path: str):
@@ -54,7 +62,7 @@ def _load_agent_from_file(path: str):
 
 
 @click.group()
-@click.version_option(version="0.0.1", prog_name="omniserve")
+@click.version_option(version=_package_version(), prog_name="omniserve")
 def cli():
     """OmniServe - Production-ready API server for AI agents.
 
@@ -125,7 +133,8 @@ def run(
     # Start server
     click.echo("")
     click.echo("=" * 50)
-    click.echo("🚀 OmniServe v0.0.1")
+    click.echo("OmniServe")
+    click.echo(f"OmniCoreAgent {_package_version()}")
     click.echo("=" * 50)
     click.echo(f"Agent: {loaded_agent.name}")
     click.echo(f"Server: http://{config.host}:{config.port}")
@@ -211,7 +220,8 @@ def quickstart(
 
     click.echo("")
     click.echo("=" * 50)
-    click.echo("🚀 OmniServe v0.0.1 - Quickstart")
+    click.echo("OmniServe Quickstart")
+    click.echo(f"OmniCoreAgent {_package_version()}")
     click.echo("=" * 50)
     click.echo(f"Agent: {name}")
     click.echo(f"Model: {provider}/{model}")
@@ -268,10 +278,17 @@ export LLM_API_KEY=your_api_key_here
 # Optional background task persistence
 # Background APIs and the worker are enabled by default with in-memory task state.
 # Use SQL, Redis, or MongoDB when task control-plane state must survive restarts.
+# Choose one backend:
+#
+# SQL / SQLite
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE=sql
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=sqlite:///.omnicoreagent/background.db
+#
+# Redis
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE=redis
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=redis://localhost:6379/0
+#
+# MongoDB
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE=mongodb
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=mongodb://localhost:27017
 # export OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent
@@ -391,10 +408,12 @@ CMD ["sh", "-c", "omniserve run --agent $AGENT_PATH"]
 
     console.print("\n[bold]Next Steps:[/bold]")
     console.print("1. Build the image:")
-    console.print("   docker build -t omniserver .")
+    console.print("   docker build -t omnicoreagent-serve .")
 
     console.print("\n2. Run with local workspace:")
-    console.print("   docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omniserver")
+    console.print(
+        "   docker run -p 8000:8000 -e LLM_API_KEY=$LLM_API_KEY omnicoreagent-serve"
+    )
 
     console.print("\n   Or run with S3/R2 workspace persistence:")
     console.print("   docker run -p 8000:8000 \\")
@@ -403,7 +422,7 @@ CMD ["sh", "-c", "omniserve run --agent $AGENT_PATH"]
     console.print("     -e AWS_S3_BUCKET=your-bucket \\")
     console.print("     -e AWS_ACCESS_KEY_ID=... \\")
     console.print("     -e AWS_SECRET_ACCESS_KEY=... \\")
-    console.print("     omniserver")
+    console.print("     omnicoreagent-serve")
 
     console.print(
         "\n[yellow]⚠ Local workspace is ephemeral unless you mount a volume.[/yellow]"

--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -55,7 +55,12 @@ def _get_env_bool(prefix: str, key: str) -> Optional[bool]:
     val = _get_env(prefix, key)
     if val is None:
         return None
-    return val.lower() in ("true", "1", "yes", "on")
+    normalized = val.lower()
+    if normalized in ("true", "1", "yes", "on"):
+        return True
+    if normalized in ("false", "0", "no", "off"):
+        return False
+    raise ValueError(f"{prefix}_{key} must be a boolean value")
 
 
 def _get_env_int(prefix: str, key: str) -> Optional[int]:
@@ -66,7 +71,18 @@ def _get_env_int(prefix: str, key: str) -> Optional[int]:
     try:
         return int(val)
     except ValueError:
+        raise ValueError(f"{prefix}_{key} must be an integer") from None
+
+
+def _get_env_float(prefix: str, key: str) -> Optional[float]:
+    """Get float environment variable. Returns None if not set."""
+    val = _get_env(prefix, key)
+    if val is None:
         return None
+    try:
+        return float(val)
+    except ValueError:
+        raise ValueError(f"{prefix}_{key} must be a number") from None
 
 
 def _get_env_list(prefix: str, key: str) -> Optional[list[str]]:
@@ -247,11 +263,8 @@ class OmniServeConfig(BaseModel):
             self.background_task_store_prefix = val
         if (val := _get_env(background_prefix, "TASK_STORE_COLLECTION_PREFIX")) is not None:
             self.background_task_store_collection_prefix = val
-        if (val := _get_env(background_prefix, "TASK_STORE_CONNECT_TIMEOUT")) is not None:
-            try:
-                self.background_task_store_connect_timeout = float(val)
-            except ValueError:
-                pass
+        if (val := _get_env_float(background_prefix, "TASK_STORE_CONNECT_TIMEOUT")) is not None:
+            self.background_task_store_connect_timeout = val
         if (val := _get_env_bool(background_prefix, "START_WORKER")) is not None:
             self.background_start_worker = val
 
@@ -266,7 +279,13 @@ class OmniServeConfig(BaseModel):
         """Return normalized task-store config for BackgroundAgentManager."""
         if isinstance(self.background_task_store, dict):
             return self.background_task_store
+        backend = self.background_task_store or "in_memory"
         if self.background_task_store_uri:
+            if backend not in {"in_memory", "mongodb"}:
+                raise ValueError(
+                    "OMNICOREAGENT_BACKGROUND_TASK_STORE_URI can only be used "
+                    "with the MongoDB background task store"
+                )
             return {
                 "backend": "mongodb",
                 "uri": self.background_task_store_uri,
@@ -275,9 +294,13 @@ class OmniServeConfig(BaseModel):
                 "connect_timeout": self.background_task_store_connect_timeout,
             }
         if self.background_task_store_url:
-            backend = self.background_task_store or "sql"
             if backend == "in_memory":
                 backend = "sql"
+            if backend not in {"sql", "redis"}:
+                raise ValueError(
+                    "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL can only be used "
+                    "with the SQL or Redis background task store"
+                )
             return {
                 "backend": backend,
                 "url": self.background_task_store_url,
@@ -285,19 +308,13 @@ class OmniServeConfig(BaseModel):
                 "connect_timeout": self.background_task_store_connect_timeout,
             }
         if self.background_task_store == "mongodb":
-            return {
-                "backend": "mongodb",
-                "uri": os.getenv("MONGODB_URI"),
-                "database": self.background_task_store_database or "omnicoreagent",
-                "prefix": self.background_task_store_prefix,
-                "collection_prefix": self.background_task_store_collection_prefix,
-                "connect_timeout": self.background_task_store_connect_timeout,
-            }
+            raise ValueError(
+                "MongoDB background task store requires "
+                "OMNICOREAGENT_BACKGROUND_TASK_STORE_URI"
+            )
         if self.background_task_store == "redis":
-            return {
-                "backend": "redis",
-                "url": os.getenv("REDIS_URL"),
-                "prefix": self.background_task_store_prefix,
-                "connect_timeout": self.background_task_store_connect_timeout,
-            }
+            raise ValueError(
+                "Redis background task store requires "
+                "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL"
+            )
         return self.background_task_store

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -117,7 +117,7 @@ class HealthResponse(BaseModel):
     status: str = Field(..., description="Health status ('healthy' or 'unhealthy')")
     agent_name: str = Field(..., description="Name of the agent")
     uptime: float = Field(..., description="Server uptime in seconds")
-    version: str = Field(default="1.0.0", description="OmniServe version")
+    version: str = Field(default="0+unknown", description="OmniCoreAgent version")
 
 
 class ReadinessResponse(BaseModel):
@@ -177,11 +177,11 @@ class EventsResponse(BaseModel):
 
 
 class TraceResponse(BaseModel):
-    """Response model for session trace endpoint."""
+    """Response model for session event summary endpoint."""
 
     session_id: str = Field(..., description="Session ID")
-    summary: dict[str, Any] = Field(..., description="Trace summary")
-    steps: list[dict[str, Any]] = Field(..., description="Ordered trace steps")
+    summary: dict[str, Any] = Field(..., description="Event summary")
+    steps: list[dict[str, Any]] = Field(..., description="Ordered event steps")
 
 
 class BackgroundStatusResponse(BaseModel):

--- a/src/omnicoreagent/serve/routes/health.py
+++ b/src/omnicoreagent/serve/routes/health.py
@@ -1,6 +1,7 @@
 """Health and readiness routes for OmniServe."""
 
 import time
+from importlib.metadata import PackageNotFoundError, version
 
 from fastapi import APIRouter, Request
 
@@ -26,7 +27,7 @@ def create_health_router() -> APIRouter:
             status="healthy",
             agent_name=get_agent_name(agent),
             uptime=time.time() - start_time,
-            version="1.0.0",
+            version=_package_version(),
         )
 
     @router.get(
@@ -48,3 +49,10 @@ def create_health_router() -> APIRouter:
         )
 
     return router
+
+
+def _package_version() -> str:
+    try:
+        return version("omnicoreagent")
+    except PackageNotFoundError:
+        return "0+unknown"

--- a/src/omnicoreagent/serve/routes/sessions.py
+++ b/src/omnicoreagent/serve/routes/sessions.py
@@ -49,8 +49,8 @@ def create_sessions_router() -> APIRouter:
     @router.get(
         "/events/{session_id}/trace",
         response_model=TraceResponse,
-        summary="Get session trace summary",
-        description="Build a compact trace summary from stored session events.",
+        summary="Get session event summary",
+        description="Build a compact summary from stored session events.",
     )
     async def get_trace(request: Request, session_id: str) -> TraceResponse:
         agent = get_agent(request)

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -107,6 +107,42 @@ def test_omniserve_docs_include_all_public_env_vars():
         assert not missing, f"{path} is missing OmniServe env vars: {missing}"
 
 
+def test_omniserve_docs_do_not_show_separate_or_stale_serve_version():
+    docs = [
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("cookbook/omniserve/README.mdx"),
+        Path("cookbook/omniserve/python_api.py"),
+        Path("cookbook/omniserve/cli_agent.py"),
+    ]
+
+    offenders = []
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        found = [phrase for phrase in ("OmniServe v", "v0.0.1") if phrase in text]
+        if found:
+            offenders.append(f"{path}: {', '.join(found)}")
+
+    assert not offenders, (
+        "OmniServe inherits OmniCoreAgent package versioning and must not show "
+        "a separate stale version:\n" + "\n".join(offenders)
+    )
+
+
+def test_omniserve_docs_use_consistent_docker_image_name():
+    docs = [
+        Path("docs/how-to-guides/omniserve.mdx"),
+        Path("cookbook/omniserve/README.mdx"),
+        Path("docker/Dockerfile"),
+        Path("docker/docker-compose.yml"),
+        Path("docker/prometheus.yml"),
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert "omnicoreagent-serve" in text
+        assert "omniserver" not in text
+
+
 def test_background_docs_do_not_claim_sql_is_only_durable_store():
     docs = [
         Path("docs/how-to-guides/omniserve.mdx"),

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -1,9 +1,11 @@
 import os
 import pytest
 import asyncio
+from importlib.metadata import version
 from unittest.mock import MagicMock, patch, AsyncMock
 from fastapi.testclient import TestClient
 from click.testing import CliRunner
+from pydantic import ValidationError
 from omnicoreagent import OmniCoreAgent, OmniServe, OmniServeConfig
 from omnicoreagent.serve.cli import cli
 
@@ -53,6 +55,23 @@ class TestConfiguration:
             assert config.log_level == "DEBUG"
             assert config.background_task_store == "sql"
 
+    @pytest.mark.parametrize(
+        ("env_name", "env_value", "message"),
+        [
+            ("OMNICOREAGENT_SERVE_PORT", "not-a-port", "must be an integer"),
+            ("OMNICOREAGENT_SERVE_AUTH_ENABLED", "maybe", "must be a boolean"),
+            (
+                "OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT",
+                "slow",
+                "must be a number",
+            ),
+        ],
+    )
+    def test_invalid_env_values_fail_clearly(self, env_name, env_value, message):
+        with patch.dict(os.environ, {env_name: env_value}):
+            with pytest.raises(ValidationError, match=message):
+                OmniServeConfig()
+
     def test_background_task_store_url_infers_sql(self):
         config = OmniServeConfig(
             background_task_store_url="sqlite:///custom-background.db"
@@ -79,21 +98,32 @@ class TestConfiguration:
             "connect_timeout": None,
         }
 
-    def test_background_task_store_redis_keeps_tuning_without_url(self):
+    def test_background_task_store_redis_requires_prefixed_url(self):
         with patch.dict(os.environ, {"REDIS_URL": "redis://localhost:6379/3"}):
             config = OmniServeConfig(
                 background_task_store="redis",
                 background_task_store_prefix="tasks",
                 background_task_store_connect_timeout=1.25,
             )
-            assert config.background_task_store_config() == {
-                "backend": "redis",
-                "url": "redis://localhost:6379/3",
-                "prefix": "tasks",
-                "connect_timeout": 1.25,
-            }
+            with pytest.raises(ValueError, match="TASK_STORE_URL"):
+                config.background_task_store_config()
 
-    def test_background_task_store_mongodb_keeps_tuning_without_uri(self):
+    def test_background_task_store_redis_uses_prefixed_url(self):
+        config = OmniServeConfig(
+            background_task_store="redis",
+            background_task_store_url="redis://localhost:6379/3",
+            background_task_store_prefix="tasks",
+            background_task_store_connect_timeout=1.25,
+        )
+
+        assert config.background_task_store_config() == {
+            "backend": "redis",
+            "url": "redis://localhost:6379/3",
+            "prefix": "tasks",
+            "connect_timeout": 1.25,
+        }
+
+    def test_background_task_store_mongodb_requires_prefixed_uri(self):
         with patch.dict(os.environ, {"MONGODB_URI": "mongodb://localhost:27017"}):
             config = OmniServeConfig(
                 background_task_store="mongodb",
@@ -101,14 +131,43 @@ class TestConfiguration:
                 background_task_store_collection_prefix="background_tasks",
                 background_task_store_connect_timeout=2.5,
             )
-            assert config.background_task_store_config() == {
-                "backend": "mongodb",
-                "uri": "mongodb://localhost:27017",
-                "database": "tasks",
-                "prefix": None,
-                "collection_prefix": "background_tasks",
-                "connect_timeout": 2.5,
-            }
+            with pytest.raises(ValueError, match="TASK_STORE_URI"):
+                config.background_task_store_config()
+
+    def test_background_task_store_mongodb_uses_prefixed_uri(self):
+        config = OmniServeConfig(
+            background_task_store="mongodb",
+            background_task_store_uri="mongodb://localhost:27017",
+            background_task_store_database="tasks",
+            background_task_store_collection_prefix="background_tasks",
+            background_task_store_connect_timeout=2.5,
+        )
+
+        assert config.background_task_store_config() == {
+            "backend": "mongodb",
+            "uri": "mongodb://localhost:27017",
+            "database": "tasks",
+            "collection_prefix": "background_tasks",
+            "connect_timeout": 2.5,
+        }
+
+    def test_background_task_store_rejects_mismatched_url_backend(self):
+        config = OmniServeConfig(
+            background_task_store="mongodb",
+            background_task_store_url="sqlite:///wrong.db",
+        )
+
+        with pytest.raises(ValueError, match="TASK_STORE_URL"):
+            config.background_task_store_config()
+
+    def test_background_task_store_rejects_mismatched_uri_backend(self):
+        config = OmniServeConfig(
+            background_task_store="redis",
+            background_task_store_uri="mongodb://localhost:27017",
+        )
+
+        with pytest.raises(ValueError, match="TASK_STORE_URI"):
+            config.background_task_store_config()
 
     def test_env_example_includes_background_settings(self):
         result = CliRunner().invoke(cli, ["config", "--env-example"])
@@ -122,6 +181,42 @@ class TestConfiguration:
         ]:
             assert key in result.output
         assert "export LLM_API_KEY=your_api_key_here" in result.output
+        assert "Choose one backend" in result.output
+        assert "REDIS_URL" not in result.output
+        assert "MONGODB_URI" not in result.output
+
+    def test_cli_version_uses_omnicoreagent_package_version(self):
+        result = CliRunner().invoke(cli, ["--version"])
+
+        assert result.exit_code == 0
+        assert result.output.strip() == f"omniserve, version {version('omnicoreagent')}"
+
+    def test_generate_dockerfile_uses_current_image_name(self, tmp_path):
+        agent_file = tmp_path / "agent.py"
+        agent_file.write_text(
+            "class Agent:\n"
+            "    name = 'GeneratedAgent'\n"
+            "    agent_config = {}\n\n"
+            "agent = Agent()\n",
+            encoding="utf-8",
+        )
+        output_dir = tmp_path / "docker"
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "generate-dockerfile",
+                "--file",
+                str(agent_file),
+                "--output-dir",
+                str(output_dir),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "omnicoreagent-serve" in result.output
+        assert "omniserver" not in result.output
+        assert (output_dir / "Dockerfile").exists()
 
 
 # =============================================================================
@@ -201,6 +296,30 @@ class TestMiddleware:
         assert resp.status_code == 200
         assert resp.headers["access-control-allow-origin"] == "https://example.com"
 
+    def test_rate_limit_middleware_allows_then_denies_protected_routes(self, mock_agent):
+        config = OmniServeConfig(
+            rate_limit_enabled=True,
+            rate_limit_requests=1,
+            rate_limit_window=60,
+        )
+        mock_agent.run = AsyncMock(return_value={"response": "test"})
+        server = OmniServe(agent=mock_agent, config=config)
+        client = TestClient(server.app)
+
+        public_response = client.get("/health")
+        assert public_response.status_code == 200
+        assert "X-RateLimit-Limit" not in public_response.headers
+
+        allowed = client.post("/run/sync", json={"query": "first"})
+        denied = client.post("/run/sync", json={"query": "second"})
+
+        assert allowed.status_code == 200
+        assert allowed.headers["X-RateLimit-Limit"] == "1"
+        assert allowed.headers["X-RateLimit-Remaining"] == "0"
+        assert denied.status_code == 429
+        assert denied.headers["Retry-After"]
+        assert denied.json()["error"] == "TooManyRequests"
+
 
 # =============================================================================
 # Test Endpoints
@@ -231,6 +350,13 @@ class TestEndpoints:
         assert resp.status_code == 200
         assert resp.json()["status"] == "healthy"
         assert resp.json()["agent_name"] == "EndpointTestAgent"
+        assert resp.json()["version"] == version("omnicoreagent")
+
+    def test_openapi_uses_package_version(self, server_client):
+        resp = server_client.get("/openapi.json")
+
+        assert resp.status_code == 200
+        assert resp.json()["info"]["version"] == version("omnicoreagent")
 
     def test_sync_run(self, server_client):
         resp = server_client.post("/run/sync", json={"query": "Hello"})


### PR DESCRIPTION
## Summary
- add internal OmniServe specification and expand the architecture record for serving boundaries, config, lifecycle, SSE, middleware, metrics, background APIs, and docs contracts
- harden `OmniServeConfig` env parsing so invalid booleans/ints/floats fail clearly instead of silently falling back
- remove generic `REDIS_URL`/`MONGODB_URI` fallback behavior from OmniServe background task-store config; require explicit `OMNICOREAGENT_BACKGROUND_*` task-store variables
- reject mismatched task-store URL/URI backend combinations at the OmniServe config boundary
- make OmniServe CLI, health, and OpenAPI metadata inherit the OmniCoreAgent package version instead of carrying separate/stale OmniServe versions
- clean stale OmniServe docs/cookbook/Docker naming, including `omniserver` image references and overclaims around full observability/distributed rate limiting
- add regression tests for config errors, package version metadata, Docker/docs naming, and rate-limit headers/429 behavior

## Reviewer pass
- fixed config/spec mismatch around generic Redis/Mongo env fallbacks
- clarified `/prometheus` as a global route not affected by `api_prefix`
- fixed mismatched task-store backend+URL/URI behavior and documented it
- fixed stale Docker image naming across docs, cookbook, Dockerfile, Compose, and Prometheus config
- tightened tests to compare CLI/health/OpenAPI against the OmniCoreAgent package version
- added rate-limit middleware coverage for allowed and denied protected requests

## Verification
- `uv run ruff check src/omnicoreagent/serve tests/test_omniserve_full.py tests/test_docs_claims.py`
- `uv run pytest tests/test_omniserve_full.py tests/test_omniserve_sse.py tests/test_omniserve_background.py tests/test_docs_claims.py -q -rs` -> `61 passed`
- `uv run pytest -q` -> `685 passed, 8 skipped`
- `git diff --check`
