### PR TITLE
Instrument React loop telemetry

### DIFF
--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -219,10 +219,20 @@ The runtime facade wiring phase provides:
 - injected `telemetry_store`, `telemetry_recorder`, and `telemetry_stream`
   components must share the same store instance
 
-The runtime loop, model calls, tool batches, MCP calls, memory operations,
-workspace operations, subagents, background runs, and OmniServe SSE are still
-migration work. They must emit telemetry directly instead of adding new
-`EventRouter` dependencies.
+The runtime loop instrumentation phase provides:
+
+- child `agent.step` spans under the active `agent.run` trace
+- child `model.call` spans and `model_call` / `model_response` /
+  `model_error` events
+- child `tool.batch` spans with `tool_batch_start`, `tool_batch_end`, and
+  `tool_batch_error` events
+- child `tool.call` spans with `tool_call`, `tool_result`, and `tool_error`
+  events for each tool in a parallel batch
+- `observation_pipeline_end` events after tool output parsing and formatting
+
+MCP-specific tool spans, memory operations, workspace operations, subagents,
+background runs, and OmniServe SSE are still migration work. They must emit
+telemetry directly instead of adding new `EventRouter` dependencies.
 
 Runtime controls may also emit telemetry:
 

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -617,15 +617,25 @@ Current runtime facade coverage:
   same store instance. The runtime rejects mismatches instead of silently
   writing to one store and reading from another.
 
+Current runtime loop coverage:
+
+- every ReAct iteration creates an `agent.step` child span.
+- every model call creates a `model.call` child span.
+- model calls emit `model_call`, `model_response`, and `model_error` events.
+- parallel tool batches create one `tool.batch` span.
+- tool batches emit `tool_batch_start`, `tool_batch_end`, and
+  `tool_batch_error` events.
+- each individual tool in a batch creates a `tool.call` span.
+- individual tool calls emit `tool_call`, `tool_result`, and `tool_error`
+  events.
+- parsed tool observations emit `observation_pipeline_end`.
+
 Current uncovered runtime internals:
 
-- model call spans and events
-- agent step spans
-- tool batch and tool call spans
 - MCP tool spans
 - memory read/write spans
 - workspace read/write/offload spans
-- observation pipeline spans
+- full observation pipeline start/error spans
 - subagent spans
 - background run spans
 - OmniServe request spans and SSE streaming from `TelemetryStream`

--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -22,6 +22,7 @@ from omnicoreagent.core.tools.tool_batch_runner import ToolBatchRunner
 from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
 from omnicoreagent.core.tools.tool_failure_handler import ToolFailureHandler
 from omnicoreagent.core.tools.tool_runtime_registry import ToolRuntimeRegistry
+from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor
 from omnicoreagent.core.logging import logger
 from omnicoreagent.core.events.base import Event
 from omnicoreagent.core.context_manager import (
@@ -324,6 +325,7 @@ class BaseReactAgent:
         local_tools: Any = None,
         session_id: str = None,
         event_router: Callable[[str, Event], Any] = None,
+        telemetry_recorder: Any = None,
         sub_agents: list = None,
     ) -> Any:
         """Execute ReAct loop with JSON communication
@@ -382,45 +384,90 @@ class BaseReactAgent:
                 and current_steps < self.max_steps
             ):
                 current_steps += 1
-                llm_step = await self.llm_step_runner.run(
-                    session_state=session_state,
-                    llm_connection=llm_connection,
-                    run_usage=run_usage,
-                    session_id=session_id,
-                    event_router=event_router,
-                    debug=debug,
-                )
-                if llm_step.error_result is not None:
-                    return llm_step.error_result
-                response = llm_step.response
+                step_span = None
+                if telemetry_recorder is not None:
+                    step_span = await telemetry_recorder.start_span(
+                        name="agent.step",
+                        kind="agent.step",
+                        actor=TelemetryActor(type=ActorType.AGENT, name=self.agent_name),
+                        input={"step": current_steps},
+                    )
+                    await telemetry_recorder.emit_event(
+                        "agent_step",
+                        actor=TelemetryActor(type=ActorType.AGENT, name=self.agent_name),
+                        input={"step": current_steps},
+                    )
+                try:
+                    llm_step = await self.llm_step_runner.run(
+                        session_state=session_state,
+                        llm_connection=llm_connection,
+                        run_usage=run_usage,
+                        session_id=session_id,
+                        event_router=event_router,
+                        telemetry_recorder=telemetry_recorder,
+                        debug=debug,
+                    )
+                    if llm_step.error_result is not None:
+                        if telemetry_recorder is not None and step_span is not None:
+                            await telemetry_recorder.end_span(
+                                step_span.span_id,
+                                status=SpanStatus.ERROR,
+                                output={"error_result": llm_step.error_result},
+                            )
+                        return llm_step.error_result
+                    response = llm_step.response
 
-                parsed_response = await self.extract_action_or_answer(
-                    response=response,
-                    debug=debug,
-                    session_id=session_id,
-                    event_router=event_router,
-                )
-                step_result = await self.loop_step_handler.handle(
-                    parsed_response=parsed_response,
-                    response=response,
-                    session_state=session_state,
-                    add_message_to_history=add_message_to_history,
-                    system_prompt=system_prompt,
-                    session_id=session_id,
-                    run_usage=run_usage,
-                    start_time=start_time,
-                    current_steps=current_steps,
-                    last_valid_response=last_valid_response,
-                    debug=debug,
-                    sessions=sessions,
-                    mcp_tools=mcp_tools,
-                    local_tools=runtime_local_tools,
-                    event_router=event_router,
-                    sub_agents=sub_agents,
-                )
-                last_valid_response = step_result.last_valid_response
-                if step_result.should_return:
-                    return step_result.run_result
+                    parsed_response = await self.extract_action_or_answer(
+                        response=response,
+                        debug=debug,
+                        session_id=session_id,
+                        event_router=event_router,
+                    )
+                    step_result = await self.loop_step_handler.handle(
+                        parsed_response=parsed_response,
+                        response=response,
+                        session_state=session_state,
+                        add_message_to_history=add_message_to_history,
+                        system_prompt=system_prompt,
+                        session_id=session_id,
+                        run_usage=run_usage,
+                        start_time=start_time,
+                        current_steps=current_steps,
+                        last_valid_response=last_valid_response,
+                        debug=debug,
+                        sessions=sessions,
+                        mcp_tools=mcp_tools,
+                        local_tools=runtime_local_tools,
+                        event_router=event_router,
+                        telemetry_recorder=telemetry_recorder,
+                        sub_agents=sub_agents,
+                    )
+                    last_valid_response = step_result.last_valid_response
+                    if step_result.should_return:
+                        if telemetry_recorder is not None and step_span is not None:
+                            await telemetry_recorder.end_span(
+                                step_span.span_id,
+                                status=SpanStatus.OK,
+                                output={"returned": True},
+                            )
+                        return step_result.run_result
+                    if telemetry_recorder is not None and step_span is not None:
+                        await telemetry_recorder.end_span(
+                            step_span.span_id,
+                            status=SpanStatus.OK,
+                            output={"returned": False},
+                        )
+                except Exception as exc:
+                    if telemetry_recorder is not None and step_span is not None:
+                        await telemetry_recorder.end_span(
+                            step_span.span_id,
+                            status=SpanStatus.ERROR,
+                            error={
+                                "type": exc.__class__.__name__,
+                                "message": str(exc),
+                            },
+                        )
+                    raise
 
         if session_state.state == AgentState.STUCK and last_valid_response:
             return self.run_outcome_handler.loop_stuck_result(

--- a/src/omnicoreagent/core/agents/llm_step.py
+++ b/src/omnicoreagent/core/agents/llm_step.py
@@ -8,6 +8,7 @@ from omnicoreagent.core.agents.llm_response import (
     extract_response_content,
     extract_response_usage,
 )
+from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor
 from omnicoreagent.core.system_prompts import FAST_CONVERSATION_SUMMARY_PROMPT
 from omnicoreagent.core.token_usage import (
     Usage,
@@ -50,6 +51,7 @@ class AgentLlmStepRunner:
         run_usage: Usage,
         session_id: str,
         event_router: Any = None,
+        telemetry_recorder: Any = None,
         debug: bool = False,
     ) -> AgentLlmStepResult:
         if debug:
@@ -69,13 +71,18 @@ class AgentLlmStepRunner:
                         f"Context managed: now {len(session_state.messages)} messages"
                     )
 
-            response = await llm_connection.llm_call(session_state.messages)
+            response = await self._call_model(
+                llm_connection=llm_connection,
+                messages=session_state.messages,
+                telemetry_recorder=telemetry_recorder,
+            )
             if response:
                 await self._record_response(
                     response=response,
                     run_usage=run_usage,
                     session_id=session_id,
                     event_router=event_router,
+                    telemetry_recorder=telemetry_recorder,
                     debug=debug,
                 )
                 response = extract_response_content(response)
@@ -94,6 +101,56 @@ class AgentLlmStepRunner:
             return AgentLlmStepResult(
                 error_result={"answer": error_message, "usage": run_usage}
             )
+
+    async def _call_model(
+        self,
+        *,
+        llm_connection: Any,
+        messages: list[Any],
+        telemetry_recorder: Any = None,
+    ) -> Any:
+        if telemetry_recorder is None:
+            return await llm_connection.llm_call(messages)
+
+        span_context = await telemetry_recorder.start_span(
+            name="model.call",
+            kind="model.call",
+            actor=TelemetryActor(type=ActorType.MODEL),
+            input={"message_count": len(messages)},
+        )
+        try:
+            await telemetry_recorder.emit_event(
+                "model_call",
+                actor=TelemetryActor(type=ActorType.MODEL),
+                input={"message_count": len(messages)},
+            )
+            response = await llm_connection.llm_call(messages)
+            await telemetry_recorder.emit_event(
+                "model_response",
+                actor=TelemetryActor(type=ActorType.MODEL),
+                output={
+                    "content": extract_response_content(response, strip=False),
+                    "usage": self._usage_payload(extract_response_usage(response)),
+                },
+            )
+            await telemetry_recorder.end_span(
+                span_context.span_id,
+                status=SpanStatus.OK,
+                output={"usage": self._usage_payload(extract_response_usage(response))},
+            )
+            return response
+        except Exception as exc:
+            await telemetry_recorder.record_exception(
+                exc,
+                event_type="model_error",
+                actor=TelemetryActor(type=ActorType.MODEL),
+            )
+            await telemetry_recorder.end_span(
+                span_context.span_id,
+                status=SpanStatus.ERROR,
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
+            raise
 
     def _build_context_summarizer(self, llm_connection: Any):
         async def summarize_for_context(messages):
@@ -126,6 +183,7 @@ class AgentLlmStepRunner:
         run_usage: Usage,
         session_id: str,
         event_router: Any,
+        telemetry_recorder: Any = None,
         debug: bool,
     ):
         message_content = extract_response_content(response, strip=False)
@@ -172,3 +230,15 @@ class AgentLlmStepRunner:
                 f"Remaining Requests: {remaining_requests}, "
                 f"Remaining Tokens: {remaining_tokens}"
             )
+
+    def _usage_payload(self, request_usage: Usage | None) -> dict[str, Any] | None:
+        if request_usage is None:
+            return None
+        return {
+            "requests": request_usage.requests,
+            "request_tokens": request_usage.request_tokens,
+            "response_tokens": request_usage.response_tokens,
+            "total_tokens": request_usage.total_tokens,
+            "total_time": request_usage.total_time,
+            "details": request_usage.details,
+        }

--- a/src/omnicoreagent/core/agents/loop_step.py
+++ b/src/omnicoreagent/core/agents/loop_step.py
@@ -56,6 +56,7 @@ class AgentLoopStepHandler:
         mcp_tools: dict | None = None,
         local_tools: Any = None,
         event_router: Callable[[str, Event], Any] | None = None,
+        telemetry_recorder: Any = None,
         sub_agents: list | None = None,
     ) -> AgentLoopStepResult:
         if debug:
@@ -103,6 +104,7 @@ class AgentLoopStepHandler:
                     local_tools=local_tools,
                     session_id=session_id,
                     event_router=event_router,
+                    telemetry_recorder=telemetry_recorder,
                     sub_agents=sub_agents,
                 )
 

--- a/src/omnicoreagent/core/agents/tool_action.py
+++ b/src/omnicoreagent/core/agents/tool_action.py
@@ -61,6 +61,7 @@ class AgentToolActionRunner:
         local_tools: Any = None,
         session_id: str | None = None,
         event_router: Callable[[str | None, Event], Any] | None = None,
+        telemetry_recorder: Any = None,
         sub_agents: list | None = None,
     ):
         tool_call_result = await self.resolve_tool_call_request(
@@ -83,6 +84,7 @@ class AgentToolActionRunner:
             add_message_to_history=add_message_to_history,
             session_id=session_id,
             event_router=event_router,
+            telemetry_recorder=telemetry_recorder,
         )
 
         if debug:
@@ -120,6 +122,7 @@ class AgentToolActionRunner:
         add_message_to_history: Callable[[str, str, dict | None], Any],
         session_id: str | None,
         event_router: Callable[[str | None, Event], Any] | None,
+        telemetry_recorder: Any = None,
     ) -> tuple[str, list[dict[str, Any]], str | None, list[dict[str, Any]]]:
         if isinstance(tool_call_result, ToolError):
             return await self.tool_failure_handler.handle_validation_error(
@@ -137,6 +140,7 @@ class AgentToolActionRunner:
             add_message_to_history=add_message_to_history,
             session_id=session_id,
             event_router=event_router,
+            telemetry_recorder=telemetry_recorder,
         )
         obs_text, tools_results = await self.tool_batch_runner.execute(
             tool_call_results=tool_call_results,
@@ -144,6 +148,7 @@ class AgentToolActionRunner:
             add_message_to_history=add_message_to_history,
             session_id=session_id,
             event_router=event_router,
+            telemetry_recorder=telemetry_recorder,
             tool_batch_name=tool_batch_name,
             tool_batch_args=tool_batch_args,
             parse_tool_observation=self.tool_observation_handler.parse,

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -347,6 +347,7 @@ class OmniCoreAgent:
                 message_history=self.memory_router.get_messages,
                 debug=self.debug,
                 event_router=self.event_router.append,
+                telemetry_recorder=self.telemetry_recorder,
                 **execution.build_agent_run_kwargs(
                     mcp_client=self.mcp_client,
                     local_tools=self.local_tools,

--- a/src/omnicoreagent/core/tools/tool_batch_runner.py
+++ b/src/omnicoreagent/core/tools/tool_batch_runner.py
@@ -3,6 +3,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from omnicoreagent.core.events.base import Event
+from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor
 from omnicoreagent.core.tools.tool_batch_events import (
     assign_tool_call_ids,
     build_tool_batch_args,
@@ -98,6 +99,7 @@ class ToolBatchRunner:
         add_message_to_history: Callable[[str, str, dict | None], Any],
         session_id: str | None,
         event_router: Callable[[str, Event], Any] | None,
+        telemetry_recorder: Any = None,
     ) -> tuple[str, list[dict[str, Any]]]:
         tool_batch_name = build_tool_batch_name(tool_call_results)
         tool_batch_args = build_tool_batch_args(tool_call_results)
@@ -140,18 +142,38 @@ class ToolBatchRunner:
             [list[ToolCallResult], list[dict[str, Any]], SessionState, str | None],
             str,
         ],
+        telemetry_recorder: Any = None,
     ) -> tuple[str, list[dict[str, Any]]]:
+        batch_span = None
+        if telemetry_recorder is not None:
+            batch_span = await telemetry_recorder.start_span(
+                name="tool.batch",
+                kind="tool.batch",
+                actor=TelemetryActor(type=ActorType.TOOL),
+                input={
+                    "tool_batch_name": tool_batch_name,
+                    "tool_batch_args": tool_batch_args,
+                    "tool_count": len(tool_call_results),
+                },
+            )
+            await telemetry_recorder.emit_event(
+                "tool_batch_start",
+                actor=TelemetryActor(type=ActorType.TOOL),
+                input={
+                    "tool_batch_name": tool_batch_name,
+                    "tool_batch_args": tool_batch_args,
+                    "tool_count": len(tool_call_results),
+                },
+            )
         try:
             async with asyncio.timeout(self.tool_call_timeout):
                 tool_outputs = await asyncio.gather(
                     *[
-                        single_tool.tool_executor.execute(
-                            agent_name=self.agent_name,
-                            tool_args=single_tool.tool_args,
-                            tool_name=single_tool.tool_name,
-                            tool_call_id=single_tool.tool_call_id,
+                        self._execute_single_tool(
+                            single_tool=single_tool,
                             add_message_to_history=add_message_to_history,
                             session_id=session_id,
+                            telemetry_recorder=telemetry_recorder,
                         )
                         for single_tool in tool_call_results
                     ]
@@ -187,12 +209,42 @@ class ToolBatchRunner:
             )
             if event_router:
                 await event_router(session_id=session_id, event=event)
+            if telemetry_recorder is not None:
+                await telemetry_recorder.emit_event(
+                    "observation_pipeline_end",
+                    actor=TelemetryActor(type=ActorType.SYSTEM),
+                    output={"observation": obs_text},
+                )
+                await telemetry_recorder.emit_event(
+                    "tool_batch_end",
+                    actor=TelemetryActor(type=ActorType.TOOL),
+                    output={"tool_count": len(tools_results), "status": "completed"},
+                )
+                await telemetry_recorder.end_span(
+                    batch_span.span_id,
+                    status=SpanStatus.OK,
+                    output={"tool_count": len(tools_results), "observation": obs_text},
+                )
 
             return obs_text, tools_results
 
         except asyncio.TimeoutError:
             obs_text = TOOL_CALL_TIMEOUT_MESSAGE
             logger.warning(obs_text)
+            if telemetry_recorder is not None and batch_span is not None:
+                await telemetry_recorder.emit_event(
+                    "tool_batch_error",
+                    actor=TelemetryActor(type=ActorType.TOOL),
+                    error={
+                        "type": "TimeoutError",
+                        "message": obs_text,
+                    },
+                )
+                await telemetry_recorder.end_span(
+                    batch_span.span_id,
+                    status=SpanStatus.TIMEOUT,
+                    error={"type": "TimeoutError", "message": obs_text},
+                )
             tools_results = await self.handle_execution_error(
                 tool_call_results=tool_call_results,
                 error_message=obs_text,
@@ -207,6 +259,17 @@ class ToolBatchRunner:
         except Exception as e:
             obs_text = f"Error executing tool: {str(e)}"
             logger.error(obs_text)
+            if telemetry_recorder is not None and batch_span is not None:
+                await telemetry_recorder.emit_event(
+                    "tool_batch_error",
+                    actor=TelemetryActor(type=ActorType.TOOL),
+                    error={"type": e.__class__.__name__, "message": str(e)},
+                )
+                await telemetry_recorder.end_span(
+                    batch_span.span_id,
+                    status=SpanStatus.ERROR,
+                    error={"type": e.__class__.__name__, "message": str(e)},
+                )
             tools_results = await self.handle_execution_error(
                 tool_call_results=tool_call_results,
                 error_message=obs_text,
@@ -217,3 +280,97 @@ class ToolBatchRunner:
                 tool_batch_name=tool_batch_name,
             )
             return obs_text, tools_results
+
+    async def _execute_single_tool(
+        self,
+        *,
+        single_tool: ToolCallResult,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+        telemetry_recorder: Any = None,
+    ) -> dict[str, Any]:
+        if telemetry_recorder is None:
+            return await single_tool.tool_executor.execute(
+                agent_name=self.agent_name,
+                tool_args=single_tool.tool_args,
+                tool_name=single_tool.tool_name,
+                tool_call_id=single_tool.tool_call_id,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+            )
+
+        span = await telemetry_recorder.start_span(
+            name=single_tool.tool_name,
+            kind="tool.call",
+            actor=TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
+            input={
+                "tool_name": single_tool.tool_name,
+                "tool_args": single_tool.tool_args,
+                "tool_call_id": single_tool.tool_call_id,
+            },
+        )
+        try:
+            await telemetry_recorder.emit_event(
+                "tool_call",
+                actor=TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
+                input={
+                    "tool_name": single_tool.tool_name,
+                    "tool_args": single_tool.tool_args,
+                    "tool_call_id": single_tool.tool_call_id,
+                },
+            )
+            result = await single_tool.tool_executor.execute(
+                agent_name=self.agent_name,
+                tool_args=single_tool.tool_args,
+                tool_name=single_tool.tool_name,
+                tool_call_id=single_tool.tool_call_id,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+            )
+            if result.get("status") == "error":
+                await telemetry_recorder.emit_event(
+                    "tool_error",
+                    actor=TelemetryActor(
+                        type=ActorType.TOOL, name=single_tool.tool_name
+                    ),
+                    output=result,
+                    error={
+                        "type": "ToolError",
+                        "message": result.get("message") or "Tool returned error",
+                    },
+                )
+                await telemetry_recorder.end_span(
+                    span.span_id,
+                    status=SpanStatus.ERROR,
+                    output=result,
+                    error={
+                        "type": "ToolError",
+                        "message": result.get("message") or "Tool returned error",
+                    },
+                )
+            else:
+                await telemetry_recorder.emit_event(
+                    "tool_result",
+                    actor=TelemetryActor(
+                        type=ActorType.TOOL, name=single_tool.tool_name
+                    ),
+                    output=result,
+                )
+                await telemetry_recorder.end_span(
+                    span.span_id,
+                    status=SpanStatus.OK,
+                    output=result,
+                )
+            return result
+        except Exception as exc:
+            await telemetry_recorder.record_exception(
+                exc,
+                event_type="tool_error",
+                actor=TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
+            )
+            await telemetry_recorder.end_span(
+                span.span_id,
+                status=SpanStatus.ERROR,
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
+            raise

--- a/tests/test_loop_telemetry_instrumentation.py
+++ b/tests/test_loop_telemetry_instrumentation.py
@@ -1,0 +1,131 @@
+import json
+
+import pytest
+
+from omnicoreagent.core.agents.base import BaseReactAgent
+from omnicoreagent.core.telemetry import (
+    InMemoryTelemetryStore,
+    TelemetryActor,
+    TelemetryRecorder,
+)
+from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+
+
+@pytest.mark.asyncio
+async def test_react_loop_records_model_step_and_parallel_tool_telemetry():
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-loop",
+        run_id="run-loop",
+        session_id="session-loop",
+        actor=TelemetryActor(type="agent", name="loop-agent"),
+    )
+
+    registry = ToolRegistry()
+    history = []
+
+    @registry.register_tool(
+        name="alpha",
+        inputSchema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        description="Return alpha value.",
+    )
+    async def alpha(value: str):
+        return {"status": "success", "data": f"alpha:{value}"}
+
+    @registry.register_tool(
+        name="beta",
+        inputSchema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        description="Return beta value.",
+    )
+    async def beta(value: str):
+        return {"status": "success", "data": f"beta:{value}"}
+
+    class FakeLLMConnection:
+        def __init__(self):
+            self.calls = 0
+
+        async def llm_call(self, messages):
+            self.calls += 1
+            if self.calls == 1:
+                return """
+<thought>Need both tools.</thought>
+<tool_calls>
+  <tool_call>
+    <tool_name>alpha</tool_name>
+    <parameters><value>one</value></parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>beta</tool_name>
+    <parameters><value>two</value></parameters>
+  </tool_call>
+</tool_calls>
+"""
+            return "<final_answer>done</final_answer>"
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def message_history(agent_name, session_id):
+        return history
+
+    agent = BaseReactAgent(
+        agent_name="loop-agent",
+        max_steps=5,
+        tool_call_timeout=10,
+    )
+
+    result = await agent.run(
+        system_prompt="system",
+        query="run both tools",
+        llm_connection=FakeLLMConnection(),
+        add_message_to_history=add_message_to_history,
+        message_history=message_history,
+        session_id="session-loop",
+        local_tools=registry,
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace(output={"answer": result["answer"]})
+
+    trace = await store.get_trace(context.trace_id)
+    span_kinds = [span.kind for span in trace.spans]
+    event_types = [event.event_type for event in trace.events]
+
+    assert result["answer"] == "done"
+    assert span_kinds.count("agent.step") == 2
+    assert span_kinds.count("model.call") == 2
+    assert span_kinds.count("tool.batch") == 1
+    assert span_kinds.count("tool.call") == 2
+    assert "agent_step" in event_types
+    assert event_types.count("model_call") == 2
+    assert event_types.count("model_response") == 2
+    assert "tool_batch_start" in event_types
+    assert "tool_batch_end" in event_types
+    assert event_types.count("tool_call") == 2
+    assert event_types.count("tool_result") == 2
+    assert "observation_pipeline_end" in event_types
+
+    tool_spans = [span for span in trace.spans if span.kind == "tool.call"]
+    assert {span.name for span in tool_spans} == {"alpha", "beta"}
+    assert {span.output["tool_name"] for span in tool_spans} == {"alpha", "beta"}
+
+    tool_batch = next(span for span in trace.spans if span.kind == "tool.batch")
+    assert json.loads(json.dumps(tool_batch.input["tool_batch_args"])) == [
+        {"value": "one"},
+        {"value": "two"},
+    ]


### PR DESCRIPTION
## Summary
- pass the active telemetry recorder from OmniCoreAgent into the ReAct loop
- add child spans/events for agent steps, model calls, parallel tool batches, individual tool calls, and parsed tool observations
- keep legacy EventRouter calls intact as migration compatibility while telemetry becomes the canonical evidence path
- update internal telemetry architecture/spec status for loop instrumentation coverage
- add an end-to-end loop telemetry test that exercises a two-step model/tool/final-answer run

## Tests
- uv run ruff check src tests
- uv run pytest tests/test_loop_telemetry_instrumentation.py tests/test_llm_step.py tests/test_tool_batch_runner.py tests/test_base.py tests/test_runtime_telemetry_wiring.py tests/test_import_startup.py -q
- uv run pytest tests/test_loop_telemetry_instrumentation.py tests/test_runtime_telemetry_wiring.py tests/test_telemetry_foundation.py tests/test_omniserve_sse.py -q
- uv run pytest -q (769 passed, 9 skipped)