### PR TITLE
Require OmniServe auth token when auth is enabled

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -87,8 +87,8 @@ limiting until you opt in.
 | `OMNICOREAGENT_SERVE_CORS_METHODS` | `*` | Allowed methods |
 | `OMNICOREAGENT_SERVE_CORS_HEADERS` | `*` | Allowed headers |
 | `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `true` | Allow credentials |
-| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer auth |
-| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer auth. Requires a non-empty auth token |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value used when auth is enabled |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Rate limiting |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests/window |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window seconds |

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -91,8 +91,8 @@ and use an in-memory task store. Set only the values you want to override.
 | `OMNICOREAGENT_SERVE_CORS_METHODS` | `*` | Comma-separated allowed methods. |
 | `OMNICOREAGENT_SERVE_CORS_HEADERS` | `*` | Comma-separated allowed headers. |
 | `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `true` | Allow CORS credentials. |
-| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. |
-| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | unset | Bearer token value. |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. Requires a non-empty `OMNICOREAGENT_SERVE_AUTH_TOKEN` value. |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | unset | Bearer token value used when auth is enabled. |
 | `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log incoming requests. |
 | `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Server log level. |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds. Set `0` to disable timeout middleware. |

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -348,8 +348,8 @@ authentication, rate limits, or background storage.
 | `OMNICOREAGENT_SERVE_CORS_METHODS` | `*` | Allowed methods (comma-separated) |
 | `OMNICOREAGENT_SERVE_CORS_HEADERS` | `*` | Allowed headers (comma-separated) |
 | `OMNICOREAGENT_SERVE_CORS_CREDENTIALS` | `true` | Allow credentials |
-| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth |
-| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value |
+| `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. Requires a non-empty auth token |
+| `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value used when auth is enabled |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per window |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window in seconds |

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -202,6 +202,7 @@ When auth is disabled, all routes are accessible.
 
 When auth is enabled:
 
+- a non-empty `auth_token` is required during configuration creation.
 - `/health` and `/ready` bypass auth.
 - prefixed health/readiness paths bypass auth when `api_prefix` is set.
 - `/docs`, `/redoc`, `/openapi.json`, and `/prometheus` bypass auth.

--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -268,7 +268,15 @@ class OmniServeConfig(BaseModel):
         if (val := _get_env_bool(background_prefix, "START_WORKER")) is not None:
             self.background_start_worker = val
 
+        self._validate_auth_config()
         return self
+
+    def _validate_auth_config(self) -> None:
+        if self.auth_enabled and not _has_value(self.auth_token):
+            raise ValueError(
+                "OMNICOREAGENT_SERVE_AUTH_TOKEN is required when "
+                "OMNICOREAGENT_SERVE_AUTH_ENABLED=true"
+            )
 
     @classmethod
     def from_env(cls) -> "OmniServeConfig":
@@ -318,3 +326,7 @@ class OmniServeConfig(BaseModel):
                 "OMNICOREAGENT_BACKGROUND_TASK_STORE_URL"
             )
         return self.background_task_store
+
+
+def _has_value(value: str | None) -> bool:
+    return value is not None and value.strip() != ""

--- a/src/omnicoreagent/serve/middleware/auth.py
+++ b/src/omnicoreagent/serve/middleware/auth.py
@@ -67,8 +67,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
 def add_auth_middleware(app: FastAPI, config: OmniServeConfig) -> None:
     """Install bearer-token auth when enabled."""
-    if not config.auth_enabled or not config.auth_token:
+    if not config.auth_enabled:
         return
+    if not config.auth_token or not config.auth_token.strip():
+        raise ValueError(
+            "OmniServe auth is enabled but no bearer token is configured"
+        )
 
     app.add_middleware(
         AuthMiddleware,

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -41,6 +41,7 @@ class TestConfiguration:
             {
                 "OMNICOREAGENT_SERVE_PORT": "7777",
                 "OMNICOREAGENT_SERVE_AUTH_ENABLED": "true",
+                "OMNICOREAGENT_SERVE_AUTH_TOKEN": "env-secret",
                 "OMNICOREAGENT_SERVE_LOG_LEVEL": "DEBUG",
                 "OMNICOREAGENT_BACKGROUND_TASK_STORE": "sql",
             },
@@ -52,6 +53,7 @@ class TestConfiguration:
 
             assert config.port == 7777
             assert config.auth_enabled is True
+            assert config.auth_token == "env-secret"
             assert config.log_level == "DEBUG"
             assert config.background_task_store == "sql"
 
@@ -70,6 +72,18 @@ class TestConfiguration:
     def test_invalid_env_values_fail_clearly(self, env_name, env_value, message):
         with patch.dict(os.environ, {env_name: env_value}):
             with pytest.raises(ValidationError, match=message):
+                OmniServeConfig()
+
+    def test_auth_enabled_requires_non_empty_token(self):
+        with pytest.raises(ValidationError, match="AUTH_TOKEN is required"):
+            OmniServeConfig(auth_enabled=True)
+
+        with pytest.raises(ValidationError, match="AUTH_TOKEN is required"):
+            OmniServeConfig(auth_enabled=True, auth_token="   ")
+
+    def test_auth_env_enabled_requires_token(self):
+        with patch.dict(os.environ, {"OMNICOREAGENT_SERVE_AUTH_ENABLED": "true"}):
+            with pytest.raises(ValidationError, match="AUTH_TOKEN is required"):
                 OmniServeConfig()
 
     def test_background_task_store_url_infers_sql(self):


### PR DESCRIPTION
## Summary
- fail OmniServeConfig clearly when auth is enabled without a non-empty token
- keep auth middleware defensive so invalid auth config cannot silently serve open
- update OmniServe docs/spec/cookbook to state the token requirement

## Verification
- `uv run ruff check src/omnicoreagent/serve tests/test_omniserve_full.py`
- `uv run pytest tests/test_omniserve_full.py tests/test_docs_claims.py -q`
- `uv run pytest tests/test_omniserve_background.py tests/test_omniserve_sse.py tests/test_import_startup.py -q`
- `uv run pytest -q`
- `git diff --check`

## Reviewer agents
- initial reviewers stalled and were closed
- replacement bounded reviewer checked the exact diff and returned no blocking findings
