### PR TITLE
Mount OmniServe background routes only when enabled

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -126,6 +126,10 @@ limiting until you opt in.
 
 ### Background Task Endpoints
 
+These routes are mounted when background execution is enabled. It is enabled by
+default and can be turned off with `OMNICOREAGENT_BACKGROUND_ENABLED=false` or
+`OmniServeConfig(background_enabled=False)`.
+
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | POST | `/background/agents` | Yes* | Register a background agent |

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -213,6 +213,10 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 
 ### Background Task Endpoints
 
+These routes are mounted when background execution is enabled. It is enabled by
+default and can be turned off with `OMNICOREAGENT_BACKGROUND_ENABLED=false` or
+`OmniServeConfig(background_enabled=False)`.
+
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | `GET` | `/background/status` | Yes* | Inspect background manager counts and run status totals |

--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -134,6 +134,10 @@ OmniServe exposes one agent through a stable API surface:
 - `/prometheus`
 - `/background/*` when background execution is enabled
 
+When background execution is disabled, the background router is not mounted.
+Disabled background execution should not expose dead `/background/*` endpoints
+or stale OpenAPI paths.
+
 `api_prefix` applies to API routes mounted by the agent router. Global FastAPI
 documentation and Prometheus paths remain global unless a deliberate design
 changes that.

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -180,6 +180,9 @@ When `background_enabled` is true, background routes expose:
 | `GET` | `/background/runs/{run_id}/events` | Replay run lifecycle events |
 | `GET` | `/background/runs/{run_id}/workspace` | Inspect run workspace files |
 
+When `background_enabled` is false, OmniServe does not mount `/background/*`
+routes and does not include background paths in the OpenAPI schema.
+
 `api_prefix` applies to these agent router paths.
 
 Global FastAPI routes are not mounted through the agent router:

--- a/src/omnicoreagent/serve/app_factory.py
+++ b/src/omnicoreagent/serve/app_factory.py
@@ -51,7 +51,7 @@ def create_omniserve_app(
     setup_all_middleware(app, config)
     setup_metrics(app, config)
 
-    app.include_router(create_agent_router(), prefix=config.api_prefix)
+    app.include_router(create_agent_router(config), prefix=config.api_prefix)
 
     logger.info(f"OmniServe: Created FastAPI app for agent '{get_agent_name(agent)}'")
     return app

--- a/src/omnicoreagent/serve/routes/__init__.py
+++ b/src/omnicoreagent/serve/routes/__init__.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from .background import create_background_router
+from ..config import OmniServeConfig
 from .health import create_health_router
 from .metrics import create_metrics_router
 from .runs import create_runs_router
@@ -10,7 +10,7 @@ from .sessions import create_sessions_router
 from .tools import create_tools_router
 
 
-def create_agent_router() -> APIRouter:
+def create_agent_router(config: OmniServeConfig) -> APIRouter:
     """Create the complete OmniServe API router."""
     router = APIRouter()
     router.include_router(create_health_router())
@@ -18,5 +18,8 @@ def create_agent_router() -> APIRouter:
     router.include_router(create_sessions_router())
     router.include_router(create_tools_router())
     router.include_router(create_metrics_router())
-    router.include_router(create_background_router())
+    if config.background_enabled:
+        from .background import create_background_router
+
+        router.include_router(create_background_router())
     return router

--- a/tests/test_omniserve_background.py
+++ b/tests/test_omniserve_background.py
@@ -546,8 +546,10 @@ def test_background_api_can_be_disabled():
 
     response = client.get("/background/agents")
 
-    assert response.status_code == 503
-    assert response.json()["detail"] == "Background execution is disabled"
+    assert response.status_code == 404
+
+    schema = client.get("/openapi.json").json()
+    assert not any(path.startswith("/background") for path in schema["paths"])
 
 
 def test_background_openapi_matches_http_exception_response_shapes(tmp_path):


### PR DESCRIPTION
## Summary
- pass OmniServeConfig into route composition
- mount `/background/*` only when `background_enabled` is true
- keep disabled background routes out of OpenAPI instead of exposing dead 503 endpoints
- align internal spec, architecture, public docs, and cookbook wording

## Verification
- `uv run ruff check src/omnicoreagent/serve tests/test_omniserve_background.py`
- `uv run pytest tests/test_omniserve_background.py tests/test_omniserve_full.py tests/test_docs_claims.py -q`
- `uv run pytest tests/test_import_startup.py tests/test_omniserve_sse.py -q`
- `uv run pytest -q`
- `git diff --check`

## Reviewer agents
- initial reviewers stalled and were closed
- replacement bounded reviewer checked the exact diff and returned no blocking findings
