### PR TITLE
Harden OmniServe readiness lifecycle

### DIFF
--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -100,15 +100,21 @@ while running with defaults.
 OmniServe owns the HTTP lifespan around one served agent:
 
 1. store agent/config/background manager in app state.
-2. connect MCP servers when the served agent exposes `connect_mcp_servers`.
-3. initialize the background manager when background execution is enabled.
-4. register the served agent under `background_agent_id`.
-5. start the background worker when configured.
-6. on shutdown, stop the background manager before agent cleanup.
-7. call agent cleanup when the served agent exposes `cleanup`.
+2. keep `omniserve_startup_complete` false while startup is in progress.
+3. connect MCP servers when the served agent exposes `connect_mcp_servers`.
+4. initialize the background manager when background execution is enabled.
+5. register the served agent under `background_agent_id`.
+6. start the background worker when configured.
+7. mark startup complete only after dependencies are ready.
+8. on shutdown, mark startup incomplete before stopping the background manager.
+9. call agent cleanup when the served agent exposes `cleanup`.
 
 Lifespan errors should fail startup or shutdown clearly. They should not leave a
 half-started server that reports readiness while core dependencies failed.
+
+Readiness is intentionally cheap. `/ready` combines the startup-complete flag,
+agent initialization state, and MCP client presence. It never performs model
+calls, tool calls, background work, or network probes.
 
 ## HTTP API Boundary
 

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -315,15 +315,19 @@ Runtime events normalize to JSON-ready dictionaries using:
 Startup:
 
 1. set `app.state.start_time`.
-2. call `agent.connect_mcp_servers()` when present.
-3. initialize background manager when enabled.
-4. register the served agent under `background_agent_id`.
-5. start background worker when `background_start_worker` is true.
+2. mark `app.state.omniserve_startup_complete` false.
+3. call `agent.connect_mcp_servers()` when present.
+4. initialize background manager when enabled.
+5. register the served agent under `background_agent_id`.
+6. start background worker when `background_start_worker` is true.
+7. mark `app.state.omniserve_startup_complete` true only after startup
+   dependencies succeed.
 
 Shutdown:
 
-1. shut down background manager when present.
-2. call `agent.cleanup()` when present.
+1. mark `app.state.omniserve_startup_complete` false.
+2. shut down background manager when present.
+3. call `agent.cleanup()` when present.
 
 Startup failures must not report readiness as healthy.
 
@@ -337,6 +341,11 @@ Startup failures must not report readiness as healthy.
 - `agent_name`
 - `initialized`
 - `mcp_connected`
+
+`ready` is true only when lifespan startup completed, the agent is initialized,
+and an exposed MCP client is present. If startup has not completed, startup
+failed, the agent reports `_initialized=False`, or an exposed `mcp_client` is
+`None`, readiness is false.
 
 Readiness must remain cheap. It should not execute model calls, tool calls, or
 background work.

--- a/src/omnicoreagent/serve/app_factory.py
+++ b/src/omnicoreagent/serve/app_factory.py
@@ -42,6 +42,7 @@ def create_omniserve_app(
     app.state.agent = agent
     app.state.config = config
     app.state.start_time = time.time()
+    app.state.omniserve_startup_complete = False
     app.state.background_manager = _build_background_manager(
         config=config,
         background_manager=background_manager,

--- a/src/omnicoreagent/serve/lifespan.py
+++ b/src/omnicoreagent/serve/lifespan.py
@@ -5,6 +5,7 @@ Async context manager for agent lifecycle management.
 Handles initialization, MCP server connections, and cleanup.
 """
 
+import sys
 import time
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
@@ -45,6 +46,7 @@ async def agent_lifespan(app: FastAPI):
 
     # Record start time for uptime tracking
     app.state.start_time = time.time()
+    app.state.omniserve_startup_complete = False
 
     try:
         if hasattr(agent, "connect_mcp_servers"):
@@ -60,17 +62,32 @@ async def agent_lifespan(app: FastAPI):
             if config.background_start_worker:
                 await background_manager.start()
 
+        app.state.omniserve_startup_complete = True
         logger.info(f"OmniServe: Agent '{agent_name}' is ready")
 
         yield
 
     finally:
+        app.state.omniserve_startup_complete = False
         logger.info(f"OmniServe: Shutting down agent '{agent_name}'...")
 
+        cleanup_error: BaseException | None = None
+        active_exception = sys.exc_info()[0] is not None
+
         if background_manager is not None:
-            await background_manager.shutdown()
+            try:
+                await background_manager.shutdown()
+            except Exception as exc:
+                cleanup_error = exc
+                logger.error(f"OmniServe: Background manager shutdown failed: {exc}")
 
         if hasattr(agent, "cleanup"):
-            await agent.cleanup()
+            try:
+                await agent.cleanup()
+            except Exception as exc:
+                cleanup_error = cleanup_error or exc
+                logger.error(f"OmniServe: Agent cleanup failed: {exc}")
 
         logger.info(f"OmniServe: Agent '{agent_name}' cleanup complete")
+        if cleanup_error is not None and not active_exception:
+            raise cleanup_error

--- a/src/omnicoreagent/serve/readiness.py
+++ b/src/omnicoreagent/serve/readiness.py
@@ -1,0 +1,50 @@
+"""Readiness checks for the OmniServe serving boundary."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from fastapi import Request
+
+from .state import get_agent, get_agent_name
+
+if TYPE_CHECKING:
+    from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent as AgentType
+else:
+    AgentType = Any
+
+
+@dataclass(frozen=True)
+class ReadinessState:
+    """Computed readiness state for one OmniServe app instance."""
+
+    ready: bool
+    agent_name: str
+    initialized: bool
+    mcp_connected: bool
+
+
+def evaluate_readiness(request: Request) -> ReadinessState:
+    """Return cheap readiness state without executing model or tool work."""
+    agent = get_agent(request)
+    initialized = _agent_initialized(agent)
+    mcp_connected = _mcp_connected(agent)
+    startup_complete = bool(
+        getattr(request.app.state, "omniserve_startup_complete", False)
+    )
+
+    return ReadinessState(
+        ready=startup_complete and initialized and mcp_connected,
+        agent_name=get_agent_name(agent),
+        initialized=initialized,
+        mcp_connected=mcp_connected,
+    )
+
+
+def _agent_initialized(agent: AgentType) -> bool:
+    return bool(getattr(agent, "_initialized", True))
+
+
+def _mcp_connected(agent: AgentType) -> bool:
+    if not hasattr(agent, "mcp_client"):
+        return True
+    return getattr(agent, "mcp_client") is not None

--- a/src/omnicoreagent/serve/routes/health.py
+++ b/src/omnicoreagent/serve/routes/health.py
@@ -6,6 +6,7 @@ from importlib.metadata import PackageNotFoundError, version
 from fastapi import APIRouter, Request
 
 from ..models import HealthResponse, ReadinessResponse
+from ..readiness import evaluate_readiness
 from ..state import get_agent, get_agent_name
 
 
@@ -37,15 +38,13 @@ def create_health_router() -> APIRouter:
         description="Check if the agent is ready to accept requests.",
     )
     async def readiness_check(request: Request) -> ReadinessResponse:
-        agent = get_agent(request)
-        initialized = getattr(agent, "_initialized", True)
-        mcp_connected = not hasattr(agent, "mcp_client") or agent.mcp_client is not None
+        readiness = evaluate_readiness(request)
 
         return ReadinessResponse(
-            ready=initialized,
-            agent_name=get_agent_name(agent),
-            initialized=initialized,
-            mcp_connected=mcp_connected,
+            ready=readiness.ready,
+            agent_name=readiness.agent_name,
+            initialized=readiness.initialized,
+            mcp_connected=readiness.mcp_connected,
         )
 
     return router

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -352,6 +352,147 @@ class TestEndpoints:
         assert resp.json()["agent_name"] == "EndpointTestAgent"
         assert resp.json()["version"] == version("omnicoreagent")
 
+    def test_readiness_requires_lifespan_startup(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "ReadinessAgent"
+        agent.generate_session_id.return_value = "readiness-session"
+
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+        client = TestClient(server.app)
+
+        resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ready": False,
+            "agent_name": "ReadinessAgent",
+            "initialized": True,
+            "mcp_connected": True,
+        }
+
+    def test_readiness_true_after_successful_lifespan_startup(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "ReadyAgent"
+        agent.generate_session_id.return_value = "ready-session"
+
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ready": True,
+            "agent_name": "ReadyAgent",
+            "initialized": True,
+            "mcp_connected": True,
+        }
+
+    def test_readiness_reflects_uninitialized_agent(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "UninitializedAgent"
+        agent.generate_session_id.return_value = "uninitialized-session"
+        agent._initialized = False
+
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["ready"] is False
+        assert resp.json()["initialized"] is False
+
+    def test_readiness_reflects_mcp_connection_state(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "MCPReadinessAgent"
+        agent.generate_session_id.return_value = "mcp-readiness-session"
+        agent.mcp_client = None
+
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["ready"] is False
+        assert resp.json()["mcp_connected"] is False
+
+    def test_lifespan_cleanup_runs_after_startup_failure(self):
+        class FailingStartupAgent:
+            name = "FailingStartupAgent"
+
+            def __init__(self):
+                self.cleaned = False
+
+            async def connect_mcp_servers(self):
+                raise RuntimeError("mcp startup failed")
+
+            async def cleanup(self):
+                self.cleaned = True
+
+        agent = FailingStartupAgent()
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with pytest.raises(RuntimeError, match="mcp startup failed"):
+            with TestClient(server.app):
+                pass
+
+        assert agent.cleaned is True
+        assert server.app.state.omniserve_startup_complete is False
+
+    def test_lifespan_agent_cleanup_runs_when_background_shutdown_fails(self):
+        class CleanupAgent:
+            name = "CleanupAgent"
+
+            def __init__(self):
+                self.cleaned = False
+
+            async def cleanup(self):
+                self.cleaned = True
+
+        class FailingShutdownManager:
+            async def initialize(self):
+                return None
+
+            async def register_agent(self, *args, **kwargs):
+                return None
+
+            async def start(self):
+                return None
+
+            async def shutdown(self):
+                raise RuntimeError("background shutdown failed")
+
+        agent = CleanupAgent()
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_start_worker=True),
+            background_manager=FailingShutdownManager(),
+        )
+
+        with pytest.raises(RuntimeError, match="background shutdown failed"):
+            with TestClient(server.app):
+                assert server.app.state.omniserve_startup_complete is True
+
+        assert agent.cleaned is True
+        assert server.app.state.omniserve_startup_complete is False
+
     def test_openapi_uses_package_version(self, server_client):
         resp = server_client.get("/openapi.json")
 
@@ -424,6 +565,29 @@ class TestEndpoints:
 
         assert resp.status_code == 504
         assert "timed out" in resp.json()["detail"]
+
+    def test_unhandled_route_errors_return_stable_json(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "ErrorAgent"
+        agent.generate_session_id.return_value = "error-session"
+        server = OmniServe(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        @server.app.get("/boom")
+        async def boom():
+            raise RuntimeError("route exploded")
+
+        client = TestClient(server.app, raise_server_exceptions=False)
+        resp = client.get("/boom")
+
+        assert resp.status_code == 500
+        assert resp.json() == {
+            "error": "InternalServerError",
+            "message": "An internal server error occurred",
+            "detail": "route exploded",
+        }
 
     def test_request_metrics_are_per_app_instance(self):
         agent_one = MagicMock(spec=OmniCoreAgent)


### PR DESCRIPTION
## Summary
- add an explicit OmniServe startup-complete readiness flag
- make `/ready` require successful lifespan startup, agent initialization, and MCP client presence
- ensure agent cleanup still runs when background manager shutdown fails
- align internal OmniServe architecture/spec wording with the new readiness contract

## Verification
- `uv run ruff check src/omnicoreagent/serve tests/test_omniserve_full.py`
- `uv run pytest tests/test_omniserve_full.py tests/test_omniserve_sse.py tests/test_omniserve_background.py tests/test_docs_claims.py -q`
- `uv run pytest -q`
- `git diff --check`

## Reviewer agents
- lifecycle reviewer found the untracked readiness module risk; fixed by staging/committing `src/omnicoreagent/serve/readiness.py`
- docs/spec reviewer found MCP readiness wording overclaimed live connectivity; narrowed to MCP client presence
- QA reviewer returned no blocking findings
