### PR TITLE
Design telemetry architecture and specification

### DIFF
--- a/engineering/README.md
+++ b/engineering/README.md
@@ -31,8 +31,10 @@ Current records:
 - `architecture/background-agents.md`
 - `architecture/events.md`
 - `architecture/omniserve.md`
+- `architecture/telemetry.md`
 - `architecture/workspace.md`
 - `specifications/background-agents.md`
 - `specifications/events.md`
 - `specifications/omniserve.md`
+- `specifications/telemetry.md`
 - `specifications/workspace.md`

--- a/engineering/README.md
+++ b/engineering/README.md
@@ -26,15 +26,22 @@ engineering/
 Architecture records explain how to think about a subsystem.
 Specifications define what that subsystem must do exactly.
 
-Current records:
+Target architecture and specification records:
 
 - `architecture/background-agents.md`
-- `architecture/events.md`
 - `architecture/omniserve.md`
 - `architecture/telemetry.md`
 - `architecture/workspace.md`
 - `specifications/background-agents.md`
-- `specifications/events.md`
 - `specifications/omniserve.md`
 - `specifications/telemetry.md`
 - `specifications/workspace.md`
+
+Current implementation contracts during telemetry migration:
+
+- `architecture/events.md`
+- `specifications/events.md`
+
+The event records describe the current legacy runtime event and SSE behavior.
+They are kept so maintainers can migrate safely. They are not the future
+telemetry architecture.

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -18,6 +18,12 @@ Read this before changing:
 - `src/omnicoreagent/core/events`
 - `src/omnicoreagent/core/memory_store`
 - `engineering/specifications/background-agents.md`
+- `engineering/architecture/telemetry.md`
+
+Telemetry migration note: sections that mention `EventRouter` describe current
+visibility wiring. Target background execution evidence and live/replay
+streaming must use telemetry. Do not add new background features that depend on
+`EventRouter`.
 
 ---
 

--- a/engineering/architecture/events.md
+++ b/engineering/architecture/events.md
@@ -4,12 +4,21 @@ This is an internal architecture record under `engineering/architecture`, not
 public product documentation. It defines the current runtime event boundary for
 OmniCoreAgent.
 
+Migration status: this document describes the current legacy runtime event and
+SSE implementation only. The target execution evidence, replay, and streaming
+architecture is `engineering/architecture/telemetry.md`.
+
+Do not build new features on `EventRouter`. New runtime, serving, background,
+trace, observability, or evaluation work must target telemetry.
+
 Runtime events are the lightweight execution signal emitted while an agent is
 running. They power live UIs, debugging, session history, compact trace
-summaries, background task lifecycle inspection, and future observability work.
+summaries, and background task lifecycle inspection in the current
+implementation.
 
-Runtime events are not the future trace/evaluation system. They are the ordered
-execution facts that future trace/eval layers can build from.
+Runtime events are not the future trace/evaluation system. During migration,
+current runtime events may be adapted into telemetry records, but telemetry is
+the canonical future evidence model.
 
 ## Purpose
 

--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -8,6 +8,12 @@ OmniServe is the optional HTTP serving layer for an already-built
 `OmniCoreAgent`. It must not become a second agent runtime, tracing system,
 evaluation system, or workflow engine.
 
+Telemetry migration note: sections that mention SSE over runtime events describe
+current serving behavior. Target live/replay streaming is
+`TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE`.
+New serving work should target telemetry and should not add new `EventRouter`
+dependencies.
+
 ## Purpose
 
 OmniServe exists to expose an agent over HTTP:

--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -8,12 +8,11 @@ during agent execution in a form that can later support debugging,
 observability, regression analysis, and the future OmniCoreAgent Agentic
 Evaluation system.
 
-This document replaces the older event-only architecture model. Runtime events
-remain useful for SSE streaming and lightweight debugging, but they are not a
-complete trace system and must not be treated as the evaluation evidence model.
-The current runtime event contract remains documented in
-`engineering/architecture/events.md` and `engineering/specifications/events.md`
-until telemetry becomes the canonical runtime path.
+This document replaces the older event-only architecture model. Live streaming
+and replay remain required harness capabilities, but they should be served from
+telemetry rather than from a separate permanent `EventRouter` subsystem.
+`EventRouter` is a legacy implementation detail to remove during migration, not
+the long-term owner of execution evidence.
 
 ## Purpose
 
@@ -24,7 +23,8 @@ OmniCoreAgent telemetry exists to:
 - preserve point-in-time facts as append-only events
 - build complete traces for one logical run
 - provide stable evidence references for future evaluation
-- support local debugging without requiring an observability product
+- support local debugging and live streaming without requiring an observability
+  product
 - make future observability, exports, and evals consumers of the same evidence
 
 Telemetry is runtime infrastructure. Observability is a later product layer on
@@ -33,10 +33,9 @@ top of telemetry. Evaluation is a later consumer of normalized telemetry.
 ```text
 runtime execution
   -> telemetry recorder
-  -> events + spans
-  -> trace store
-  -> trace normalizer
-  -> future observability / future evaluation / future exporters
+  -> telemetry store
+       -> telemetry stream -> OmniServe SSE / live clients
+       -> trace normalizer -> future observability / future evaluation / future exporters
 ```
 
 ## Non-Goals
@@ -94,6 +93,16 @@ That model is useful, but incomplete. It does not provide:
 The current `/events/{session_id}/trace` endpoint is therefore a compact event
 summary, not a full trace. Future docs and code should avoid using it as the
 canonical trace model.
+
+The replacement is not "EventRouter plus telemetry." The replacement is
+telemetry owning the full path:
+
+```text
+TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
+```
+
+Anything still using `EventRouter` after telemetry lands is transitional code
+and should have a removal plan.
 
 ## Core Concepts
 
@@ -170,10 +179,11 @@ OmniServe / application call
   -> TelemetryRecorder starts root span
   -> agent runtime starts agent.run span
   -> model/tool/memory/workspace/context/subagent spans emit events
-  -> TraceStore persists events and spans
-  -> TraceNormalizer builds stable normalized trace
-  -> future BehaviorExtractor consumes normalized trace
-  -> future evaluators attach evidence-linked judgments
+  -> TelemetryStore persists events and spans
+       -> TelemetryStream serves replay/follow to OmniServe SSE
+       -> TraceNormalizer builds stable normalized trace
+            -> future BehaviorExtractor consumes normalized trace
+            -> future evaluators attach evidence-linked judgments
 ```
 
 Runtime controls may also emit telemetry:
@@ -335,8 +345,28 @@ Later storage backends:
 - PostgreSQL for production querying
 - object storage for archival
 
-Redis streams remain useful for live runtime events, but Redis streams are not
-the canonical long-term trace store.
+Redis streams may be a live fanout implementation for `TelemetryStream`, but
+Redis streams are not the canonical long-term trace store.
+
+## Telemetry Stream
+
+The telemetry stream is the live/replay adapter over telemetry records.
+
+It replaces the long-term need for `EventRouter`.
+
+Responsibilities:
+
+- stream selected telemetry events for one session, run, or trace
+- replay stored telemetry events from a cursor
+- support SSE consumers without requiring dashboards or observability services
+- preserve session and run isolation
+- expose cursors for reconnect and catch-up
+- avoid creating another evidence source outside telemetry
+
+The stream is a view over `TelemetryStore`; it is not a separate truth source.
+
+Initial stream backends may reuse implementation ideas from current in-memory
+queues and Redis streams, but the public contract should be telemetry-native.
 
 ## Trace Normalizer
 
@@ -391,24 +421,28 @@ object storage by reference.
 
 Telemetry must never force secrets into traces.
 
-## Relationship to Current Runtime Events
+## Relationship to Legacy Runtime Events
 
-Runtime events remain as a lightweight streaming layer during migration.
+Legacy runtime events are only a migration concern.
 
 Short-term:
 
-- existing `EventRouter` continues powering SSE and event replay
 - current `Event` records can be adapted into telemetry events
-- `get_trace()` remains a compact event summary
+- `EventRouter` may remain temporarily while call sites are moved
+- `get_trace()` remains a compact event summary until replaced
 
 Target:
 
 - runtime emits through `TelemetryRecorder`
-- SSE can stream selected telemetry events
+- `TelemetryStream` powers live/replay streaming
+- OmniServe SSE streams selected telemetry events
 - event summary becomes a derived view
 - trace retrieval reads canonical telemetry traces
+- `EventRouter` and legacy event stores are removed once no call sites require
+  them
 
-The migration should avoid maintaining two unrelated truth sources.
+The migration must avoid maintaining two unrelated truth sources. New runtime
+work should not add new dependencies on `EventRouter`.
 
 ## Relationship to OmniServe
 
@@ -473,7 +507,7 @@ only ensure the evidence exists.
 ## Invariants
 
 - Telemetry is the source of execution evidence.
-- Runtime events are not the full trace model.
+- Legacy runtime events are not the full trace model.
 - Every trace has a `trace_id`.
 - Every span belongs to one trace.
 - Every event belongs to one trace or is explicitly marked legacy/unbound.
@@ -498,5 +532,5 @@ Each implementation phase must include:
 - concurrent tool batch tests
 - redaction tests
 - partial trace tests
-- migration tests from current runtime events
+- migration tests from legacy runtime events
 - documentation updates

--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -1,0 +1,502 @@
+# Telemetry Architecture
+
+This is an internal architecture record under `engineering/architecture`, not
+public product documentation.
+
+Telemetry is the evidence layer of OmniCoreAgent. It records what happened
+during agent execution in a form that can later support debugging,
+observability, regression analysis, and the future OmniCoreAgent Agentic
+Evaluation system.
+
+This document replaces the older event-only architecture model. Runtime events
+remain useful for SSE streaming and lightweight debugging, but they are not a
+complete trace system and must not be treated as the evaluation evidence model.
+The current runtime event contract remains documented in
+`engineering/architecture/events.md` and `engineering/specifications/events.md`
+until telemetry becomes the canonical runtime path.
+
+## Purpose
+
+OmniCoreAgent telemetry exists to:
+
+- capture execution facts from the harness while an agent runs
+- represent timed work as spans with parent/child relationships
+- preserve point-in-time facts as append-only events
+- build complete traces for one logical run
+- provide stable evidence references for future evaluation
+- support local debugging without requiring an observability product
+- make future observability, exports, and evals consumers of the same evidence
+
+Telemetry is runtime infrastructure. Observability is a later product layer on
+top of telemetry. Evaluation is a later consumer of normalized telemetry.
+
+```text
+runtime execution
+  -> telemetry recorder
+  -> events + spans
+  -> trace store
+  -> trace normalizer
+  -> future observability / future evaluation / future exporters
+```
+
+## Non-Goals
+
+This architecture does not implement or design:
+
+- dashboards
+- observability UI
+- alerting
+- eval runner
+- evaluator modules
+- benchmark suites
+- feedback UI
+- OpenTelemetry exporter implementation
+- LangSmith, Opik, Phoenix, Langfuse, Braintrust, or vendor integration
+- policy engine
+- sandbox logs
+
+Those systems will be designed separately. They must consume telemetry instead
+of bypassing it.
+
+## Current Limitation Being Replaced
+
+Current runtime events are session-scoped records:
+
+```text
+EventRouter -> EventStore -> Event -> compact event summary
+```
+
+They contain:
+
+- `type`
+- `payload`
+- `agent_name`
+- `timestamp`
+- `event_id`
+- `sequence`
+- `run_id`
+
+That model is useful, but incomplete. It does not provide:
+
+- `trace_id`
+- `span_id`
+- `parent_span_id`
+- `parent_event_id`
+- standard `input`, `output`, and `error` fields
+- duration for timed work
+- token usage and estimated cost
+- normalized actor identity
+- trace-level metadata
+- version metadata
+- first-class memory, context, workspace, guardrail, model, and MCP records
+- stable normalized evidence for future evaluators
+
+The current `/events/{session_id}/trace` endpoint is therefore a compact event
+summary, not a full trace. Future docs and code should avoid using it as the
+canonical trace model.
+
+## Core Concepts
+
+The terminology deliberately follows the standard telemetry shape used by
+OpenTelemetry and modern LLM observability systems: traces contain spans, spans
+represent timed work, and events record point-in-time facts. OmniCoreAgent owns
+its internal schema first. Vendor exports and OTLP integration are later
+adapters, not the foundation.
+
+### Telemetry Event
+
+A telemetry event is an append-only fact that happened at a point in time.
+
+Examples:
+
+- user message received
+- model response parsed
+- tool result observed
+- guardrail violation detected
+- context compressed
+- workspace file written
+- background run heartbeat emitted
+
+Events are evidence. They must be stable enough to reference later from an
+evaluation report.
+
+### Telemetry Span
+
+A telemetry span is a timed unit of work.
+
+Examples:
+
+- `agent.run`
+- `agent.step`
+- `model.call`
+- `tool.batch`
+- `tool.call`
+- `mcp.tool.call`
+- `memory.read`
+- `workspace.write`
+- `subagent.run`
+- `background.run`
+- `serve.request`
+
+Spans form a parent/child tree. This hierarchy is the main difference between
+runtime events and real telemetry.
+
+### Telemetry Trace
+
+A telemetry trace is one logical execution graph.
+
+For a normal interactive request, the trace usually starts at `agent.run`.
+For OmniServe, it may start at `serve.request` and contain `agent.run`.
+For a background task, it may start at `background.run` and contain `agent.run`.
+
+### Telemetry Context
+
+Telemetry context carries active identifiers through async execution:
+
+- `trace_id`
+- `span_id`
+- `run_id`
+- `session_id`
+- `task_id`
+- `workflow_id`
+
+Context propagation must work across model calls, parallel tool batches,
+subagents, background runs, and OmniServe request handling.
+
+## Target Data Flow
+
+```text
+OmniServe / application call
+  -> TelemetryRecorder starts root span
+  -> agent runtime starts agent.run span
+  -> model/tool/memory/workspace/context/subagent spans emit events
+  -> TraceStore persists events and spans
+  -> TraceNormalizer builds stable normalized trace
+  -> future BehaviorExtractor consumes normalized trace
+  -> future evaluators attach evidence-linked judgments
+```
+
+Runtime controls may also emit telemetry:
+
+- resource guard warning
+- resource guard halt
+- safety guard halt
+- approval requested
+- approval granted
+- approval denied
+
+Runtime controls may stop execution. Evaluators do not stop live execution in
+the foundation telemetry phase.
+
+## Identity Model
+
+Use separate identifiers for separate concerns:
+
+| Identifier | Meaning |
+|------------|---------|
+| `trace_id` | Telemetry execution id. Primary key for one trace. |
+| `span_id` | Timed operation id inside a trace. |
+| `event_id` | Point-in-time evidence id. |
+| `run_id` | Runtime/background run id. |
+| `session_id` | Conversation continuity id. |
+| `task_id` | Background/evaluation task id when present. |
+| `workflow_id` | Workflow/orchestration id when present. |
+
+`trace_id` is not the same as `session_id`. A session may have many traces.
+`trace_id` is not the same as `run_id`. A background run may map directly to a
+trace, but the runtime should not assume they are always identical.
+
+## Canonical Span Tree
+
+The target execution hierarchy should support this shape:
+
+```text
+serve.request
+  agent.run
+    agent.step
+      context.assembly
+      memory.read
+      model.call
+      tool.batch
+        tool.call
+        mcp.tool.call
+      observation.pipeline
+      memory.write
+      workspace.write
+    subagent.run
+      agent.run
+        model.call
+        tool.call
+```
+
+Background execution should use the same telemetry model:
+
+```text
+background.task
+  background.run
+    agent.run
+      agent.step
+```
+
+## Span Kinds
+
+The first-class span kinds are:
+
+```text
+agent.run
+agent.step
+model.call
+context.assembly
+context.compression
+tool.batch
+tool.call
+mcp.tool.call
+observation.pipeline
+memory.read
+memory.write
+workspace.read
+workspace.write
+tool.offload
+guardrail.check
+subagent.run
+workflow.route
+background.task
+background.run
+serve.request
+runtime.control
+```
+
+Reserved span kinds for later phases:
+
+```text
+verifier.run
+eval.score
+```
+
+These reserved kinds are part of the long-term schema direction, but they must
+not be emitted until verification and evaluation are implemented.
+
+## Event Type Groups
+
+Telemetry events should cover these groups:
+
+- agent lifecycle
+- user input
+- model interaction
+- tool interaction
+- MCP interaction
+- approval flow
+- memory
+- context
+- workspace
+- guardrails
+- runtime controls
+- reasoning
+- subagents
+- workflows
+- background lifecycle
+- serving
+- finalization
+- errors
+
+The event registry must stay explicit. Arbitrary string events can be accepted
+during migration, but stable telemetry requires documented event names.
+
+## Trace Recorder
+
+The Trace Recorder is the runtime-facing API. Runtime code should not write
+directly to the store.
+
+Responsibilities:
+
+- create traces
+- start/end spans
+- emit events
+- attach input/output/error data according to redaction policy
+- compute duration
+- attach token usage and estimated cost when available
+- preserve parent/child relationships
+- persist partial traces on failure or cancellation
+- expose current telemetry context to nested runtime components
+
+The recorder must be safe to call from concurrent tool execution and subagent
+runs.
+
+## Trace Store
+
+Foundation storage should be simple and reliable:
+
+- `in_memory` for tests and local development
+- local JSONL for persisted local traces
+
+Later storage backends:
+
+- SQLite for small teams and local durability
+- PostgreSQL for production querying
+- object storage for archival
+
+Redis streams remain useful for live runtime events, but Redis streams are not
+the canonical long-term trace store.
+
+## Trace Normalizer
+
+The normalizer converts raw runtime telemetry into a stable schema for future
+evaluation.
+
+Evaluators must consume normalized traces only. They must not depend on
+runtime-specific payload shapes, internal class names, or legacy event types.
+
+The normalizer should:
+
+- sort spans and events deterministically
+- validate parent/child references
+- preserve evidence ids
+- classify span and event kinds
+- produce behavior-relevant summaries
+- flag incomplete traces without hiding them
+
+## Evidence Contract
+
+Every future evaluation judgment must be able to reference evidence:
+
+- `trace_id`
+- `span_id`
+- `event_id`
+- `sequence_number`
+
+If a telemetry record cannot be referenced later, it is not sufficient evidence.
+
+Reports must be able to say:
+
+```text
+tool_discipline.score evidence: [event_004, span_tool_batch_001]
+```
+
+## Redaction and Payload Policy
+
+Telemetry must support privacy and cost control from the first implementation.
+
+Configuration should control:
+
+- whether inputs are recorded
+- whether outputs are recorded
+- whether tool results are recorded inline
+- maximum payload bytes
+- redacted key names
+- large payload offload
+- whether model prompts and completions are stored
+
+Large payloads should be summarized inline and optionally stored in workspace or
+object storage by reference.
+
+Telemetry must never force secrets into traces.
+
+## Relationship to Current Runtime Events
+
+Runtime events remain as a lightweight streaming layer during migration.
+
+Short-term:
+
+- existing `EventRouter` continues powering SSE and event replay
+- current `Event` records can be adapted into telemetry events
+- `get_trace()` remains a compact event summary
+
+Target:
+
+- runtime emits through `TelemetryRecorder`
+- SSE can stream selected telemetry events
+- event summary becomes a derived view
+- trace retrieval reads canonical telemetry traces
+
+The migration should avoid maintaining two unrelated truth sources.
+
+## Relationship to OmniServe
+
+OmniServe should eventually create `serve.request` spans for:
+
+- `/run`
+- `/run/sync`
+- background task API calls
+
+The served agent run should become a child of the serving span when the request
+starts the agent directly.
+
+SSE streaming should not require the full observability stack. It should stream
+the subset of telemetry events needed by clients.
+
+## Relationship to Background Agents
+
+Background agents already persist lifecycle events, run ids, attempts,
+workspace paths, and heartbeat records.
+
+Telemetry should unify these facts into the trace model:
+
+- `background.task`
+- `background.run`
+- `agent.run`
+- heartbeat events
+- lease events
+- retry attempts
+- cancellation requests
+- run workspace references
+
+Background run events are execution evidence and must remain recoverable after
+restart when a durable task store is configured.
+
+## Relationship to Future Evaluation
+
+The future OmniCoreAgent Agentic Evaluation system requires trace-native,
+evidence-linked execution records.
+
+The evaluation architecture requires more than a final response and a flat event
+log. It needs complete trajectories with stable evidence references, state
+changes, tool behavior, recovery behavior, risk signals, memory/context
+behavior, coordination boundaries, latency, tokens, and cost.
+
+Telemetry must support these evaluation dimensions:
+
+- outcome correctness
+- trajectory quality
+- tool discipline
+- recovery quality
+- risk profile
+- longitudinal risk
+- efficiency
+- evidence grounding
+- memory and context behavior
+- coordination quality
+- final response quality
+
+Evaluation is not implemented in this telemetry phase. The telemetry design must
+only ensure the evidence exists.
+
+## Invariants
+
+- Telemetry is the source of execution evidence.
+- Runtime events are not the full trace model.
+- Every trace has a `trace_id`.
+- Every span belongs to one trace.
+- Every event belongs to one trace or is explicitly marked legacy/unbound.
+- Spans preserve parent/child relationships.
+- Events preserve stable ids and sequence numbers.
+- Partial traces are valid traces.
+- Missing evidence is represented explicitly.
+- Redaction policy applies before persistence.
+- Evaluators consume normalized traces, not raw runtime objects.
+- Observability, dashboards, exporters, and eval runner are out of scope for the
+  telemetry foundation.
+
+## Implementation Discipline
+
+No coding phase should start until the telemetry specification is accepted.
+
+Each implementation phase must include:
+
+- schema tests
+- context propagation tests
+- parent/child span tests
+- concurrent tool batch tests
+- redaction tests
+- partial trace tests
+- migration tests from current runtime events
+- documentation updates

--- a/engineering/specifications/README.md
+++ b/engineering/specifications/README.md
@@ -21,4 +21,5 @@ Current specifications:
 - `background-agents.md`
 - `events.md`
 - `omniserve.md`
+- `telemetry.md`
 - `workspace.md`

--- a/engineering/specifications/README.md
+++ b/engineering/specifications/README.md
@@ -16,10 +16,17 @@ Specifications are stricter than architecture records. Architecture explains
 the system shape and decisions. A specification defines the contract that code
 must obey.
 
-Current specifications:
+Target specifications:
 
 - `background-agents.md`
-- `events.md`
 - `omniserve.md`
 - `telemetry.md`
 - `workspace.md`
+
+Current implementation contract during telemetry migration:
+
+- `events.md`
+
+The events specification documents the current legacy runtime event and SSE
+contract. New telemetry work should use `telemetry.md` as the target
+specification.

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -11,8 +11,14 @@ Read this with:
 - `src/omnicoreagent/core/workspace`
 - `src/omnicoreagent/core/events`
 - `src/omnicoreagent/core/memory_store`
+- `engineering/specifications/telemetry.md`
 
 When this specification changes, implementation and tests must change with it.
+
+Telemetry migration note: current event behavior remains documented here for
+the shipped background system. Future background visibility, replay, and trace
+evidence must move to telemetry. New work should not add new `EventRouter`
+dependencies.
 
 ---
 

--- a/engineering/specifications/events.md
+++ b/engineering/specifications/events.md
@@ -3,6 +3,13 @@
 This specification defines the behavior contract for OmniCoreAgent runtime
 events.
 
+Migration status: this specification documents the current legacy event/SSE
+contract only. The target streaming, replay, trace, and evaluation evidence
+contract is `engineering/specifications/telemetry.md`.
+
+Do not add new `EventRouter` dependencies except inside explicitly marked
+telemetry migration adapters.
+
 Read this with:
 
 - `engineering/architecture/events.md`
@@ -12,7 +19,8 @@ Read this with:
 - `src/omnicoreagent/serve/routes/runs.py`
 - `src/omnicoreagent/serve/routes/sessions.py`
 
-When this specification changes, implementation and tests must change with it.
+When this current implementation contract changes, implementation and tests must
+change with it. New telemetry work must follow `telemetry.md`.
 
 ---
 

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -7,6 +7,11 @@ implement and test. Public docs live under `docs/` and `cookbook/`.
 
 OmniServe turns one existing `OmniCoreAgent` instance into a REST/SSE API.
 
+Telemetry migration note: current SSE/runtime-event behavior is documented for
+the shipped serving layer. Target streaming and replay must be backed by
+`TelemetryStream`, with `EventRouter` limited to migration adapters until it is
+removed.
+
 It owns the HTTP serving contract:
 
 - configuration

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -1,0 +1,645 @@
+# Telemetry Specification
+
+This specification defines the target behavior contract for OmniCoreAgent
+telemetry.
+
+Read this with:
+
+- `engineering/architecture/telemetry.md`
+- `src/omnicoreagent/core/events`
+- `src/omnicoreagent/background/event_log.py`
+- `src/omnicoreagent/serve/sse.py`
+- `src/omnicoreagent/serve/routes/runs.py`
+- `src/omnicoreagent/serve/routes/sessions.py`
+
+This is a design specification. It does not mean the implementation already
+exists. When implementation begins, code and tests must move toward this
+contract phase by phase.
+
+---
+
+## Scope
+
+This specification covers:
+
+- telemetry identity model
+- event schema
+- span schema
+- trace schema
+- recorder behavior
+- context propagation
+- storage contracts
+- normalization contract
+- redaction and payload policy
+- migration from current runtime events
+- required tests
+
+This specification does not cover:
+
+- observability dashboards
+- observability UI
+- alerting
+- eval runner
+- evaluator modules
+- eval suite execution
+- vendor exporters
+- OpenTelemetry exporter implementation
+- policy engine
+- sandbox execution implementation
+
+Telemetry must be built before observability and evaluation.
+
+---
+
+## OpenTelemetry Alignment
+
+OmniCoreAgent telemetry uses the standard trace/span/event model so it can map
+cleanly to OpenTelemetry later.
+
+Rules:
+
+- `trace_id`, `span_id`, and `parent_span_id` must be compatible with a
+  hierarchical trace model.
+- internal span kinds and event types are OmniCoreAgent-owned.
+- OTLP export is a later adapter and must not define the internal schema.
+- vendor integrations must consume normalized telemetry rather than adding
+  runtime-specific tracing paths.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| Telemetry event | Append-only point-in-time fact. |
+| Telemetry span | Timed unit of work with parent/child relationship. |
+| Telemetry trace | Complete execution graph for one logical run. |
+| Trace recorder | Runtime API that records events and spans. |
+| Trace store | Persistence boundary for traces, spans, and events. |
+| Trace normalizer | Converts runtime telemetry into stable evaluator-ready schema. |
+| Evidence reference | Stable reference to `trace_id`, `span_id`, `event_id`, or `sequence_number`. |
+
+---
+
+## Identity Contract
+
+Telemetry records use these identifiers:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `trace_id` | yes | Primary id for one telemetry trace. |
+| `span_id` | yes for spans, optional for events | Timed operation id. |
+| `parent_span_id` | optional | Parent span id inside the same trace. |
+| `event_id` | yes for events | Point-in-time evidence id. |
+| `parent_event_id` | optional | Parent event id when event causality is explicit. |
+| `run_id` | optional | Runtime/background run id. |
+| `session_id` | optional | Conversation continuity id. |
+| `task_id` | optional | Background/evaluation task id. |
+| `suite_id` | optional | Future evaluation suite id when a trace is captured for an eval task. |
+| `agent_id` | optional | Stable application/runtime agent id when available. |
+| `workflow_id` | optional | Workflow/orchestration id. |
+
+Rules:
+
+- `trace_id` is not derived from `session_id`.
+- A session may contain many traces.
+- `run_id` may equal `trace_id` in simple cases, but this must not be required.
+- Every span belongs to exactly one trace.
+- Every canonical telemetry event belongs to exactly one trace.
+- Legacy runtime events that cannot be assigned to a trace must be marked
+  `legacy_unbound=true` by the normalizer.
+
+---
+
+## Telemetry Event Schema
+
+Every canonical telemetry event uses this structure:
+
+```yaml
+event_id: string
+trace_id: string
+span_id: string | null
+parent_event_id: string | null
+sequence_number: int
+timestamp: datetime
+event_type: string
+actor:
+  type: system | user | agent | model | tool | mcp_server | memory | workspace | guardrail | background | serve
+  id: string | null
+  name: string | null
+input: object | null
+output: object | null
+error: object | null
+  type: string
+  message: string
+  retryable: bool | null
+  metadata: object
+  stack: string | null
+duration_ms: int | null
+token_usage:
+  prompt_tokens: int | null
+  completion_tokens: int | null
+  total_tokens: int | null
+estimated_cost_usd: float | null
+metadata: object
+```
+
+Rules:
+
+- `event_id` must be stable and unique inside a trace.
+- `sequence_number` is monotonically increasing inside one trace.
+- `timestamp` must be UTC.
+- `event_type` must come from the registry unless the record is explicitly
+  marked experimental.
+- `input`, `output`, and `error` must be standard fields. Event-specific data
+  belongs in these fields or `metadata`, not arbitrary top-level fields.
+- `duration_ms` is allowed for point events but required only when the event
+  represents a completed operation without a span.
+- token and cost fields must be present with null values when unknown.
+- redaction must happen before persistence.
+
+---
+
+## Telemetry Span Schema
+
+Every telemetry span uses this structure:
+
+```yaml
+span_id: string
+trace_id: string
+parent_span_id: string | null
+name: string
+kind: string
+status: running | ok | error | cancelled | timeout | skipped
+started_at: datetime
+ended_at: datetime | null
+duration_ms: int | null
+actor:
+  type: system | agent | model | tool | mcp_server | memory | workspace | guardrail | background | serve
+  id: string | null
+  name: string | null
+input: object | null
+output: object | null
+error: object | null
+  type: string
+  message: string
+  retryable: bool | null
+  metadata: object
+  stack: string | null
+token_usage:
+  prompt_tokens: int | null
+  completion_tokens: int | null
+  total_tokens: int | null
+estimated_cost_usd: float | null
+attributes: object
+event_ids: list[string]
+```
+
+Rules:
+
+- `span_id` must be stable and unique inside a trace.
+- `parent_span_id` must refer to another span in the same trace or be null.
+- root spans have `parent_span_id=null`.
+- `ended_at` may be null for partial traces.
+- if `ended_at` is null, `duration_ms` may be null.
+- terminal spans must set `status`.
+- spans should reference child events through `event_ids`.
+- token usage and cost rollups can be null until computed.
+
+---
+
+## Telemetry Trace Schema
+
+Every telemetry trace uses this structure:
+
+```yaml
+trace_id: string
+run_id: string | null
+session_id: string | null
+task_id: string | null
+suite_id: string | null
+agent_id: string | null
+workflow_id: string | null
+root_span_id: string
+status: running | completed | failed | cancelled | timeout | aborted_resource_guard | aborted_safety_guard | partial
+started_at: datetime
+ended_at: datetime | null
+metadata:
+  agent_name: string | null
+  agent_version: string | null
+  model_provider: string | null
+  model: string | null
+  prompt_version: string | null
+  tool_schema_version: string | null
+  memory_config_version: string | null
+  constraint_config_version: string | null
+  tags: list[string]
+spans: list[TelemetrySpan]
+events: list[TelemetryEvent]
+```
+
+Rules:
+
+- a trace must contain exactly one root span.
+- `root_span_id` must refer to a span in `spans`.
+- partial traces are valid.
+- failed or aborted traces must retain all evidence captured before failure.
+- `metadata` must preserve version fields needed for future regression
+  evaluation.
+- trace status must not hide runtime control halts.
+
+---
+
+## Span Kind Registry
+
+Foundation span kinds:
+
+```text
+agent.run
+agent.step
+model.call
+context.assembly
+context.compression
+tool.batch
+tool.call
+mcp.tool.call
+observation.pipeline
+memory.read
+memory.write
+workspace.read
+workspace.write
+tool.offload
+guardrail.check
+subagent.run
+workflow.route
+background.task
+background.run
+serve.request
+runtime.control
+```
+
+Reserved span kinds:
+
+```text
+verifier.run
+eval.score
+```
+
+Rules:
+
+- new span kinds require specification updates.
+- reserved span kinds must not be emitted until their subsystem exists.
+- span kind names use lowercase dotted names.
+
+---
+
+## Event Type Registry
+
+Foundation event groups:
+
+| Group | Event Types |
+|-------|-------------|
+| Agent lifecycle | `agent_start`, `agent_step`, `agent_end` |
+| User input | `user_message`, `system_instruction` |
+| Model interaction | `model_call`, `model_response`, `model_error` |
+| Tool interaction | `tool_call`, `tool_result`, `tool_error`, `tool_retry` |
+| Tool batches | `tool_batch_start`, `tool_batch_end`, `tool_batch_error` |
+| MCP | `mcp_tool_call`, `mcp_tool_result`, `mcp_tool_error` |
+| Approval | `approval_request`, `approval_granted`, `approval_denied` |
+| Memory | `memory_read`, `memory_write`, `memory_update`, `memory_eviction` |
+| Context | `context_compression`, `context_dropped`, `context_restored` |
+| Observation | `observation_pipeline_start`, `observation_pipeline_end`, `observation_pipeline_error` |
+| Workspace | `workspace_read`, `workspace_write`, `workspace_delete`, `workspace_offload` |
+| Guardrails | `guardrail_check`, `guardrail_violation` |
+| Runtime controls | `resource_guard_warning`, `resource_guard_halt`, `safety_guard_halt` |
+| Reasoning | `planning_step`, `reflection`, `retry` |
+| Subagents | `subagent_spawn`, `subagent_result`, `subagent_error` |
+| Workflow | `workflow_route`, `workflow_handoff`, `workflow_join` |
+| Background | `background_run_queued`, `background_run_started`, `background_run_heartbeat`, `background_run_completed`, `background_run_failed`, `background_run_cancelled`, `background_run_timeout` |
+| Serving | `serve_request_start`, `serve_request_end`, `serve_request_error` |
+| Finalization | `final_answer`, `final_state` |
+| Errors | `runtime_error`, `uncaught_exception`, `telemetry_error` |
+
+Rules:
+
+- current legacy `EventType` values can be adapted into these names during
+  migration.
+- arbitrary string events must be marked experimental and should not be used by
+  future evaluators.
+- event types must not encode dynamic ids.
+
+---
+
+## Recorder Contract
+
+The telemetry recorder exposes these operations:
+
+```python
+start_trace(...)
+end_trace(...)
+start_span(...)
+end_span(...)
+emit_event(...)
+record_exception(...)
+current_context()
+```
+
+Rules:
+
+- recorder calls must be safe inside async execution.
+- recorder context must propagate through parallel tool execution.
+- recorder context must propagate into subagents with explicit parent linkage.
+- recorder context must propagate into background runs.
+- recorder must persist partial traces when execution fails, times out, or is
+  cancelled.
+- recorder must apply redaction before store writes.
+- recorder must not raise into the agent hot path for non-critical telemetry
+  storage failures unless telemetry is configured as strict.
+
+Strict mode:
+
+- intended for tests, CI, and evaluation capture.
+- telemetry write failures fail the run or mark the trace incomplete.
+
+Best-effort mode:
+
+- intended for production serving where agent execution should continue if
+  telemetry storage has a transient issue.
+- failures are recorded as local telemetry errors when possible.
+
+---
+
+## Context Propagation Contract
+
+Telemetry context contains:
+
+```yaml
+trace_id: string
+span_id: string | null
+run_id: string | null
+session_id: string | null
+task_id: string | null
+suite_id: string | null
+agent_id: string | null
+workflow_id: string | null
+```
+
+Rules:
+
+- context is stored in context variables or an equivalent async-safe mechanism.
+- nested spans default to the current span as parent.
+- parallel tool calls share the same trace and parent `tool.batch` span.
+- each tool call gets its own child `tool.call` or `mcp.tool.call` span.
+- subagent execution is represented as child spans inside the parent trace in
+  the foundation design.
+- linked traces are out of scope until a future specification defines
+  `parent_trace_id`, trace links, and cross-trace evidence rules.
+- background runs create or resume telemetry context from `run_id` and
+  `session_id`.
+
+---
+
+## Storage Contract
+
+Foundation stores:
+
+```text
+in_memory
+jsonl
+```
+
+Later stores:
+
+```text
+sqlite
+postgres
+object_storage
+```
+
+Store interface:
+
+```python
+append_event(trace_id: str, event: TelemetryEvent) -> None
+start_span(trace_id: str, span: TelemetrySpan) -> None
+end_span(trace_id: str, span_id: str, patch: dict) -> None
+upsert_trace(trace: TelemetryTrace) -> None
+get_trace(trace_id: str) -> TelemetryTrace | None
+list_traces(filter: TraceFilter) -> list[TelemetryTrace]
+```
+
+Rules:
+
+- stores must preserve trace-local sequence order.
+- JSONL records must be append-friendly.
+- in-memory store is for tests and local development.
+- Redis stream is not the canonical trace store.
+- storage failure behavior depends on recorder strict/best-effort mode.
+
+Required indexes for durable stores:
+
+- `trace_id`
+- `run_id`
+- `session_id`
+- `task_id`
+- `suite_id`
+- `agent_id`
+- `workflow_id`
+- `model`
+- `status`
+- `started_at`
+- `ended_at`
+- `agent_version`
+- `prompt_version`
+- `tool_schema_version`
+- `memory_config_version`
+- `constraint_config_version`
+
+---
+
+## Normalization Contract
+
+The trace normalizer converts raw telemetry into normalized traces for future
+evaluation.
+
+Output requirements:
+
+- deterministic ordering
+- validated parent/child span references
+- validated event/span references
+- canonical event type names
+- canonical span kind names
+- explicit incomplete/missing evidence markers
+- behavior summary inputs preserved for future extraction
+
+Rules:
+
+- evaluators consume normalized traces only.
+- normalizer must not discard errors.
+- normalizer must not hide incomplete traces.
+- unsupported legacy events must be preserved as `legacy_event` records with
+  metadata explaining the source type.
+
+---
+
+## Redaction and Payload Contract
+
+Telemetry configuration must support:
+
+```yaml
+record_inputs: bool
+record_outputs: bool
+record_model_prompts: bool
+record_model_responses: bool
+record_tool_results: bool
+max_payload_bytes: int
+redact_keys: list[string]
+offload_large_payloads: bool
+offload_target: workspace | object_storage
+strict: bool
+```
+
+Rules:
+
+- redaction runs before persistence.
+- keys matching `redact_keys` are replaced with a redaction marker.
+- payloads larger than `max_payload_bytes` are summarized and optionally
+  offloaded.
+- offloaded payloads must store a reference, size, content type when known, and
+  checksum when available.
+- secrets must not be stored by default.
+
+---
+
+## Runtime Coverage Requirements
+
+Telemetry must eventually capture:
+
+- agent run start/end
+- agent step start/end
+- user message
+- model call input/output/error
+- token usage
+- estimated cost
+- tool batch start/end/error
+- individual tool call input/output/error
+- MCP tool call input/output/error
+- observation pipeline result
+- guardrail checks and violations
+- memory reads and writes
+- context compression and dropped/restored fields
+- workspace reads/writes/offloads
+- subagent spawn/result/error
+- background task/run lifecycle and heartbeat
+- OmniServe request start/end/error
+- final answer
+- final state when available
+
+Foundation implementation can phase these in, but the schema must support them
+from the start.
+
+---
+
+## Migration From Runtime Events
+
+Existing runtime events continue to exist during migration.
+
+Mapping examples:
+
+| Legacy Runtime Event | Telemetry Event | Span |
+|----------------------|-----------------|------|
+| `user_message` | `user_message` | `agent.run` |
+| `agent_message` | `model_response` | `model.call` |
+| `agent_thought` | `planning_step` or metadata event | `agent.step` |
+| `tool_call_started` | `tool_batch_start` plus child `tool_call` events | `tool.batch` |
+| `tool_call_result` | `tool_result` | `tool.call` |
+| `tool_call_error` | `tool_error` | `tool.call` |
+| `sub_agent_call_started` | `subagent_spawn` | `subagent.run` |
+| `sub_agent_call_result` | `subagent_result` | `subagent.run` |
+| `background_agent_status` | background lifecycle event | `background.run` |
+| `final_answer` | `final_answer` | `agent.run` |
+
+Rules:
+
+- old `/events/{session_id}` behavior must keep working until the serving API is
+  deliberately changed.
+- current `get_trace()` should be documented as event summary until replaced.
+- migration must avoid two unrelated sources of truth.
+- once telemetry becomes canonical, SSE should stream selected telemetry events.
+
+---
+
+## Evaluation Evidence Requirements
+
+The future evaluation architecture requires telemetry evidence for:
+
+- outcome correctness
+- trajectory quality
+- tool discipline
+- recovery quality
+- risk profile
+- longitudinal risk
+- efficiency
+- evidence grounding
+- memory and context behavior
+- coordination quality
+- final response quality
+
+Telemetry must therefore preserve:
+
+- final output
+- final state when available
+- tool inputs and outputs subject to redaction
+- failed tool calls and retry attempts
+- approval requests and decisions
+- memory/context operations
+- workspace mutations
+- subagent and handoff boundaries
+- runtime guard warnings and halts
+- cost, latency, token, and step counts
+- event/span references for every evaluator claim
+
+Evaluation is out of scope for this phase. These are trace requirements only.
+
+---
+
+## Required Tests
+
+Telemetry implementation phases require tests for:
+
+- event schema serialization and validation
+- span schema serialization and validation
+- trace schema serialization and validation
+- trace id/span id/event id generation
+- parent/child span linking
+- context propagation across async tasks
+- parallel tool batch child spans
+- subagent parent linkage
+- background run telemetry context
+- OmniServe request root spans
+- partial trace persistence on error
+- timeout and cancellation trace status
+- token/cost fields with known and unknown values
+- redaction of configured keys
+- payload size truncation/offload references
+- JSONL append/read behavior
+- current runtime event compatibility
+- normalized trace deterministic ordering
+- missing evidence markers
+
+No telemetry implementation phase is complete until tests prove both successful
+and failed execution paths.
+
+---
+
+## Acceptance Criteria For Foundation Design
+
+The telemetry foundation is acceptable when:
+
+- architecture and specification are accepted
+- implementation has a canonical event/span/trace schema
+- recorder can capture agent/model/tool/final-answer basics
+- trace store can persist and retrieve traces locally
+- normalizer can produce deterministic normalized traces
+- current runtime event streaming still works
+- future evaluation can reference `trace_id`, `span_id`, and `event_id`
+- docs clearly separate telemetry from observability and evaluation

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -29,9 +29,10 @@ This specification covers:
 - recorder behavior
 - context propagation
 - storage contracts
+- live/replay stream contract
 - normalization contract
 - redaction and payload policy
-- migration from current runtime events
+- migration from legacy runtime events and `EventRouter`
 - required tests
 
 This specification does not cover:
@@ -75,7 +76,8 @@ Rules:
 | Telemetry span | Timed unit of work with parent/child relationship. |
 | Telemetry trace | Complete execution graph for one logical run. |
 | Trace recorder | Runtime API that records events and spans. |
-| Trace store | Persistence boundary for traces, spans, and events. |
+| Telemetry store | Persistence boundary for traces, spans, and events. |
+| Telemetry stream | Live/replay adapter over telemetry records. |
 | Trace normalizer | Converts runtime telemetry into stable evaluator-ready schema. |
 | Evidence reference | Stable reference to `trace_id`, `span_id`, `event_id`, or `sequence_number`. |
 
@@ -399,7 +401,7 @@ Rules:
 
 ---
 
-## Storage Contract
+## Telemetry Store Contract
 
 Foundation stores:
 
@@ -453,6 +455,54 @@ Required indexes for durable stores:
 - `tool_schema_version`
 - `memory_config_version`
 - `constraint_config_version`
+
+---
+
+## Telemetry Stream Contract
+
+The telemetry stream replaces `EventRouter` as the long-term streaming and
+replay boundary.
+
+Interface:
+
+```python
+get_stream_cursor(scope: TelemetryStreamScope) -> str | None
+stream_after(scope: TelemetryStreamScope, cursor: str | None) -> AsyncIterator[TelemetryEvent]
+get_events_after(scope: TelemetryStreamScope, cursor: str | None) -> list[TelemetryEvent]
+```
+
+Scope:
+
+```yaml
+trace_id: string | null
+run_id: string | null
+session_id: string | null
+task_id: string | null
+event_types: list[string] | null
+```
+
+Rules:
+
+- the stream reads from telemetry records, not a separate event source.
+- stream cursors must support replay/follow behavior for SSE reconnect.
+- stream scopes must isolate sessions, runs, and traces.
+- `/run` SSE streams events for the trace/run it started.
+- `/events/{session_id}` can remain during migration but should become a
+  telemetry stream view.
+- stream failures must not corrupt the stored trace.
+- Redis streams may be used as an implementation backend for live fanout, but
+  Redis stream records are not a separate canonical evidence model.
+
+Replay/follow behavior:
+
+- capture the current stream cursor before replay begins.
+- replay stored telemetry events after the client cursor and up to the captured
+  cursor.
+- switch to live follow after the captured cursor.
+- de-duplicate by `event_id` when replay and live follow overlap.
+- preserve trace-local `sequence_number` ordering for replayed records.
+- never mix records from another `trace_id`, `run_id`, `session_id`, or
+  `task_id` outside the requested scope.
 
 ---
 
@@ -539,9 +589,22 @@ from the start.
 
 ---
 
-## Migration From Runtime Events
+## Migration From Legacy Runtime Events
 
-Existing runtime events continue to exist during migration.
+Existing runtime events and `EventRouter` exist only during migration.
+
+Target ownership:
+
+```text
+TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
+```
+
+There must not be a permanent parallel stack:
+
+```text
+EventRouter -> EventStore
+TelemetryRecorder -> TelemetryStore
+```
 
 Mapping examples:
 
@@ -560,11 +623,14 @@ Mapping examples:
 
 Rules:
 
-- old `/events/{session_id}` behavior must keep working until the serving API is
-  deliberately changed.
+- old `/events/{session_id}` behavior must keep working until it is deliberately
+  reimplemented on `TelemetryStream` or replaced by a new route.
 - current `get_trace()` should be documented as event summary until replaced.
 - migration must avoid two unrelated sources of truth.
-- once telemetry becomes canonical, SSE should stream selected telemetry events.
+- once telemetry becomes canonical, SSE must stream selected telemetry events.
+- no new feature should depend on `EventRouter`.
+- `EventRouter` and legacy event stores should be removed after OmniServe,
+  background agents, and runtime emission are telemetry-native.
 
 ---
 
@@ -622,7 +688,11 @@ Telemetry implementation phases require tests for:
 - redaction of configured keys
 - payload size truncation/offload references
 - JSONL append/read behavior
-- current runtime event compatibility
+- legacy runtime event migration
+- telemetry stream replay/follow behavior
+- guard test or review check that new telemetry, serving, and background code
+  does not import or instantiate `EventRouter` except inside explicitly named
+  migration adapters
 - normalized trace deterministic ordering
 - missing evidence markers
 
@@ -631,15 +701,29 @@ and failed execution paths.
 
 ---
 
-## Acceptance Criteria For Foundation Design
+## Acceptance Criteria For This Design PR
 
-The telemetry foundation is acceptable when:
+This design PR is acceptable when:
 
 - architecture and specification are accepted
+- telemetry owns the target streaming path:
+  `TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE`
+- legacy runtime events and `EventRouter` are documented only as migration
+  concerns
+- the spec defines the schema, recorder, store, stream, normalizer, redaction,
+  migration, and future evaluation evidence contracts
+- docs clearly separate telemetry from observability and evaluation
+
+## Acceptance Criteria For Future Foundation Implementation
+
+The future telemetry foundation implementation is acceptable when:
+
 - implementation has a canonical event/span/trace schema
 - recorder can capture agent/model/tool/final-answer basics
-- trace store can persist and retrieve traces locally
+- telemetry store can persist and retrieve traces locally
+- telemetry stream can replay/follow selected telemetry events
+- OmniServe SSE is backed by `TelemetryStream`
+- the implementation PR includes an explicit `EventRouter` removal or migration
+  completion plan for remaining call sites
 - normalizer can produce deterministic normalized traces
-- current runtime event streaming still works
 - future evaluation can reference `trace_id`, `span_id`, and `event_id`
-- docs clearly separate telemetry from observability and evaluation


### PR DESCRIPTION
## Summary
- Adds internal telemetry architecture and specification records.
- Defines telemetry as the execution evidence layer: events, spans, traces, context propagation, store, stream, normalizer, redaction, and future evaluation evidence references.
- Makes telemetry the target owner of live streaming and replay through TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE.
- Marks EventRouter and current runtime events as legacy migration/current implementation contracts only.
- Adds migration banners to events, background-agent, and OmniServe engineering docs so future work does not build new EventRouter dependencies.

## Scope
This is design/spec work only. It does not implement telemetry, dashboards, observability UI, eval runner, vendor exporters, policy, or sandboxing.

## Reviewer checks
- Fixed reviewer blockers around diagrams that omitted TelemetryStream -> OmniServe SSE.
- Split design acceptance criteria from future implementation acceptance criteria.
- Moved durable store indexes under Telemetry Store instead of Telemetry Stream.
- Added TelemetryStream replay/follow behavior: cursor capture, replay, live follow, de-duplication, ordering, and scope isolation.
- Added required guard/review check that new telemetry, serving, and background code must not import or instantiate EventRouter except inside explicit migration adapters.