### PR TITLE
Harden OmniServe production serving config

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -77,8 +77,8 @@ limiting until you opt in.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host |
-| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port |
-| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes |
+| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. Must be `1`-`65535` |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes. Must be at least `1` |
 | `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix |
 | `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
 | `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
@@ -90,8 +90,8 @@ limiting until you opt in.
 | `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer auth. Requires a non-empty auth token |
 | `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value used when auth is enabled |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Rate limiting |
-| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests/window |
-| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window seconds |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests/window. Must be at least `1` when enabled |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window seconds. Must be at least `1` when enabled |
 | `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log requests |
 | `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Timeout seconds |

--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -76,10 +76,10 @@ limiting until you opt in.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host |
+| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host. Must not be empty |
 | `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. Must be `1`-`65535` |
-| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes. Must be at least `1` |
-| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Direct OmniServe worker count. Must be `1`; scale by running multiple processes |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix. Normalized to a leading slash with no trailing slash; whitespace is invalid |
 | `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
 | `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
 | `OMNICOREAGENT_SERVE_CORS_ENABLED` | `true` | Enable CORS |
@@ -93,7 +93,7 @@ limiting until you opt in.
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests/window. Must be at least `1` when enabled |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window seconds. Must be at least `1` when enabled |
 | `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log requests |
-| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE` |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Timeout seconds |
 | `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints |
 | `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id for the served agent in background tasks |

--- a/cookbook/omniserve/cli_agent.py
+++ b/cookbook/omniserve/cli_agent.py
@@ -33,7 +33,7 @@ CLI OPTIONS
     --agent, -a         Path to agent file (required)
     --host, -h          Host to bind (default: 0.0.0.0)
     --port, -p          Port to bind (default: 8000)
-    --workers, -w       Worker processes (default: 1)
+    --workers, -w       Worker processes (direct OmniServe requires 1)
     --auth-token        Enable auth with this token
     --rate-limit        Rate limit (requests per minute)
     --cors-origins      Comma-separated CORS origins

--- a/cookbook/omniserve/python_api.py
+++ b/cookbook/omniserve/python_api.py
@@ -146,7 +146,7 @@ config = OmniServeConfig(
     # -------------------------------------------------------------------------
     host="0.0.0.0",  # OMNICOREAGENT_SERVE_HOST
     port=8000,  # OMNICOREAGENT_SERVE_PORT
-    workers=1,  # OMNICOREAGENT_SERVE_WORKERS
+    workers=1,  # OMNICOREAGENT_SERVE_WORKERS - direct OmniServe requires 1
     api_prefix="",  # OMNICOREAGENT_SERVE_API_PREFIX (e.g., "/api/v1")
     # -------------------------------------------------------------------------
     # DOCUMENTATION
@@ -176,7 +176,7 @@ config = OmniServeConfig(
     # LOGGING
     # -------------------------------------------------------------------------
     request_logging=True,  # OMNICOREAGENT_SERVE_REQUEST_LOGGING
-    log_level="INFO",  # OMNICOREAGENT_SERVE_LOG_LEVEL (DEBUG/INFO/WARNING/ERROR)
+    log_level="INFO",  # OMNICOREAGENT_SERVE_LOG_LEVEL
     # -------------------------------------------------------------------------
     # TIMEOUTS
     # -------------------------------------------------------------------------

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -81,8 +81,8 @@ and use an in-memory task store. Set only the values you want to override.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server bind host. |
-| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. |
-| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Uvicorn worker count. |
+| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. Must be `1`-`65535`. |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Uvicorn worker count. Must be at least `1`. |
 | `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API route prefix, such as `/api/v1`. |
 | `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Enable Swagger UI. |
 | `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | Enable ReDoc. |
@@ -97,8 +97,8 @@ and use an in-memory task store. Set only the values you want to override.
 | `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Server log level. |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds. Set `0` to disable timeout middleware. |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Enable in-process rate limiting. |
-| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per rate-limit window. |
-| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Rate-limit window in seconds. |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per rate-limit window. Must be at least `1` when rate limiting is enabled. |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Rate-limit window in seconds. Must be at least `1` when rate limiting is enabled. |
 | `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints. |
 | `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id used when OmniServe registers the served agent for background work. |
 | `OMNICOREAGENT_BACKGROUND_TASK_STORE` | `in_memory` | Background control-plane store: `in_memory`, `sql`, `redis`, or `mongodb`. |

--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -80,10 +80,10 @@ and use an in-memory task store. Set only the values you want to override.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server bind host. |
+| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server bind host. Must not be empty. |
 | `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. Must be `1`-`65535`. |
-| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Uvicorn worker count. Must be at least `1`. |
-| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API route prefix, such as `/api/v1`. |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Direct OmniServe worker count. Must be `1`; run multiple processes behind a process manager for horizontal scaling. |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API route prefix, such as `/api/v1`. Normalized to a leading slash with no trailing slash; whitespace is invalid. |
 | `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Enable Swagger UI. |
 | `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | Enable ReDoc. |
 | `OMNICOREAGENT_SERVE_CORS_ENABLED` | `true` | Enable CORS middleware. |
@@ -94,7 +94,7 @@ and use an in-memory task store. Set only the values you want to override.
 | `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. Requires a non-empty `OMNICOREAGENT_SERVE_AUTH_TOKEN` value. |
 | `OMNICOREAGENT_SERVE_AUTH_TOKEN` | unset | Bearer token value used when auth is enabled. |
 | `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log incoming requests. |
-| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Server log level. |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Server log level: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`. |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds. Set `0` to disable timeout middleware. |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Enable in-process rate limiting. |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per rate-limit window. Must be at least `1` when rate limiting is enabled. |

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -337,10 +337,10 @@ authentication, rate limits, or background storage.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host |
+| `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host. Must not be empty |
 | `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. Must be `1`-`65535` |
-| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes. Must be at least `1` |
-| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix (e.g., `/api/v1`) |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Direct OmniServe worker count. Must be `1`; scale by running multiple processes |
+| `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix (e.g., `/api/v1`). Normalized to a leading slash with no trailing slash; whitespace is invalid |
 | `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
 | `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
 | `OMNICOREAGENT_SERVE_CORS_ENABLED` | `true` | Enable CORS |
@@ -354,7 +354,7 @@ authentication, rate limits, or background storage.
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per window. Must be at least `1` when enabled |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window in seconds. Must be at least `1` when enabled |
 | `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log requests |
-| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level (DEBUG/INFO/WARNING/ERROR) |
+| `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE` |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds |
 | `OMNICOREAGENT_BACKGROUND_ENABLED` | `true` | Expose background task endpoints |
 | `OMNICOREAGENT_BACKGROUND_AGENT_ID` | `default` | Agent id for the served agent in background tasks |

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -338,8 +338,8 @@ authentication, rate limits, or background storage.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OMNICOREAGENT_SERVE_HOST` | `0.0.0.0` | Server host |
-| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port |
-| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes |
+| `OMNICOREAGENT_SERVE_PORT` | `8000` | Server port. Must be `1`-`65535` |
+| `OMNICOREAGENT_SERVE_WORKERS` | `1` | Worker processes. Must be at least `1` |
 | `OMNICOREAGENT_SERVE_API_PREFIX` | `""` | API path prefix (e.g., `/api/v1`) |
 | `OMNICOREAGENT_SERVE_ENABLE_DOCS` | `true` | Swagger UI at `/docs` |
 | `OMNICOREAGENT_SERVE_ENABLE_REDOC` | `true` | ReDoc at `/redoc` |
@@ -351,8 +351,8 @@ authentication, rate limits, or background storage.
 | `OMNICOREAGENT_SERVE_AUTH_ENABLED` | `false` | Enable Bearer token auth. Requires a non-empty auth token |
 | `OMNICOREAGENT_SERVE_AUTH_TOKEN` | — | Bearer token value used when auth is enabled |
 | `OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
-| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per window |
-| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window in seconds |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS` | `100` | Requests per window. Must be at least `1` when enabled |
+| `OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW` | `60` | Window in seconds. Must be at least `1` when enabled |
 | `OMNICOREAGENT_SERVE_REQUEST_LOGGING` | `true` | Log requests |
 | `OMNICOREAGENT_SERVE_LOG_LEVEL` | `INFO` | Log level (DEBUG/INFO/WARNING/ERROR) |
 | `OMNICOREAGENT_SERVE_REQUEST_TIMEOUT` | `300` | Request timeout in seconds |

--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -228,6 +228,9 @@ of the production agent harness.
   clients.
 - `omnicoreagent[serve]` owns FastAPI and Uvicorn dependencies.
 - Multiple `OmniServe` app instances must not share request metrics state.
+- Direct `OmniServe` serves an in-process agent object and therefore runs with
+  one Uvicorn worker. Horizontal scaling is done by running multiple OmniServe
+  processes behind a process manager or load balancer.
 - `api_prefix` must apply consistently to API routes.
 - Background routes must use the same `api_prefix`, auth, rate-limit, logging,
   and timeout middleware as other protected API routes.

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -44,8 +44,8 @@ Defaults:
 |-------|---------|---------|
 | `host` | `0.0.0.0` | Bind address |
 | `port` | `8000` | Bind port |
-| `workers` | `1` | Uvicorn worker processes |
-| `api_prefix` | `""` | Prefix for agent API routes |
+| `workers` | `1` | Direct OmniServe worker process count. Must be `1` |
+| `api_prefix` | `""` | Prefix for agent API routes. Normalized to `""` or a leading-slash path |
 | `enable_docs` | `true` | Enable `/docs` |
 | `enable_redoc` | `true` | Enable `/redoc` |
 | `cors_enabled` | `true` | Enable CORS middleware |
@@ -56,7 +56,7 @@ Defaults:
 | `auth_enabled` | `false` | Require bearer auth on protected routes |
 | `auth_token` | `None` | Bearer token |
 | `request_logging` | `true` | Log requests |
-| `log_level` | `INFO` | Uvicorn log level |
+| `log_level` | `INFO` | Uvicorn log level: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE` |
 | `request_timeout` | `300` | HTTP request timeout seconds |
 | `rate_limit_enabled` | `false` | Enable in-process rate limiting |
 | `rate_limit_requests` | `100` | Requests per window |
@@ -105,8 +105,16 @@ not be silently ignored.
 
 Serving bounds must also fail clearly during configuration creation:
 
+- `host` must not be empty.
 - `port` must be between `1` and `65535`.
-- `workers` must be at least `1`.
+- `workers` must be `1` for direct OmniServe because the served agent object is
+  bound to the current process. Horizontal scaling should run multiple
+  OmniServe processes behind a process manager or load balancer.
+- `api_prefix` is normalized by trimming whitespace, converting `"/"` to `""`,
+  adding a leading slash when missing, and removing trailing slashes. Whitespace
+  inside the prefix is invalid.
+- `log_level` is uppercased and must be one of `CRITICAL`, `ERROR`, `WARNING`,
+  `INFO`, `DEBUG`, or `TRACE`.
 - when rate limiting is enabled, `rate_limit_requests` must be at least `1`.
 - when rate limiting is enabled, `rate_limit_window` must be at least `1`.
 - `request_timeout <= 0` remains valid and disables OmniServe request timeout

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -103,6 +103,15 @@ Environment variables override code values:
 Invalid env values must fail clearly during configuration creation. They must
 not be silently ignored.
 
+Serving bounds must also fail clearly during configuration creation:
+
+- `port` must be between `1` and `65535`.
+- `workers` must be at least `1`.
+- when rate limiting is enabled, `rate_limit_requests` must be at least `1`.
+- when rate limiting is enabled, `rate_limit_window` must be at least `1`.
+- `request_timeout <= 0` remains valid and disables OmniServe request timeout
+  behavior.
+
 Generic env fallbacks such as `REDIS_URL`, `MONGODB_URI`, `OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GROQ_API_KEY` are not part of the
 OmniServe public configuration contract.

--- a/src/omnicoreagent/serve/cli.py
+++ b/src/omnicoreagent/serve/cli.py
@@ -82,7 +82,13 @@ def cli():
 @click.option(
     "--port", "-p", default=None, type=int, help="Port to bind to (default: 8000)"
 )
-@click.option("--workers", "-w", default=1, type=int, help="Number of workers")
+@click.option(
+    "--workers",
+    "-w",
+    default=1,
+    type=int,
+    help="Worker processes. Direct OmniServe requires 1.",
+)
 @click.option("--no-docs", is_flag=True, help="Disable Swagger UI")
 @click.option("--cors-origins", default="*", help="Comma-separated CORS origins")
 @click.option("--auth-token", default=None, help="Enable auth with this token")
@@ -111,24 +117,26 @@ def run(
             "Please specify an agent file with --agent or use 'omniserve quickstart'"
         )
 
-    # Load the agent
+    try:
+        config = OmniServeConfig(
+            host=host if host is not None else "0.0.0.0",
+            port=port if port is not None else 8000,
+            workers=workers,
+            enable_docs=not no_docs,
+            cors_origins=[o.strip() for o in cors_origins.split(",") if o.strip()],
+            auth_enabled=auth_token is not None,
+            auth_token=auth_token,
+            rate_limit_enabled=rate_limit is not None,
+            rate_limit_requests=rate_limit if rate_limit is not None else 100,
+            rate_limit_window=60,
+        )
+    except Exception as exc:
+        raise click.ClickException(f"Invalid OmniServe config: {exc}") from exc
+
+    # Load the agent after config validation so invalid serving config fails first.
     click.echo(f"📦 Loading agent from: {agent}")
     loaded_agent = _load_agent_from_file(agent)
     click.echo(f"✅ Loaded agent: {loaded_agent.name}")
-
-    # Build config
-    config = OmniServeConfig(
-        host=host or "0.0.0.0",
-        port=port or 8000,
-        workers=workers,
-        enable_docs=not no_docs,
-        cors_origins=[o.strip() for o in cors_origins.split(",")],
-        auth_enabled=auth_token is not None,
-        auth_token=auth_token,
-        rate_limit_enabled=rate_limit is not None,
-        rate_limit_requests=rate_limit or 100,
-        rate_limit_window=60,
-    )
 
     # Start server
     click.echo("")
@@ -198,9 +206,19 @@ def quickstart(
     """
     from omnicoreagent import OmniCoreAgent, OmniServe, OmniServeConfig
 
+    try:
+        config = OmniServeConfig(
+            host=host,
+            port=port,
+            enable_docs=True,
+            cors_origins=["*"],
+        )
+    except Exception as exc:
+        raise click.ClickException(f"Invalid OmniServe config: {exc}") from exc
+
     click.echo(f"🚀 Creating {provider}/{model} agent...")
 
-    # Create agent
+    # Create agent after config validation so invalid serving config fails first.
     agent = OmniCoreAgent(
         name=name,
         system_instruction=instruction,
@@ -211,13 +229,6 @@ def quickstart(
         debug=False,
     )
 
-    config = OmniServeConfig(
-        host=host,
-        port=port,
-        enable_docs=True,
-        cors_origins=["*"],
-    )
-
     click.echo("")
     click.echo("=" * 50)
     click.echo("OmniServe Quickstart")
@@ -225,9 +236,9 @@ def quickstart(
     click.echo("=" * 50)
     click.echo(f"Agent: {name}")
     click.echo(f"Model: {provider}/{model}")
-    click.echo(f"Server: http://{host}:{port}")
-    click.echo(f"Docs: http://{host}:{port}/docs")
-    click.echo(f"Metrics: http://{host}:{port}/prometheus")
+    click.echo(f"Server: http://{config.host}:{config.port}")
+    click.echo(f"Docs: http://{config.host}:{config.port}/docs")
+    click.echo(f"Metrics: http://{config.host}:{config.port}/prometheus")
     click.echo("")
     click.echo("Features (default):")
     click.echo("  • Auth: ✗ (use 'omniserve run' with --auth-token to enable)")
@@ -239,7 +250,7 @@ def quickstart(
     click.echo("=" * 50)
     click.echo("")
     click.echo("Test with:")
-    click.echo(f"  curl -X POST http://{host}:{port}/run/sync \\")
+    click.echo(f"  curl -X POST http://{config.host}:{config.port}/run/sync \\")
     click.echo('    -H "Content-Type: application/json" \\')
     click.echo('    -d \'{"query": "Hello!"}\'')
     click.echo("")

--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -8,7 +8,7 @@ OMNICOREAGENT_BACKGROUND_* environment variables.
 Environment Variables (OVERRIDE code values):
     OMNICOREAGENT_SERVE_HOST: Host to bind to (default: 0.0.0.0)
     OMNICOREAGENT_SERVE_PORT: Port to bind to (default: 8000)
-    OMNICOREAGENT_SERVE_WORKERS: Number of worker processes (default: 1)
+    OMNICOREAGENT_SERVE_WORKERS: Worker processes. Direct OmniServe requires 1.
     OMNICOREAGENT_SERVE_API_PREFIX: API path prefix (default: "")
     OMNICOREAGENT_SERVE_ENABLE_DOCS: Enable Swagger UI (default: true)
     OMNICOREAGENT_SERVE_ENABLE_REDOC: Enable ReDoc UI (default: true)
@@ -42,6 +42,8 @@ Priority: Environment variables ALWAYS override code values.
 import os
 from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_VALID_LOG_LEVELS = {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"}
 
 
 def _get_env(prefix: str, key: str) -> Optional[str]:
@@ -93,6 +95,32 @@ def _get_env_list(prefix: str, key: str) -> Optional[list[str]]:
     return [item.strip() for item in val.split(",") if item.strip()]
 
 
+def normalize_api_prefix(value: str | None) -> str:
+    """Normalize a FastAPI router prefix from code or environment."""
+    prefix = (value or "").strip()
+    if prefix in {"", "/"}:
+        return ""
+    if any(char.isspace() for char in prefix):
+        raise ValueError("OMNICOREAGENT_SERVE_API_PREFIX must not contain whitespace")
+    if not prefix.startswith("/"):
+        prefix = f"/{prefix}"
+    return prefix.rstrip("/")
+
+
+def validate_server_bind_config(*, host: str, port: int, workers: int) -> None:
+    """Validate server bind values used by config and runtime overrides."""
+    if not host or not host.strip():
+        raise ValueError("OMNICOREAGENT_SERVE_HOST must not be empty")
+    if port < 1 or port > 65535:
+        raise ValueError("OMNICOREAGENT_SERVE_PORT must be between 1 and 65535")
+    if workers != 1:
+        raise ValueError(
+            "OMNICOREAGENT_SERVE_WORKERS must be 1 for direct OmniServe. "
+            "Run multiple OmniServe processes behind a process manager for "
+            "horizontal scaling."
+        )
+
+
 class OmniServeConfig(BaseModel):
     """
     Configuration for OmniServe server.
@@ -105,7 +133,10 @@ class OmniServeConfig(BaseModel):
     # Server settings
     host: str = Field(default="0.0.0.0", description="Host to bind the server to")
     port: int = Field(default=8000, description="Port to bind the server to")
-    workers: int = Field(default=1, description="Number of worker processes")
+    workers: int = Field(
+        default=1,
+        description="Worker processes. Direct OmniServe requires one process.",
+    )
 
     # API settings
     api_prefix: str = Field(default="", description="API path prefix (e.g., '/api/v1')")
@@ -268,16 +299,27 @@ class OmniServeConfig(BaseModel):
         if (val := _get_env_bool(background_prefix, "START_WORKER")) is not None:
             self.background_start_worker = val
 
+        self.api_prefix = normalize_api_prefix(self.api_prefix)
+        self.log_level = self.log_level.upper()
         self._validate_server_config()
+        self._validate_log_level()
         self._validate_auth_config()
         self._validate_rate_limit_config()
         return self
 
     def _validate_server_config(self) -> None:
-        if self.port < 1 or self.port > 65535:
-            raise ValueError("OMNICOREAGENT_SERVE_PORT must be between 1 and 65535")
-        if self.workers < 1:
-            raise ValueError("OMNICOREAGENT_SERVE_WORKERS must be at least 1")
+        validate_server_bind_config(
+            host=self.host,
+            port=self.port,
+            workers=self.workers,
+        )
+
+    def _validate_log_level(self) -> None:
+        if self.log_level not in _VALID_LOG_LEVELS:
+            allowed = ", ".join(sorted(_VALID_LOG_LEVELS))
+            raise ValueError(
+                f"OMNICOREAGENT_SERVE_LOG_LEVEL must be one of: {allowed}"
+            )
 
     def _validate_auth_config(self) -> None:
         if self.auth_enabled and not _has_value(self.auth_token):

--- a/src/omnicoreagent/serve/config.py
+++ b/src/omnicoreagent/serve/config.py
@@ -268,14 +268,36 @@ class OmniServeConfig(BaseModel):
         if (val := _get_env_bool(background_prefix, "START_WORKER")) is not None:
             self.background_start_worker = val
 
+        self._validate_server_config()
         self._validate_auth_config()
+        self._validate_rate_limit_config()
         return self
+
+    def _validate_server_config(self) -> None:
+        if self.port < 1 or self.port > 65535:
+            raise ValueError("OMNICOREAGENT_SERVE_PORT must be between 1 and 65535")
+        if self.workers < 1:
+            raise ValueError("OMNICOREAGENT_SERVE_WORKERS must be at least 1")
 
     def _validate_auth_config(self) -> None:
         if self.auth_enabled and not _has_value(self.auth_token):
             raise ValueError(
                 "OMNICOREAGENT_SERVE_AUTH_TOKEN is required when "
                 "OMNICOREAGENT_SERVE_AUTH_ENABLED=true"
+            )
+
+    def _validate_rate_limit_config(self) -> None:
+        if not self.rate_limit_enabled:
+            return
+        if self.rate_limit_requests < 1:
+            raise ValueError(
+                "OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS must be at least 1 "
+                "when rate limiting is enabled"
+            )
+        if self.rate_limit_window < 1:
+            raise ValueError(
+                "OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW must be at least 1 "
+                "when rate limiting is enabled"
             )
 
     @classmethod

--- a/src/omnicoreagent/serve/server.py
+++ b/src/omnicoreagent/serve/server.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 from omnicoreagent.core.logging import logger
 
 from .app_factory import create_omniserve_app
-from .config import OmniServeConfig
+from .config import OmniServeConfig, validate_server_bind_config
 from .state import get_agent_name
 
 if TYPE_CHECKING:
@@ -108,13 +108,19 @@ class OmniServe:
         Args:
             host: Host to bind to (overrides config)
             port: Port to bind to (overrides config)
-            workers: Number of worker processes (overrides config)
+            workers: Worker process count. Direct OmniServe requires 1 because
+                the served agent instance lives in the current process.
         """
         import uvicorn
 
-        final_host = host or self.config.host
-        final_port = port or self.config.port
-        final_workers = workers or self.config.workers
+        final_host = self.config.host if host is None else host
+        final_port = self.config.port if port is None else port
+        final_workers = self.config.workers if workers is None else workers
+        validate_server_bind_config(
+            host=final_host,
+            port=final_port,
+            workers=final_workers,
+        )
 
         logger.info(f"OmniServe: Starting server at http://{final_host}:{final_port}")
         logger.info(
@@ -145,8 +151,13 @@ class OmniServe:
         """
         import uvicorn
 
-        final_host = host or self.config.host
-        final_port = port or self.config.port
+        final_host = self.config.host if host is None else host
+        final_port = self.config.port if port is None else port
+        validate_server_bind_config(
+            host=final_host,
+            port=final_port,
+            workers=self.config.workers,
+        )
 
         logger.info(
             f"OmniServe: Starting async server at http://{final_host}:{final_port}"

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -34,6 +34,18 @@ class TestConfiguration:
         assert config.port == 9090
         assert config.host == "127.0.0.1"
 
+    def test_api_prefix_is_normalized(self):
+        assert OmniServeConfig(api_prefix="api").api_prefix == "/api"
+        assert OmniServeConfig(api_prefix="/api/").api_prefix == "/api"
+        assert OmniServeConfig(api_prefix="/").api_prefix == ""
+
+    def test_env_api_prefix_is_normalized(self):
+        with patch.dict(os.environ, {"OMNICOREAGENT_SERVE_API_PREFIX": "api/v1/"}):
+            assert OmniServeConfig().api_prefix == "/api/v1"
+
+    def test_log_level_is_normalized(self):
+        assert OmniServeConfig(log_level="debug").log_level == "DEBUG"
+
     def test_env_vars_override_code(self):
         """Verify public env vars override code values."""
         with patch.dict(
@@ -62,6 +74,12 @@ class TestConfiguration:
         [
             ("OMNICOREAGENT_SERVE_PORT", "not-a-port", "must be an integer"),
             ("OMNICOREAGENT_SERVE_AUTH_ENABLED", "maybe", "must be a boolean"),
+            ("OMNICOREAGENT_SERVE_LOG_LEVEL", "LOUD", "LOG_LEVEL must be one of"),
+            (
+                "OMNICOREAGENT_SERVE_API_PREFIX",
+                "bad prefix",
+                "API_PREFIX must not contain whitespace",
+            ),
             (
                 "OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT",
                 "slow",
@@ -91,7 +109,11 @@ class TestConfiguration:
         [
             ({"port": 0}, "PORT must be between 1 and 65535"),
             ({"port": 65536}, "PORT must be between 1 and 65535"),
-            ({"workers": 0}, "WORKERS must be at least 1"),
+            ({"host": ""}, "HOST must not be empty"),
+            ({"workers": 0}, "WORKERS must be 1 for direct OmniServe"),
+            ({"workers": 2}, "WORKERS must be 1 for direct OmniServe"),
+            ({"api_prefix": "bad prefix"}, "API_PREFIX must not contain whitespace"),
+            ({"log_level": "LOUD"}, "LOG_LEVEL must be one of"),
             (
                 {"rate_limit_enabled": True, "rate_limit_requests": 0},
                 "RATE_LIMIT_REQUESTS must be at least 1",
@@ -110,7 +132,16 @@ class TestConfiguration:
         ("env_name", "env_value", "message"),
         [
             ("OMNICOREAGENT_SERVE_PORT", "0", "PORT must be between 1 and 65535"),
-            ("OMNICOREAGENT_SERVE_WORKERS", "0", "WORKERS must be at least 1"),
+            (
+                "OMNICOREAGENT_SERVE_WORKERS",
+                "0",
+                "WORKERS must be 1 for direct OmniServe",
+            ),
+            (
+                "OMNICOREAGENT_SERVE_WORKERS",
+                "2",
+                "WORKERS must be 1 for direct OmniServe",
+            ),
             (
                 "OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS",
                 "0",
@@ -136,6 +167,134 @@ class TestConfiguration:
     def test_non_positive_request_timeout_remains_allowed_to_disable_timeout(self):
         assert OmniServeConfig(request_timeout=0).request_timeout == 0
         assert OmniServeConfig(request_timeout=-1).request_timeout == -1
+
+    def test_server_start_overrides_are_validated_before_uvicorn(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "StartValidationAgent"
+        server = OmniServe(agent, OmniServeConfig(background_enabled=False))
+
+        with patch("uvicorn.run") as run:
+            with pytest.raises(ValueError, match="PORT must be between 1 and 65535"):
+                server.start(port=0)
+            run.assert_not_called()
+
+        with patch("uvicorn.run") as run:
+            with pytest.raises(ValueError, match="WORKERS must be 1"):
+                server.start(workers=0)
+            run.assert_not_called()
+
+        with patch("uvicorn.run") as run:
+            with pytest.raises(ValueError, match="WORKERS must be 1"):
+                server.start(workers=2)
+            run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_server_start_async_overrides_are_validated_before_uvicorn(self):
+        agent = MagicMock(spec=OmniCoreAgent)
+        agent.name = "AsyncStartValidationAgent"
+        server = OmniServe(agent, OmniServeConfig(background_enabled=False))
+
+        with patch("uvicorn.Server") as uvicorn_server:
+            with pytest.raises(ValueError, match="PORT must be between 1 and 65535"):
+                await server.start_async(port=0)
+            uvicorn_server.assert_not_called()
+
+    def test_cli_run_invalid_rate_limit_fails_before_serving(self, tmp_path):
+        agent_file = tmp_path / "agent.py"
+        marker_file = tmp_path / "loaded.txt"
+        agent_file.write_text(
+            "from pathlib import Path\n"
+            f"Path({str(marker_file)!r}).write_text('loaded', encoding='utf-8')\n"
+            "class Agent:\n"
+            "    name = 'CliValidationAgent'\n"
+            "    agent_config = {}\n\n"
+            "agent = Agent()\n",
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            ["run", "--agent", str(agent_file), "--rate-limit", "0"],
+        )
+
+        assert result.exit_code != 0
+        assert "RATE_LIMIT_REQUESTS must be at least 1" in result.output
+        assert not marker_file.exists()
+
+    def test_cli_run_invalid_port_fails_before_serving(self, tmp_path):
+        agent_file = tmp_path / "agent.py"
+        marker_file = tmp_path / "loaded.txt"
+        agent_file.write_text(
+            "from pathlib import Path\n"
+            f"Path({str(marker_file)!r}).write_text('loaded', encoding='utf-8')\n"
+            "class Agent:\n"
+            "    name = 'CliPortValidationAgent'\n"
+            "    agent_config = {}\n\n"
+            "agent = Agent()\n",
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            ["run", "--agent", str(agent_file), "--port", "0"],
+        )
+
+        assert result.exit_code != 0
+        assert "PORT must be between 1 and 65535" in result.output
+        assert not marker_file.exists()
+
+    def test_cli_run_invalid_env_port_fails_before_loading_agent(self, tmp_path):
+        agent_file = tmp_path / "agent.py"
+        marker_file = tmp_path / "loaded.txt"
+        agent_file.write_text(
+            "from pathlib import Path\n"
+            f"Path({str(marker_file)!r}).write_text('loaded', encoding='utf-8')\n"
+            "class Agent:\n"
+            "    name = 'CliEnvPortValidationAgent'\n"
+            "    agent_config = {}\n\n"
+            "agent = Agent()\n",
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            ["run", "--agent", str(agent_file)],
+            env={"OMNICOREAGENT_SERVE_PORT": "0"},
+        )
+
+        assert result.exit_code != 0
+        assert "PORT must be between 1 and 65535" in result.output
+        assert not marker_file.exists()
+
+    def test_cli_run_invalid_workers_fails_before_loading_agent(self, tmp_path):
+        agent_file = tmp_path / "agent.py"
+        marker_file = tmp_path / "loaded.txt"
+        agent_file.write_text(
+            "from pathlib import Path\n"
+            f"Path({str(marker_file)!r}).write_text('loaded', encoding='utf-8')\n"
+            "class Agent:\n"
+            "    name = 'CliWorkerValidationAgent'\n"
+            "    agent_config = {}\n\n"
+            "agent = Agent()\n",
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            ["run", "--agent", str(agent_file), "--workers", "2"],
+        )
+
+        assert result.exit_code != 0
+        assert "WORKERS must be 1 for direct OmniServe" in result.output
+        assert not marker_file.exists()
+
+    def test_cli_quickstart_invalid_port_fails_before_creating_agent(self):
+        with patch("omnicoreagent.OmniCoreAgent") as agent_cls:
+            result = CliRunner().invoke(cli, ["quickstart", "--port", "0"])
+
+        assert result.exit_code != 0
+        assert "PORT must be between 1 and 65535" in result.output
+        agent_cls.assert_not_called()
 
     def test_background_task_store_url_infers_sql(self):
         config = OmniServeConfig(

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -86,6 +86,57 @@ class TestConfiguration:
             with pytest.raises(ValidationError, match="AUTH_TOKEN is required"):
                 OmniServeConfig()
 
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"port": 0}, "PORT must be between 1 and 65535"),
+            ({"port": 65536}, "PORT must be between 1 and 65535"),
+            ({"workers": 0}, "WORKERS must be at least 1"),
+            (
+                {"rate_limit_enabled": True, "rate_limit_requests": 0},
+                "RATE_LIMIT_REQUESTS must be at least 1",
+            ),
+            (
+                {"rate_limit_enabled": True, "rate_limit_window": 0},
+                "RATE_LIMIT_WINDOW must be at least 1",
+            ),
+        ],
+    )
+    def test_invalid_serving_bounds_fail_clearly(self, kwargs, message):
+        with pytest.raises(ValidationError, match=message):
+            OmniServeConfig(**kwargs)
+
+    @pytest.mark.parametrize(
+        ("env_name", "env_value", "message"),
+        [
+            ("OMNICOREAGENT_SERVE_PORT", "0", "PORT must be between 1 and 65535"),
+            ("OMNICOREAGENT_SERVE_WORKERS", "0", "WORKERS must be at least 1"),
+            (
+                "OMNICOREAGENT_SERVE_RATE_LIMIT_REQUESTS",
+                "0",
+                "RATE_LIMIT_REQUESTS must be at least 1",
+            ),
+            (
+                "OMNICOREAGENT_SERVE_RATE_LIMIT_WINDOW",
+                "0",
+                "RATE_LIMIT_WINDOW must be at least 1",
+            ),
+        ],
+    )
+    def test_invalid_serving_bounds_from_env_fail_clearly(
+        self, env_name, env_value, message
+    ):
+        env = {env_name: env_value}
+        if "RATE_LIMIT" in env_name:
+            env["OMNICOREAGENT_SERVE_RATE_LIMIT_ENABLED"] = "true"
+        with patch.dict(os.environ, env):
+            with pytest.raises(ValidationError, match=message):
+                OmniServeConfig()
+
+    def test_non_positive_request_timeout_remains_allowed_to_disable_timeout(self):
+        assert OmniServeConfig(request_timeout=0).request_timeout == 0
+        assert OmniServeConfig(request_timeout=-1).request_timeout == -1
+
     def test_background_task_store_url_infers_sql(self):
         config = OmniServeConfig(
             background_task_store_url="sqlite:///custom-background.db"


### PR DESCRIPTION
## Summary
- validate OmniServe bind config before runtime startup, including host, port, direct-worker mode, API prefix, log level, auth, and rate-limit bounds
- normalize API prefixes and log levels from code and environment so mounted routes are predictable
- make CLI run/quickstart fail invalid serving config before importing or creating agent code
- document OmniServe production config invariants across internal architecture/spec, public docs, and cookbook examples

## Reviewers
- production serving correctness reviewer: no blocking findings
- docs/spec contract reviewer: found stale cookbook log-level wording; fixed
- QA/DX reviewer: found CLI pre-load test gaps; fixed with marker-file assertions and env override coverage

## Verification
- uv run ruff check src/omnicoreagent/serve tests/test_omniserve_full.py cookbook/omniserve/python_api.py
- uv run pytest tests/test_omniserve_full.py tests/test_docs_claims.py -q
- uv run pytest tests/test_omniserve_background.py tests/test_omniserve_sse.py tests/test_import_startup.py tests/test_background_agent.py tests/test_background_task_store_contract.py tests/test_background_durable_manager_integration.py tests/test_background_cookbook.py -q
- uv run pytest -q
- git diff --check