### PR TITLE
Wire runtime telemetry into OmniCoreAgent

### DIFF
--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -186,6 +186,44 @@ OmniServe / application call
             -> future evaluators attach evidence-linked judgments
 ```
 
+## Implementation Status
+
+Telemetry is being moved into the runtime in phases.
+
+The foundation phase provides:
+
+- canonical telemetry dataclasses for traces, spans, events, actors, token usage,
+  errors, and trace metadata
+- async context propagation through `TelemetryContext`
+- `TelemetryRecorder`
+- in-memory telemetry storage
+- JSONL telemetry storage
+- `TelemetryStream`
+- deterministic trace normalization
+- legacy event conversion helpers for migration
+
+The runtime facade wiring phase provides:
+
+- automatic telemetry initialization on `OmniCoreAgent`
+- one `agent.run` trace for every `OmniCoreAgent.run(...)` call
+- a unique `run_id` for every run, even when multiple runs share one
+  `session_id`
+- explicit `run_id` injection for serving/event/telemetry correlation during
+  migration
+- `user_message`, `guardrail_violation`, `final_answer`, and `runtime_error`
+  events at the facade boundary
+- completed, failed, cancelled, and safety-aborted trace statuses
+- runtime helper methods for trace lookup and telemetry stream replay/follow
+- public `run(...)` responses include `trace_id` and `run_id` so application
+  code can retrieve or stream the exact trace it just created
+- injected `telemetry_store`, `telemetry_recorder`, and `telemetry_stream`
+  components must share the same store instance
+
+The runtime loop, model calls, tool batches, MCP calls, memory operations,
+workspace operations, subagents, background runs, and OmniServe SSE are still
+migration work. They must emit telemetry directly instead of adding new
+`EventRouter` dependencies.
+
 Runtime controls may also emit telemetry:
 
 - resource guard warning
@@ -429,7 +467,10 @@ Short-term:
 
 - current `Event` records can be adapted into telemetry events
 - `EventRouter` may remain temporarily while call sites are moved
-- `get_trace()` remains a compact event summary until replaced
+- `get_event_trace(session_id)` remains the explicit compact event summary
+  accessor until replaced
+- `get_trace(trace_id)` and positional `get_trace("trace_...")` return
+  canonical telemetry traces
 
 Target:
 

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -587,6 +587,49 @@ Telemetry must eventually capture:
 Foundation implementation can phase these in, but the schema must support them
 from the start.
 
+Current runtime facade coverage:
+
+- `OmniCoreAgent.run(...)` starts one `agent.run` trace per call.
+- every run receives a `run_id`. The caller may provide it explicitly, the
+  runtime may adopt the current legacy event run context, or the runtime may
+  generate a new one.
+- a single `session_id` may contain multiple traces and run ids.
+- successful runs emit `user_message` and `final_answer`, then complete the
+  trace.
+- input guardrail blocks emit `user_message`, `guardrail_violation`, and
+  `final_answer`, then abort the trace with `aborted_safety_guard`.
+- runtime exceptions emit `user_message` and `runtime_error`, then fail the
+  trace before re-raising the original exception.
+- initialization failures inside `OmniCoreAgent.run(...)` emit `user_message`
+  and `runtime_error`, then fail the trace before re-raising the original
+  exception.
+- cancellations emit `user_message` and `final_state`, then mark the trace
+  `cancelled` before re-raising the cancellation.
+- `OmniCoreAgent` exposes telemetry trace lookup and telemetry stream
+  replay/follow helpers.
+- successful and guardrail-blocked public run responses include `trace_id` and
+  `run_id`.
+- `get_trace(trace_id)` returns a telemetry trace when passed a returned
+  telemetry `trace_id`; `get_trace(session_id=...)` and `get_event_trace(...)`
+  remain legacy event-summary accessors during migration.
+- if callers inject telemetry components directly, `telemetry_store`,
+  `telemetry_recorder.store`, and `telemetry_stream.store` must refer to the
+  same store instance. The runtime rejects mismatches instead of silently
+  writing to one store and reading from another.
+
+Current uncovered runtime internals:
+
+- model call spans and events
+- agent step spans
+- tool batch and tool call spans
+- MCP tool spans
+- memory read/write spans
+- workspace read/write/offload spans
+- observation pipeline spans
+- subagent spans
+- background run spans
+- OmniServe request spans and SSE streaming from `TelemetryStream`
+
 ---
 
 ## Migration From Legacy Runtime Events

--- a/src/omnicoreagent/core/runtime/construction.py
+++ b/src/omnicoreagent/core/runtime/construction.py
@@ -13,6 +13,12 @@ def default_event_router() -> Any:
     return runtime("EventRouter")(event_store_type="in_memory")
 
 
+def default_telemetry_store() -> Any:
+    from omnicoreagent.core.telemetry import InMemoryTelemetryStore
+
+    return InMemoryTelemetryStore()
+
+
 def build_guardrail(agent_name: str, agent_config: dict[str, Any]) -> tuple[str, Any]:
     guardrail_mode = agent_config.get("guardrail_mode", "full")
     if guardrail_mode == "off":

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict, List, Optional
+import uuid
 
 from omnicoreagent.core.runtime import (
     builder,
@@ -14,6 +16,15 @@ from omnicoreagent.core.runtime.imports import (
     LazyDefaultPromptBuilder,
     runtime,
     runtime_logger,
+)
+from omnicoreagent.core.telemetry import (
+    ActorType,
+    TelemetryActor,
+    TelemetryRecorder,
+    TelemetryStream,
+    TelemetryStreamScope,
+    TraceFilter,
+    TraceStatus,
 )
 
 
@@ -36,6 +47,9 @@ class OmniCoreAgent:
         agent_config: Optional[Any] = None,
         memory_router: Optional[Any] = None,
         event_router: Optional[Any] = None,
+        telemetry_store: Optional[Any] = None,
+        telemetry_recorder: Optional[Any] = None,
+        telemetry_stream: Optional[Any] = None,
         prompt_builder: Optional[Any] = None,
         debug: bool = False,
     ):
@@ -53,6 +67,9 @@ class OmniCoreAgent:
             embedding_config: Optional embedding configuration
             memory_router: Optional memory router (MemoryRouter)
             event_router: Optional event router (EventRouter)
+            telemetry_store: Optional telemetry store
+            telemetry_recorder: Optional telemetry recorder
+            telemetry_stream: Optional telemetry stream
             debug: Enable debug logging
         """
         self.name = name
@@ -69,6 +86,9 @@ class OmniCoreAgent:
 
         self.memory_router = memory_router
         self.event_router = event_router
+        self.telemetry_store = telemetry_store
+        self.telemetry_recorder = telemetry_recorder
+        self.telemetry_stream = telemetry_stream
         if prompt_builder:
             self.prompt_builder = prompt_builder
         else:
@@ -92,6 +112,8 @@ class OmniCoreAgent:
 
         if not self.event_router:
             self.event_router = construction.default_event_router()
+
+        self._ensure_telemetry()
 
         agent_cfg = self.agent_config
         self.guardrail_mode, self.guardrail = construction.build_guardrail(
@@ -166,9 +188,62 @@ class OmniCoreAgent:
 
     def generate_session_id(self) -> str:
         """Generate a new session ID for the session"""
-        import uuid
-
         return f"omni_core_agent_{self.name}_{uuid.uuid4().hex[:8]}"
+
+    def generate_run_id(self) -> str:
+        """Generate a unique run ID inside a session."""
+        return f"run_{uuid.uuid4().hex}"
+
+    def _ensure_telemetry(self) -> None:
+        """Attach default telemetry components without touching legacy events."""
+        if self.telemetry_store is None:
+            if self.telemetry_recorder is not None:
+                self.telemetry_store = self.telemetry_recorder.store
+            elif self.telemetry_stream is not None:
+                self.telemetry_store = self.telemetry_stream.store
+            else:
+                self.telemetry_store = construction.default_telemetry_store()
+
+        if self.telemetry_recorder is None:
+            self.telemetry_recorder = TelemetryRecorder(self.telemetry_store)
+        elif self.telemetry_recorder.store is not self.telemetry_store:
+            raise ValueError(
+                "telemetry_recorder.store must be the same object as telemetry_store"
+            )
+
+        if self.telemetry_stream is None:
+            self.telemetry_stream = TelemetryStream(self.telemetry_store)
+        elif self.telemetry_stream.store is not self.telemetry_store:
+            raise ValueError(
+                "telemetry_stream.store must be the same object as telemetry_store"
+            )
+
+    def _telemetry_actor(self) -> TelemetryActor:
+        return TelemetryActor(type=ActorType.AGENT, name=self.name)
+
+    def _telemetry_metadata(self) -> dict[str, Any]:
+        return {
+            "agent_name": self.name,
+            "model_provider": self.model_config.get("provider"),
+            "model": self.model_config.get("model"),
+        }
+
+    def _telemetry_scope(
+        self,
+        *,
+        trace_id: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        task_id: str | None = None,
+        event_types: tuple[str, ...] | None = None,
+    ) -> TelemetryStreamScope:
+        return TelemetryStreamScope(
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            task_id=task_id,
+            event_types=event_types,
+        )
 
     async def connect_mcp_servers(self):
         """Connect to MCP servers if MCP tools are configured"""
@@ -183,58 +258,148 @@ class OmniCoreAgent:
                 local_tools=self.local_tools,
             )
 
-    async def run(self, query: str, session_id: Optional[str] = None) -> Dict[str, Any]:
+    async def run(
+        self,
+        query: str,
+        session_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Run the agent with a query and optional session ID.
 
         Args:
             query: The user query
             session_id: Optional session ID for session continuity
+            run_id: Optional run ID for serving/event/telemetry correlation
 
         Returns:
-            Dict containing response and session_id
+            Dict containing response, session_id, trace_id, and run_id.
         """
-        if not self._initialized:
-            await self.initialize()
-
-        blocked_response = execution.blocked_guardrail_response(
-            guardrail=self.guardrail,
-            query=query,
-            session_id=session_id,
-            agent_name=self.name,
-        )
-        if blocked_response:
-            return blocked_response
-
         if not session_id:
             session_id = self.generate_session_id()
 
-        runtime_prompt = self.prompt_builder.build(
-            system_instruction=self.system_instruction
+        self._ensure_telemetry()
+
+        from omnicoreagent.core.events.base import (
+            current_event_run_id,
+            reset_event_run_id,
+            set_event_run_id,
         )
 
-        response = await self.agent.run(
-            system_prompt=runtime_prompt,
-            query=query,
-            llm_connection=self.llm_connection,
-            add_message_to_history=self.memory_router.store_message,
-            message_history=self.memory_router.get_messages,
-            debug=self.debug,
-            event_router=self.event_router.append,
-            **execution.build_agent_run_kwargs(
-                mcp_client=self.mcp_client,
-                local_tools=self.local_tools,
+        run_id = run_id or current_event_run_id() or self.generate_run_id()
+        event_run_token = set_event_run_id(run_id)
+        trace_context = None
+        try:
+            trace_context = await self.telemetry_recorder.start_trace(
+                name="agent.run",
+                kind="agent.run",
+                actor=self._telemetry_actor(),
+                run_id=run_id,
                 session_id=session_id,
-                sub_agents=self.sub_agents,
-            ),
-        )
+                agent_id=self.name,
+                metadata=self._telemetry_metadata(),
+                input={"query": query},
+            )
+            await self.telemetry_recorder.emit_event(
+                "user_message",
+                actor=TelemetryActor(type=ActorType.USER),
+                input={"message": query},
+            )
 
-        return execution.format_run_response(
-            response=response,
-            session_id=session_id,
-            agent_name=self.name,
-            usage_getter=self._usage,
-        )
+            if not self._initialized:
+                await self.initialize()
+
+            blocked_response = execution.blocked_guardrail_response(
+                guardrail=self.guardrail,
+                query=query,
+                session_id=session_id,
+                agent_name=self.name,
+            )
+            if blocked_response:
+                await self.telemetry_recorder.emit_event(
+                    "guardrail_violation",
+                    actor=TelemetryActor(type=ActorType.GUARDRAIL, name=self.name),
+                    input={"query": query},
+                    output=blocked_response.get("guardrail_result"),
+                )
+                await self.telemetry_recorder.emit_event(
+                    "final_answer",
+                    actor=self._telemetry_actor(),
+                    output={"response": blocked_response["response"]},
+                )
+                await self.telemetry_recorder.end_trace(
+                    status=TraceStatus.ABORTED_SAFETY_GUARD,
+                    output={"response": blocked_response["response"]},
+                )
+                blocked_response["trace_id"] = trace_context.trace_id
+                blocked_response["run_id"] = run_id
+                return blocked_response
+
+            runtime_prompt = self.prompt_builder.build(
+                system_instruction=self.system_instruction
+            )
+
+            response = await self.agent.run(
+                system_prompt=runtime_prompt,
+                query=query,
+                llm_connection=self.llm_connection,
+                add_message_to_history=self.memory_router.store_message,
+                message_history=self.memory_router.get_messages,
+                debug=self.debug,
+                event_router=self.event_router.append,
+                **execution.build_agent_run_kwargs(
+                    mcp_client=self.mcp_client,
+                    local_tools=self.local_tools,
+                    session_id=session_id,
+                    sub_agents=self.sub_agents,
+                ),
+            )
+
+            formatted_response = execution.format_run_response(
+                response=response,
+                session_id=session_id,
+                agent_name=self.name,
+                usage_getter=self._usage,
+            )
+            await self.telemetry_recorder.emit_event(
+                "final_answer",
+                actor=self._telemetry_actor(),
+                output={"response": formatted_response.get("response")},
+            )
+            await self.telemetry_recorder.end_trace(
+                status=TraceStatus.COMPLETED,
+                output={"response": formatted_response.get("response")},
+            )
+            formatted_response["trace_id"] = trace_context.trace_id
+            formatted_response["run_id"] = run_id
+            return formatted_response
+        except asyncio.CancelledError as exc:
+            if trace_context is not None:
+                await self.telemetry_recorder.emit_event(
+                    "final_state",
+                    actor=self._telemetry_actor(),
+                    output={"status": TraceStatus.CANCELLED.value},
+                )
+                await self.telemetry_recorder.end_trace(
+                    status=TraceStatus.CANCELLED,
+                    error={"type": exc.__class__.__name__, "message": str(exc)},
+                )
+            raise
+        except Exception as exc:
+            if trace_context is not None:
+                await self.telemetry_recorder.record_exception(
+                    exc,
+                    event_type="runtime_error",
+                    actor=self._telemetry_actor(),
+                    metadata={"phase": "agent.run"},
+                )
+                await self.telemetry_recorder.end_trace(
+                    status=TraceStatus.FAILED,
+                    error={"type": exc.__class__.__name__, "message": str(exc)},
+                )
+            raise
+        finally:
+            reset_event_run_id(event_run_token)
 
     async def get_metrics(self) -> Dict[str, Any]:
         """
@@ -314,9 +479,144 @@ class OmniCoreAgent:
     async def get_events(self, session_id: str):
         return await self.event_router.get_events(session_id=session_id)
 
-    async def get_trace(self, session_id: str) -> Dict[str, Any]:
+    async def get_event_trace(self, session_id: str) -> Dict[str, Any]:
         trace = await self.event_router.get_trace(session_id=session_id)
         return trace.model_dump()
+
+    async def get_trace(
+        self,
+        identifier: str | None = None,
+        *,
+        session_id: str | None = None,
+        trace_id: str | None = None,
+    ) -> Dict[str, Any] | None:
+        """
+        Return a telemetry trace by trace_id, or a legacy event summary by session_id.
+
+        Passing a returned ``run()`` trace_id uses telemetry. Passing session_id keeps
+        the legacy event-summary behavior until EventRouter migration is complete.
+        """
+        if trace_id is not None:
+            return await self.get_telemetry_trace(trace_id)
+        if session_id is not None:
+            return await self.get_event_trace(session_id)
+        if identifier is None:
+            raise TypeError("get_trace() requires trace_id or session_id")
+        if identifier.startswith("trace_"):
+            return await self.get_telemetry_trace(identifier)
+        return await self.get_event_trace(identifier)
+
+    async def get_telemetry_trace(self, trace_id: str) -> Dict[str, Any] | None:
+        self._ensure_telemetry()
+        trace = await self.telemetry_store.get_trace(trace_id)
+        return trace.model_dump() if trace else None
+
+    async def list_telemetry_traces(
+        self,
+        trace_filter: TraceFilter | None = None,
+        *,
+        trace_id: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        task_id: str | None = None,
+        agent_id: str | None = None,
+        workflow_id: str | None = None,
+        model: str | None = None,
+        status: TraceStatus | str | None = None,
+    ) -> list[Dict[str, Any]]:
+        self._ensure_telemetry()
+        if trace_filter is not None and any(
+            value is not None
+            for value in (
+                trace_id,
+                run_id,
+                session_id,
+                task_id,
+                agent_id,
+                workflow_id,
+                model,
+                status,
+            )
+        ):
+            raise ValueError(
+                "Use either trace_filter or telemetry filter keyword arguments, not both"
+            )
+        if trace_filter is None:
+            trace_filter = TraceFilter(
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+                task_id=task_id,
+                agent_id=agent_id,
+                workflow_id=workflow_id,
+                model=model,
+                status=status,
+            )
+        traces = await self.telemetry_store.list_traces(trace_filter)
+        return [trace.model_dump() for trace in traces]
+
+    async def get_telemetry_stream_cursor(
+        self,
+        *,
+        trace_id: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        task_id: str | None = None,
+        event_types: tuple[str, ...] | None = None,
+    ) -> str | None:
+        self._ensure_telemetry()
+        return await self.telemetry_stream.get_stream_cursor(
+            self._telemetry_scope(
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+                task_id=task_id,
+                event_types=event_types,
+            )
+        )
+
+    async def stream_telemetry_after(
+        self,
+        *,
+        cursor: str | None,
+        trace_id: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        task_id: str | None = None,
+        event_types: tuple[str, ...] | None = None,
+    ):
+        self._ensure_telemetry()
+        scope = self._telemetry_scope(
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            task_id=task_id,
+            event_types=event_types,
+        )
+        async for event in self.telemetry_stream.stream_after(scope, cursor):
+            yield event
+
+    async def get_telemetry_events_after(
+        self,
+        *,
+        cursor: str | None,
+        trace_id: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        task_id: str | None = None,
+        event_types: tuple[str, ...] | None = None,
+    ):
+        self._ensure_telemetry()
+        return await self.telemetry_stream.get_events_after(
+            self._telemetry_scope(
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+                task_id=task_id,
+                event_types=event_types,
+            ),
+            cursor,
+        )
 
     async def get_event_store_type(self) -> str:
         """Get the current event store type."""

--- a/src/omnicoreagent/core/telemetry/recorder.py
+++ b/src/omnicoreagent/core/telemetry/recorder.py
@@ -28,6 +28,16 @@ from omnicoreagent.core.telemetry.redaction import TelemetryConfig, redact_paylo
 from omnicoreagent.core.telemetry.store import AbstractTelemetryStore
 
 
+def _span_status_for_trace_status(status: TraceStatus) -> SpanStatus:
+    if status == TraceStatus.COMPLETED:
+        return SpanStatus.OK
+    if status == TraceStatus.CANCELLED:
+        return SpanStatus.CANCELLED
+    if status == TraceStatus.TIMEOUT:
+        return SpanStatus.TIMEOUT
+    return SpanStatus.ERROR
+
+
 class TelemetryRecorder:
     def __init__(
         self,
@@ -126,11 +136,8 @@ class TelemetryRecorder:
             )
             parent_context = self._span_parent_contexts.get(trace.root_span_id)
             ended_at = utc_now()
-            terminal_span_status = (
-                SpanStatus.OK
-                if TraceStatus(status) == TraceStatus.COMPLETED
-                else SpanStatus.ERROR
-            )
+            trace_status = TraceStatus(status)
+            terminal_span_status = _span_status_for_trace_status(trace_status)
             for span in sorted(
                 trace.spans,
                 key=lambda item: item.started_at,

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -109,6 +109,12 @@ class RunResponse(BaseModel):
     metric: Optional[dict[str, Any]] = Field(
         None, description="Optional metrics for this run"
     )
+    trace_id: Optional[str] = Field(
+        None, description="Telemetry trace ID for this run"
+    )
+    run_id: Optional[str] = Field(
+        None, description="Runtime run ID for this run"
+    )
 
 
 class HealthResponse(BaseModel):

--- a/src/omnicoreagent/serve/routes/sessions.py
+++ b/src/omnicoreagent/serve/routes/sessions.py
@@ -54,7 +54,10 @@ def create_sessions_router() -> APIRouter:
     )
     async def get_trace(request: Request, session_id: str) -> TraceResponse:
         agent = get_agent(request)
-        trace = await agent.get_trace(session_id)
+        if hasattr(agent, "get_event_trace"):
+            trace = await agent.get_event_trace(session_id)
+        else:
+            trace = await agent.get_trace(session_id=session_id)
 
         return TraceResponse(
             session_id=session_id,

--- a/src/omnicoreagent/serve/serialization.py
+++ b/src/omnicoreagent/serve/serialization.py
@@ -39,6 +39,8 @@ def normalize_run_result(result: Any, *, agent_name: str) -> dict[str, Any]:
             "response": result.get("response", ""),
             "agent_name": result.get("agent_name", agent_name),
             "metric": normalize_metric(result.get("metric")),
+            "trace_id": result.get("trace_id"),
+            "run_id": result.get("run_id"),
         }
 
     return {

--- a/src/omnicoreagent/serve/sse.py
+++ b/src/omnicoreagent/serve/sse.py
@@ -318,14 +318,15 @@ async def run_agent_stream(
                     response,
                     agent_name=get_agent_name(agent),
                 )
+                complete_payload = {
+                    "session_id": session_id,
+                    **normalized,
+                }
+                complete_payload["run_id"] = normalized.get("run_id") or run_id
 
                 yield format_sse_event(
                     "complete",
-                    {
-                        "session_id": session_id,
-                        "run_id": run_id,
-                        **normalized,
-                    },
+                    complete_payload,
                 )
                 break
 

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -603,7 +603,7 @@ class TestEndpoints:
         agent.run = AsyncMock(return_value={"response": "Agent response"})
         # Mock get_metrics
         agent.get_metrics = AsyncMock(return_value={"total_tokens": 100})
-        agent.get_trace = AsyncMock(
+        agent.get_event_trace = AsyncMock(
             return_value={
                 "session_id": "test-endpoint-session",
                 "summary": {"total_events": 2, "tool_calls": 1},
@@ -794,6 +794,11 @@ class TestEndpoints:
         assert data["summary"]["tool_calls"] == 1
         assert data["steps"][0]["event_type"] == "user_message"
 
+    def test_trace_endpoint_uses_legacy_event_trace_accessor(self, server_client):
+        server_client.get("/events/trace_like_session/trace")
+        agent = server_client.app.state.agent
+        agent.get_event_trace.assert_awaited_once_with("trace_like_session")
+
     def test_run_normalizes_string_agent_result(self):
         agent = MagicMock(spec=OmniCoreAgent)
         agent.name = "StringAgent"
@@ -811,6 +816,8 @@ class TestEndpoints:
             "session_id": "string-session",
             "agent_name": "StringAgent",
             "metric": None,
+            "trace_id": None,
+            "run_id": None,
         }
 
     def test_request_timeout_is_enforced_for_sync_run(self):

--- a/tests/test_runtime_telemetry_wiring.py
+++ b/tests/test_runtime_telemetry_wiring.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnicoreagent.core.events.base import (
+    current_event_run_id,
+    reset_event_run_id,
+    set_event_run_id,
+)
+from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent
+from omnicoreagent.core.telemetry import (
+    InMemoryTelemetryStore,
+    TelemetryStream,
+    TelemetryRecorder,
+    TraceFilter,
+    TraceStatus,
+)
+
+
+def _initialized_agent(
+    *,
+    store: InMemoryTelemetryStore | None = None,
+    guardrail: object | None = None,
+) -> OmniCoreAgent:
+    telemetry_store = store or InMemoryTelemetryStore()
+    agent = OmniCoreAgent(
+        name="telemetry-agent",
+        system_instruction="You are a test agent.",
+        model_config={"provider": "openai", "model": "gpt-5.4-mini", "api_key": "key"},
+        agent_config={"guardrail_mode": "off"},
+        telemetry_store=telemetry_store,
+        telemetry_recorder=TelemetryRecorder(telemetry_store),
+    )
+    agent._initialized = True
+    agent.guardrail = guardrail
+    agent.guardrail_mode = "full" if guardrail else "off"
+    agent.agent = MagicMock()
+    agent.agent.run = AsyncMock(return_value="done")
+    agent.mcp_client = None
+    agent.llm_connection = MagicMock()
+    agent.memory_router = MagicMock()
+    agent.memory_router.store_message = AsyncMock()
+    agent.memory_router.get_messages = AsyncMock(return_value=[])
+    agent.event_router = MagicMock()
+    agent.event_router.append = AsyncMock()
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_run_records_completed_telemetry_trace() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    result = await agent.run("hello", session_id="session-1")
+
+    assert result["response"] == "done"
+    assert result["session_id"] == "session-1"
+    assert result["trace_id"].startswith("trace_")
+    assert result["run_id"].startswith("run_")
+
+    traces = await store.list_traces(TraceFilter(session_id="session-1"))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.trace_id == result["trace_id"]
+    assert trace.run_id == result["run_id"]
+    assert trace.status == TraceStatus.COMPLETED
+    assert trace.metadata.agent_name == "telemetry-agent"
+    assert trace.metadata.model == "gpt-5.4-mini"
+    assert [event.event_type for event in trace.events] == [
+        "user_message",
+        "final_answer",
+    ]
+    assert trace.spans[0].kind == "agent.run"
+    assert trace.spans[0].output == {"response": "done"}
+    agent.agent.run.assert_awaited_once()
+    # Migration contract: the legacy loop still receives EventRouter while
+    # runtime callers can already read canonical facade telemetry.
+    assert agent.agent.run.await_args.kwargs["event_router"] is agent.event_router.append
+
+
+@pytest.mark.asyncio
+async def test_run_records_completed_trace_when_initializing_normally() -> None:
+    store = InMemoryTelemetryStore()
+    agent = OmniCoreAgent(
+        name="telemetry-agent",
+        system_instruction="You are a test agent.",
+        model_config={"provider": "openai", "model": "gpt-5.4-mini", "api_key": "key"},
+        agent_config={"guardrail_mode": "off"},
+        telemetry_store=store,
+    )
+
+    def attach_runtime_agent():
+        agent.agent = MagicMock()
+        agent.agent.run = AsyncMock(return_value="initialized")
+        agent.mcp_client = None
+        agent.llm_connection = MagicMock()
+
+    agent._create_agent = MagicMock(side_effect=attach_runtime_agent)
+
+    result = await agent.run("hello", session_id="session-init-success")
+
+    assert result["response"] == "initialized"
+    assert agent._initialized is True
+    traces = await store.list_traces(TraceFilter(session_id="session-init-success"))
+    assert len(traces) == 1
+    assert traces[0].status == TraceStatus.COMPLETED
+    assert [event.event_type for event in traces[0].events] == [
+        "user_message",
+        "final_answer",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_uses_supplied_run_id_for_telemetry_and_event_context() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    async def fake_run(**kwargs):
+        return current_event_run_id()
+
+    agent.agent.run = AsyncMock(side_effect=fake_run)
+
+    result = await agent.run(
+        "hello",
+        session_id="session-external-run",
+        run_id="run_external",
+    )
+
+    assert result["run_id"] == "run_external"
+    assert result["response"] == "run_external"
+    assert current_event_run_id() is None
+
+    traces = await store.list_traces(TraceFilter(session_id="session-external-run"))
+    assert len(traces) == 1
+    assert traces[0].run_id == "run_external"
+
+
+@pytest.mark.asyncio
+async def test_run_adopts_existing_legacy_event_run_context() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    token = set_event_run_id("run_from_sse")
+    try:
+        result = await agent.run("hello", session_id="session-sse")
+    finally:
+        reset_event_run_id(token)
+
+    assert result["run_id"] == "run_from_sse"
+    traces = await store.list_traces(TraceFilter(session_id="session-sse"))
+    assert traces[0].run_id == "run_from_sse"
+
+
+@pytest.mark.asyncio
+async def test_run_records_guardrail_block_as_aborted_trace() -> None:
+    store = InMemoryTelemetryStore()
+    guardrail_result = SimpleNamespace(
+        is_safe=False,
+        message="blocked",
+        to_dict=lambda: {"is_safe": False, "message": "blocked"},
+    )
+    guardrail = SimpleNamespace(check=MagicMock(return_value=guardrail_result))
+    agent = _initialized_agent(store=store, guardrail=guardrail)
+
+    result = await agent.run("unsafe", session_id="session-guard")
+
+    assert "safety concerns" in result["response"]
+    assert result["guardrail_result"] == {"is_safe": False, "message": "blocked"}
+    assert result["trace_id"].startswith("trace_")
+    assert result["run_id"].startswith("run_")
+    agent.agent.run.assert_not_called()
+
+    traces = await store.list_traces(TraceFilter(session_id="session-guard"))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.status == TraceStatus.ABORTED_SAFETY_GUARD
+    assert [event.event_type for event in trace.events] == [
+        "user_message",
+        "guardrail_violation",
+        "final_answer",
+    ]
+    assert trace.events[1].output == {"is_safe": False, "message": "blocked"}
+
+
+@pytest.mark.asyncio
+async def test_run_records_failed_trace_before_reraising() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    agent.agent.run = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await agent.run("fail", session_id="session-fail")
+
+    traces = await store.list_traces(TraceFilter(session_id="session-fail"))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.status == TraceStatus.FAILED
+    assert [event.event_type for event in trace.events] == [
+        "user_message",
+        "runtime_error",
+    ]
+    assert trace.events[1].error.type == "RuntimeError"
+    assert trace.spans[0].error.type == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_run_records_cancelled_trace_before_reraising() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    agent.agent.run = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("cancel", session_id="session-cancel")
+
+    traces = await store.list_traces(TraceFilter(session_id="session-cancel"))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.status == TraceStatus.CANCELLED
+    assert [event.event_type for event in trace.events] == [
+        "user_message",
+        "final_state",
+    ]
+    assert trace.spans[0].error.type == "CancelledError"
+    assert trace.spans[0].status.value == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_run_records_initialization_failure_before_reraising() -> None:
+    store = InMemoryTelemetryStore()
+    agent = OmniCoreAgent(
+        name="telemetry-agent",
+        system_instruction="You are a test agent.",
+        model_config={"provider": "openai", "model": "gpt-5.4-mini", "api_key": "key"},
+        telemetry_store=store,
+    )
+    agent.initialize = AsyncMock(side_effect=RuntimeError("init boom"))
+
+    with pytest.raises(RuntimeError, match="init boom"):
+        await agent.run("fail before init", session_id="session-init-fail")
+
+    traces = await store.list_traces(TraceFilter(session_id="session-init-fail"))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.status == TraceStatus.FAILED
+    assert [event.event_type for event in trace.events] == [
+        "user_message",
+        "runtime_error",
+    ]
+    assert trace.events[1].error.type == "RuntimeError"
+    assert trace.spans[0].error.type == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_run_ensures_default_telemetry_when_initialize_is_bypassed() -> None:
+    agent = _initialized_agent()
+    agent.telemetry_store = None
+    agent.telemetry_recorder = None
+    agent.telemetry_stream = None
+
+    result = await agent.run("hello", session_id="session-default")
+
+    assert result["trace_id"].startswith("trace_")
+    trace = await agent.telemetry_store.get_trace(result["trace_id"])
+    assert trace.session_id == "session-default"
+
+
+def test_ensure_telemetry_rejects_component_store_mismatch() -> None:
+    first_store = InMemoryTelemetryStore()
+    second_store = InMemoryTelemetryStore()
+    agent = OmniCoreAgent(
+        name="telemetry-agent",
+        system_instruction="You are a test agent.",
+        model_config={"provider": "openai", "model": "gpt-5.4-mini", "api_key": "key"},
+        telemetry_store=first_store,
+        telemetry_recorder=TelemetryRecorder(second_store),
+    )
+
+    with pytest.raises(ValueError, match="telemetry_recorder.store"):
+        agent._ensure_telemetry()
+
+
+def test_ensure_telemetry_rejects_stream_store_mismatch() -> None:
+    first_store = InMemoryTelemetryStore()
+    second_store = InMemoryTelemetryStore()
+    agent = OmniCoreAgent(
+        name="telemetry-agent",
+        system_instruction="You are a test agent.",
+        model_config={"provider": "openai", "model": "gpt-5.4-mini", "api_key": "key"},
+        telemetry_store=first_store,
+        telemetry_stream=TelemetryStream(second_store),
+    )
+
+    with pytest.raises(ValueError, match="telemetry_stream.store"):
+        agent._ensure_telemetry()
+
+
+def test_ensure_telemetry_derives_store_from_supplied_stream() -> None:
+    store = InMemoryTelemetryStore()
+    agent = OmniCoreAgent(
+        name="telemetry-agent",
+        system_instruction="You are a test agent.",
+        model_config={"provider": "openai", "model": "gpt-5.4-mini", "api_key": "key"},
+        telemetry_stream=TelemetryStream(store),
+    )
+
+    agent._ensure_telemetry()
+
+    assert agent.telemetry_store is store
+    assert agent.telemetry_recorder.store is store
+    assert agent.telemetry_stream.store is store
+
+
+@pytest.mark.asyncio
+async def test_get_trace_accepts_returned_trace_id_and_session_id_keyword() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    legacy_trace = SimpleNamespace(model_dump=MagicMock(return_value={"legacy": True}))
+    agent.event_router.get_trace = AsyncMock(return_value=legacy_trace)
+
+    result = await agent.run("hello", session_id="session-trace")
+
+    telemetry_trace = await agent.get_trace(result["trace_id"])
+    event_trace = await agent.get_trace(session_id="session-trace")
+
+    assert telemetry_trace["trace_id"] == result["trace_id"]
+    assert event_trace == {"legacy": True}
+    agent.event_router.get_trace.assert_awaited_once_with(session_id="session-trace")
+
+
+@pytest.mark.asyncio
+async def test_get_trace_missing_trace_id_does_not_fall_back_to_event_summary() -> None:
+    agent = _initialized_agent()
+    agent.event_router.get_trace = AsyncMock(
+        return_value=SimpleNamespace(model_dump=lambda: {"legacy": True})
+    )
+
+    trace = await agent.get_trace("trace_missing")
+
+    assert trace is None
+    agent.event_router.get_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_telemetry_traces_accepts_filter_kwargs() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    result = await agent.run("hello", session_id="session-filter")
+
+    traces = await agent.list_telemetry_traces(run_id=result["run_id"])
+
+    assert [trace["trace_id"] for trace in traces] == [result["trace_id"]]
+
+
+@pytest.mark.asyncio
+async def test_telemetry_stream_scopes_events_by_run_id_inside_same_session() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    agent.agent.run = AsyncMock(side_effect=["first", "second"])
+
+    first = await agent.run("first", session_id="shared-session")
+    second = await agent.run("second", session_id="shared-session")
+
+    first_events = await agent.get_telemetry_events_after(
+        cursor=None,
+        session_id="shared-session",
+        run_id=first["run_id"],
+    )
+    second_events = await agent.get_telemetry_events_after(
+        cursor=None,
+        session_id="shared-session",
+        run_id=second["run_id"],
+    )
+
+    assert {event.trace_id for event in first_events} == {first["trace_id"]}
+    assert {event.trace_id for event in second_events} == {second["trace_id"]}
+    assert [event.event_type for event in first_events] == [
+        "user_message",
+        "final_answer",
+    ]
+    assert [event.event_type for event in second_events] == [
+        "user_message",
+        "final_answer",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_telemetry_stream_scopes_by_run_id_inside_same_session() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    first = await agent.run("first", session_id="shared-session")
+    second = await agent.run("second", session_id="shared-session")
+    live_cursor = await agent.get_telemetry_stream_cursor(session_id="shared-session")
+    third_run_id = "run_live_third"
+
+    live_stream = agent.stream_telemetry_after(
+        cursor=live_cursor,
+        session_id="shared-session",
+        run_id=third_run_id,
+    )
+    try:
+        next_event = asyncio.create_task(anext(live_stream))
+        await asyncio.sleep(0)
+        third = await agent.run(
+            "third",
+            session_id="shared-session",
+            run_id=third_run_id,
+        )
+        event = await asyncio.wait_for(next_event, timeout=1)
+    finally:
+        await live_stream.aclose()
+
+    assert event.trace_id == third["trace_id"]
+    assert event.event_type == "user_message"
+    assert event.input == {"message": "third"}
+    assert first["trace_id"] != second["trace_id"]
+    assert second["trace_id"] != third["trace_id"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_runs_share_session_without_mixing_trace_context() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    async def fake_run(**kwargs):
+        await asyncio.sleep(0)
+        return kwargs["query"]
+
+    agent.agent.run = AsyncMock(side_effect=fake_run)
+
+    first, second = await asyncio.gather(
+        agent.run("first", session_id="shared-session"),
+        agent.run("second", session_id="shared-session"),
+    )
+
+    assert first["run_id"] != second["run_id"]
+    assert first["trace_id"] != second["trace_id"]
+
+    traces = await store.list_traces(TraceFilter(session_id="shared-session"))
+    assert {trace.trace_id for trace in traces} == {
+        first["trace_id"],
+        second["trace_id"],
+    }
+    assert {trace.run_id for trace in traces} == {
+        first["run_id"],
+        second["run_id"],
+    }
+    assert all(trace.status == TraceStatus.COMPLETED for trace in traces)
+    for trace in traces:
+        assert [event.trace_id for event in trace.events] == [
+            trace.trace_id,
+            trace.trace_id,
+        ]
+        assert trace.spans[0].output == {"response": trace.events[-1].output["response"]}
+
+    output_by_run_id = {
+        trace.run_id: trace.spans[0].output["response"] for trace in traces
+    }
+    assert output_by_run_id[first["run_id"]] == "first"
+    assert output_by_run_id[second["run_id"]] == "second"


### PR DESCRIPTION
## Summary
- add default telemetry store/recorder/stream wiring to OmniCoreAgent
- record facade-level agent.run traces with user, final, guardrail, runtime error, cancellation, trace_id, and run_id correlation
- align run_id with legacy event context during migration and expose telemetry trace/list/stream helpers
- preserve OmniServe correlation IDs in sync/SSE responses and keep legacy session event traces explicit
- update internal telemetry architecture/spec status and add runtime telemetry lifecycle coverage

## Tests
- uv run ruff check src tests
- uv run pytest tests/test_runtime_telemetry_wiring.py tests/test_omniserve_sse.py tests/test_omniserve_full.py -q
- uv run pytest tests/test_runtime_telemetry_wiring.py tests/test_omniserve_full.py tests/test_import_startup.py tests/test_telemetry_foundation.py -q
- uv run pytest -q (769 passed, 8 skipped)