### PR TITLE
Complete telemetry runtime instrumentation

### DIFF
--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -55,7 +55,7 @@ This architecture does not implement or design:
 Those systems will be designed separately. They must consume telemetry instead
 of bypassing it.
 
-## Current Telemetry Ownership
+## Telemetry Ownership
 
 Runtime evidence is emitted as trace-scoped telemetry:
 
@@ -63,44 +63,13 @@ Runtime evidence is emitted as trace-scoped telemetry:
 TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
 ```
 
-They contain:
+`TelemetryRecorder` is the only runtime write path. `TelemetryStore` is the
+canonical evidence store. `TelemetryStream` is a live/replay adapter over that
+same store. It is not a second event system.
 
-- `type`
-- `payload`
-- `agent_name`
-- `timestamp`
-- `event_id`
-- `sequence`
-- `run_id`
-
-That model is useful, but incomplete. It does not provide:
-
-- `trace_id`
-- `span_id`
-- `parent_span_id`
-- `parent_event_id`
-- standard `input`, `output`, and `error` fields
-- duration for timed work
-- token usage and estimated cost
-- normalized actor identity
-- trace-level metadata
-- version metadata
-- first-class memory, context, workspace, guardrail, model, and MCP records
-- stable normalized evidence for future evaluators
-
-The current `/events/{session_id}/trace` endpoint is therefore a compact event
-summary, not a full trace. Future docs and code should avoid using it as the
-canonical trace model.
-
-The replacement is not "telemetry stream plus telemetry." The replacement is
-telemetry owning the full path:
-
-```text
-TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
-```
-
-Anything still using telemetry stream after telemetry lands is transitional code
-and should have a removal plan.
+The old event-router idea is removed from the architecture. Routes such as
+`/events/{session_id}/trace` may keep their HTTP shape for developer ergonomics,
+but their data must be derived from telemetry traces and events.
 
 ## Core Concepts
 
@@ -154,7 +123,8 @@ router.
 A telemetry trace is one logical execution graph.
 
 For a normal interactive request, the trace usually starts at `agent.run`.
-For OmniServe, it may start at `serve.request` and contain `agent.run`.
+For OmniServe, the serving boundary starts a `serve.request` trace correlated
+to the agent trace through `session_id` and `run_id`.
 For a background task, it may start at `background.run` and contain `agent.run`.
 
 ### Telemetry Context
@@ -227,11 +197,27 @@ The runtime loop instrumentation phase provides:
   `tool_batch_error` events
 - child `tool.call` spans with `tool_call`, `tool_result`, and `tool_error`
   events for each tool in a parallel batch
-- `observation_pipeline_end` events after tool output parsing and formatting
+- child `mcp.tool.call` spans with `mcp_tool_call`, `mcp_tool_result`, and
+  `mcp_tool_error` events for MCP server tools
+- workspace file tool spans as `workspace.read`, `workspace.write`, or
+  `workspace.delete` with matching workspace events
+- memory read/write spans and `memory_read` / `memory_write` events around the
+  memory router
+- context compression spans with `context_compression` and `context_dropped`
+  events
+- observation pipeline start/end/error events after tool execution and before
+  the model sees formatted observations
+- workspace offload events when large tool results are replaced by workspace
+  references
+- subagent execution spans with `subagent_spawn`, `subagent_result`, and
+  `subagent_error` events
+- background task/run lifecycle spans and events
+- OmniServe `serve.request` traces/events for synchronous and SSE run
+  boundaries, correlated to the same `session_id` and `run_id` as the agent run
 
-MCP-specific tool spans, memory operations, workspace operations, subagents,
-background runs, and OmniServe SSE are still migration work. They must emit
-telemetry directly instead of adding new telemetry stream dependencies.
+Remaining runtime coverage should be added directly through telemetry. No new
+event router, side-channel stream, or feature-specific event store should be
+introduced.
 
 Runtime controls may also emit telemetry:
 
@@ -313,6 +299,7 @@ memory.read
 memory.write
 workspace.read
 workspace.write
+workspace.delete
 tool.offload
 guardrail.check
 subagent.run
@@ -357,7 +344,8 @@ Telemetry events should cover these groups:
 - errors
 
 The event registry must stay explicit. Arbitrary string events can be accepted
-, but stable telemetry requires documented event names.
+only when marked experimental, but stable telemetry requires documented event
+names.
 
 ## Trace Recorder
 
@@ -399,7 +387,8 @@ Redis streams are not the canonical long-term trace store.
 
 The telemetry stream is the live/replay adapter over telemetry records.
 
-It replaces the long-term need for telemetry stream.
+It replaces the old event-router responsibility without becoming another
+truth source.
 
 Responsibilities:
 
@@ -484,14 +473,14 @@ must emit telemetry directly instead of adding a parallel visibility stack.
 
 ## Relationship to OmniServe
 
-OmniServe should eventually create `serve.request` spans for:
+OmniServe creates `serve.request` traces for:
 
 - `/run`
 - `/run/sync`
-- background task API calls
 
-The served agent run should become a child of the serving span when the request
-starts the agent directly.
+The served agent run is correlated through `session_id` and `run_id`. Direct
+parent-child trace linking between `serve.request` and `agent.run` is a later
+trace-link feature, not required for the foundation telemetry phase.
 
 SSE streaming should not require the full observability stack. It should stream
 the subset of telemetry events needed by clients.
@@ -569,5 +558,5 @@ Each implementation phase must include:
 - concurrent tool batch tests
 - redaction tests
 - partial trace tests
-- telemetry stream tests from runtime telemetry events
+- telemetry stream replay/follow tests from stored telemetry events
 - documentation updates

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -32,7 +32,7 @@ This specification covers:
 - live/replay stream contract
 - normalization contract
 - redaction and payload policy
-- migration from runtime telemetry events and telemetry stream
+- removal of the old event-router path in favor of telemetry-owned streaming
 - required tests
 
 This specification does not cover:
@@ -268,6 +268,7 @@ memory.read
 memory.write
 workspace.read
 workspace.write
+workspace.delete
 tool.offload
 guardrail.check
 subagent.run
@@ -483,8 +484,8 @@ Rules:
 - stream cursors must support replay/follow behavior for SSE reconnect.
 - stream scopes must isolate sessions, runs, and traces.
 - `/run` SSE streams events for the trace/run it started.
-- `/events/{session_id}` can remain  but should become a
-  telemetry stream view.
+- `/events/{session_id}` remains as an HTTP route shape, but it must read from
+  telemetry records.
 - stream failures must not corrupt the stored trace.
 - Redis streams may be used as an implementation backend for live fanout, but
   Redis stream records are not a separate canonical evidence model.
@@ -620,20 +621,36 @@ Current runtime loop coverage:
 - parallel tool batches create one `tool.batch` span.
 - tool batches emit `tool_batch_start`, `tool_batch_end`, and
   `tool_batch_error` events.
-- each individual tool in a batch creates a `tool.call` span.
-- individual tool calls emit `tool_call`, `tool_result`, and `tool_error`
-  events.
-- parsed tool observations emit `observation_pipeline_end`.
+- local tools create `tool.call` spans and emit `tool_call`, `tool_result`, and
+  `tool_error` events.
+- MCP tools create `mcp.tool.call` spans and emit `mcp_tool_call`,
+  `mcp_tool_result`, and `mcp_tool_error` events.
+- workspace file tools create `workspace.read`, `workspace.write`, or
+  `workspace.delete` spans and emit matching workspace events.
+- memory history reads and writes create `memory.read` / `memory.write` spans
+  and emit `memory_read` / `memory_write` events.
+- context compression creates `context.compression` spans and emits
+  `context_compression`; compression failure emits `context_dropped`.
+- parsed tool observations emit `observation_pipeline_start`,
+  `observation_pipeline_end`, and `observation_pipeline_error` events.
+- workspace offloading emits `workspace_offload`.
+- dynamic subagent execution creates `subagent.run` spans and emits
+  `subagent_spawn`, `subagent_result`, and `subagent_error` events.
+- background task/run lifecycle emits background spans and events.
+- OmniServe synchronous and SSE run boundaries create `serve.request` traces and
+  emit `serve_request_start`, `serve_request_end`, and `serve_request_error`
+  events. Serve traces are correlated to agent traces by `session_id` and
+  `run_id`.
 
-Current uncovered runtime internals:
+Current remaining runtime internals:
 
-- MCP tool spans
-- memory read/write spans
-- workspace read/write/offload spans
-- full observation pipeline start/error spans
-- subagent spans
-- background run spans
-- OmniServe request spans and SSE streaming from `TelemetryStream`
+- direct workspace storage internals outside workspace file tools and offload
+- artifact-specific read/tail/search operations that still appear as generic
+  tools until artifact telemetry is specified
+- approval/resource guard telemetry paths that are reserved but not fully wired
+- cross-trace links between `serve.request`, background runs, subagents, and
+  agent traces
+- durable telemetry stores beyond in-memory and JSONL
 
 ---
 
@@ -648,7 +665,7 @@ TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
 There must not be a parallel event stack:
 
 ```text
-telemetry stream -> EventStore
+EventRouter -> EventStore
 TelemetryRecorder -> TelemetryStore
 ```
 
@@ -664,8 +681,20 @@ Canonical event mapping:
 | individual tool starts | `tool_call` | `tool.call` |
 | individual tool succeeds | `tool_result` | `tool.call` |
 | individual tool fails | `tool_error` | `tool.call` |
+| MCP tool starts | `mcp_tool_call` | `mcp.tool.call` |
+| MCP tool succeeds | `mcp_tool_result` | `mcp.tool.call` |
+| MCP tool fails | `mcp_tool_error` | `mcp.tool.call` |
+| memory history read | `memory_read` | `memory.read` |
+| memory history write | `memory_write` | `memory.write` |
+| context compressed | `context_compression` | `context.compression` |
+| observation formatted | `observation_pipeline_end` | `tool.batch` |
+| workspace file read | `workspace_read` | `workspace.read` |
+| workspace file write | `workspace_write` | `workspace.write` |
+| workspace file delete | `workspace_delete` | `workspace.delete` |
 | subagent starts | `subagent_spawn` | `subagent.run` |
 | subagent completes | `subagent_result` | `subagent.run` |
+| serve request starts | `serve_request_start` | `serve.request` |
+| serve request completes | `serve_request_end` | `serve.request` |
 | background lifecycle changes | background lifecycle event | `background.run` |
 | final answer produced | `final_answer` | `agent.run` |
 
@@ -754,22 +783,20 @@ This design PR is acceptable when:
 - architecture and specification are accepted
 - telemetry owns the target streaming path:
   `TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE`
-- runtime telemetry events and telemetry stream are documented only as migration
-  concerns
+- old event-router concerns are removed from the target architecture
 - the spec defines the schema, recorder, store, stream, normalizer, redaction,
-  migration, and future evaluation evidence contracts
+  streaming, and future evaluation evidence contracts
 - docs clearly separate telemetry from observability and evaluation
 
-## Acceptance Criteria For Future Foundation Implementation
+## Acceptance Criteria For Foundation Implementation
 
-The future telemetry foundation implementation is acceptable when:
+The telemetry foundation implementation is acceptable when:
 
 - implementation has a canonical event/span/trace schema
 - recorder can capture agent/model/tool/final-answer basics
 - telemetry store can persist and retrieve traces locally
 - telemetry stream can replay/follow selected telemetry events
 - OmniServe SSE is backed by `TelemetryStream`
-- the implementation PR includes an explicit telemetry stream removal or migration
-  completion plan for remaining call sites
+- no code path writes to a separate EventRouter/EventStore
 - normalizer can produce deterministic normalized traces
 - future evaluation can reference `trace_id`, `span_id`, and `event_id`

--- a/src/omnicoreagent/core/agents/llm_step.py
+++ b/src/omnicoreagent/core/agents/llm_step.py
@@ -60,10 +60,60 @@ class AgentLlmStepRunner:
                 self.usage_limits.check_before_request(usage=run_usage)
 
             if self.context_manager.should_trigger(session_state.messages):
-                session_state.messages = await self.context_manager.manage_context(
-                    messages=session_state.messages,
-                    summarize_fn=self._build_context_summarizer(llm_connection),
-                )
+                before_count = len(session_state.messages)
+                context_span = None
+                try:
+                    if telemetry_recorder is not None:
+                        context_span = await telemetry_recorder.start_span(
+                            name="context.compression",
+                            kind="context.compression",
+                            actor=TelemetryActor(type=ActorType.SYSTEM),
+                            input={"message_count": before_count},
+                        )
+                    session_state.messages = await self.context_manager.manage_context(
+                        messages=session_state.messages,
+                        summarize_fn=self._build_context_summarizer(llm_connection),
+                    )
+                    after_count = len(session_state.messages)
+                    if telemetry_recorder is not None:
+                        await telemetry_recorder.emit_event(
+                            "context_compression",
+                            actor=TelemetryActor(type=ActorType.SYSTEM),
+                            input={"message_count": before_count},
+                            output={
+                                "message_count": after_count,
+                                "stats": self.context_manager.get_stats(),
+                            },
+                        )
+                        if context_span is not None:
+                            await telemetry_recorder.end_span(
+                                context_span.span_id,
+                                status=SpanStatus.OK,
+                                output={
+                                    "message_count": after_count,
+                                    "stats": self.context_manager.get_stats(),
+                                },
+                            )
+                except Exception as exc:
+                    if telemetry_recorder is not None and context_span is not None:
+                        await telemetry_recorder.emit_event(
+                            "context_dropped",
+                            actor=TelemetryActor(type=ActorType.SYSTEM),
+                            input={"message_count": before_count},
+                            error={
+                                "type": exc.__class__.__name__,
+                                "message": str(exc),
+                            },
+                        )
+                        await telemetry_recorder.end_span(
+                            context_span.span_id,
+                            status=SpanStatus.ERROR,
+                            error={
+                                "type": exc.__class__.__name__,
+                                "message": str(exc),
+                            },
+                        )
+                    raise
                 if debug:
                     logger.info(
                         f"Context managed: now {len(session_state.messages)} messages"

--- a/src/omnicoreagent/core/agents/subagent_runner.py
+++ b/src/omnicoreagent/core/agents/subagent_runner.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Callable
 from typing import Any
 
-from omnicoreagent.core.telemetry import ActorType, TelemetryActor
+from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor
 from omnicoreagent.core.token_usage import Usage, usage
 from omnicoreagent.core.types import Message
 from omnicoreagent.core.agents.display import show_sub_agent_call_result
@@ -36,11 +36,6 @@ class SubAgentCallRunner:
         debug: bool = False,
     ):
         agent_calls = self._normalize_agent_calls(agent_calls)
-        await self._emit_started(
-            agent_calls=agent_calls,
-            session_id=session_id,
-            telemetry_recorder=telemetry_recorder,
-        )
         await self._record_assistant_call(
             response=response,
             agent_calls=agent_calls,
@@ -54,7 +49,12 @@ class SubAgentCallRunner:
         )
         results = await asyncio.gather(
             *[
-                self._execute_single_agent(call, sub_agents, session_id)
+                self._execute_single_agent(
+                    call,
+                    sub_agents,
+                    session_id,
+                    telemetry_recorder=telemetry_recorder,
+                )
                 for call in agent_calls
             ],
             return_exceptions=True,
@@ -81,20 +81,6 @@ class SubAgentCallRunner:
             return json.loads(agent_calls)
         return list(agent_calls)
 
-    async def _emit_started(
-        self,
-        agent_calls: list[dict[str, Any]],
-        session_id: str,
-        telemetry_recorder: Any = None,
-    ):
-        if telemetry_recorder is None:
-            return
-        await telemetry_recorder.emit_event(
-            "subagent_spawn",
-            actor=TelemetryActor(type=ActorType.AGENT, name=self.agent_name),
-            input={"agent_calls": agent_calls, "session_id": session_id},
-        )
-
     async def _record_assistant_call(
         self,
         response: str,
@@ -116,12 +102,36 @@ class SubAgentCallRunner:
         call: dict[str, Any],
         sub_agents: list,
         session_id: str,
+        telemetry_recorder: Any = None,
     ) -> tuple[str, Any]:
         agent_name = call.get("agent")
         if not agent_name:
             raise ValueError("agent_call missing 'agent' field")
 
+        span = None
+        agent = None
+        cleanup_attempted = False
         try:
+            if telemetry_recorder is not None:
+                span = await telemetry_recorder.start_span(
+                    name=f"subagent:{agent_name}",
+                    kind="subagent.run",
+                    actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
+                    input={
+                        "agent_name": agent_name,
+                        "session_id": session_id,
+                        "parameters": call.get("parameters", {}),
+                    },
+                )
+                await telemetry_recorder.emit_event(
+                    "subagent_spawn",
+                    actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
+                    input={
+                        "agent_name": agent_name,
+                        "session_id": session_id,
+                        "parameters": call.get("parameters", {}),
+                    },
+                )
             agent = resolve_agent(agent_name, sub_agents)
             params = dict(call.get("parameters", {}))
             params["session_id"] = session_id
@@ -133,12 +143,82 @@ class SubAgentCallRunner:
 
             logger.info(f"Running sub-agent: {agent_name}")
             result = await agent.run(**kwargs)
-            await agent.cleanup_mcp_servers()
+            cleanup_attempted = True
+            await self._cleanup_agent(agent_name, agent)
+            if telemetry_recorder is not None:
+                await telemetry_recorder.emit_event(
+                    "subagent_result",
+                    actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
+                    input={"session_id": session_id, "agent_name": agent_name},
+                    output={"result": result},
+                )
+            if telemetry_recorder is not None and span is not None:
+                await telemetry_recorder.end_span(
+                    span.span_id,
+                    status=SpanStatus.OK,
+                    output={"agent_name": agent_name},
+                )
             return agent_name, result
+
+        except asyncio.CancelledError as e:
+            logger.error(f"Sub-agent {agent_name} execution was cancelled")
+            if agent is not None and not cleanup_attempted:
+                try:
+                    await self._cleanup_agent(agent_name, agent)
+                except Exception as cleanup_error:
+                    logger.error(
+                        f"Failed to cleanup cancelled sub-agent {agent_name}: "
+                        f"{cleanup_error}"
+                    )
+            if telemetry_recorder is not None:
+                await telemetry_recorder.emit_event(
+                    "subagent_error",
+                    actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
+                    input={"session_id": session_id, "agent_name": agent_name},
+                    error={"type": e.__class__.__name__, "message": "cancelled"},
+                )
+            if telemetry_recorder is not None and span is not None:
+                await telemetry_recorder.end_span(
+                    span.span_id,
+                    status=SpanStatus.CANCELLED,
+                    error={"type": e.__class__.__name__, "message": "cancelled"},
+                )
+            raise
 
         except Exception as e:
             logger.error(f"Error executing agent {agent_name}: {e}", exc_info=True)
+            if agent is not None and not cleanup_attempted:
+                try:
+                    await self._cleanup_agent(agent_name, agent)
+                except Exception as cleanup_error:
+                    logger.error(
+                        f"Failed to cleanup sub-agent {agent_name} after error: "
+                        f"{cleanup_error}"
+                    )
+            if telemetry_recorder is not None:
+                await telemetry_recorder.emit_event(
+                    "subagent_error",
+                    actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
+                    input={"session_id": session_id, "agent_name": agent_name},
+                    error={"type": e.__class__.__name__, "message": str(e)},
+                )
+            if telemetry_recorder is not None and span is not None:
+                await telemetry_recorder.end_span(
+                    span.span_id,
+                    status=SpanStatus.ERROR,
+                    error={"type": e.__class__.__name__, "message": str(e)},
+                )
             return agent_name, e
+
+    async def _cleanup_agent(self, agent_name: str, agent: Any) -> None:
+        cleanup = getattr(agent, "cleanup_mcp_servers", None)
+        if not callable(cleanup):
+            return
+        try:
+            await cleanup()
+        except Exception as exc:
+            logger.error(f"Failed to cleanup sub-agent {agent_name}: {exc}")
+            raise
 
     async def _collect_observations(
         self,
@@ -149,7 +229,9 @@ class SubAgentCallRunner:
     ) -> list[dict[str, Any]]:
         observations = []
         for result in results:
-            if isinstance(result, Exception):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
                 logger.error(f"Unexpected top-level exception: {result}")
                 observations.append(
                     {
@@ -191,13 +273,6 @@ class SubAgentCallRunner:
         telemetry_recorder: Any = None,
     ) -> dict[str, Any]:
         logger.error(f"Agent {agent_name} execution failed: {error}")
-        if telemetry_recorder is not None:
-            await telemetry_recorder.emit_event(
-                "subagent_error",
-                actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
-                input={"session_id": session_id, "agent_name": agent_name},
-                error={"type": error.__class__.__name__, "message": str(error)},
-            )
         return {
             "agent_name": agent_name,
             "status": "error",
@@ -219,14 +294,6 @@ class SubAgentCallRunner:
             if sub_usage and isinstance(sub_usage, Usage):
                 run_usage.incr(sub_usage)
                 usage.incr(sub_usage)
-
-        if telemetry_recorder is not None:
-            await telemetry_recorder.emit_event(
-                "subagent_result",
-                actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
-                input={"session_id": session_id, "agent_name": agent_name},
-                output={"result": result},
-            )
 
         return {
             "agent_name": agent_name,

--- a/src/omnicoreagent/core/runtime/execution.py
+++ b/src/omnicoreagent/core/runtime/execution.py
@@ -3,21 +3,30 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from omnicoreagent.core.telemetry import ActorType, TelemetryActor
 from omnicoreagent.core.runtime.imports import runtime_logger
 
 
-def blocked_guardrail_response(
+async def blocked_guardrail_response(
     *,
     guardrail: Any,
     query: str,
     session_id: str | None,
     agent_name: str,
+    telemetry_recorder: Any = None,
 ) -> dict[str, Any] | None:
     """Return a blocked response when input guardrails reject the query."""
     if not guardrail:
         return None
 
     result = guardrail.check(query)
+    if telemetry_recorder is not None:
+        await telemetry_recorder.emit_event(
+            "guardrail_check",
+            actor=TelemetryActor(type=ActorType.GUARDRAIL),
+            input={"target": "user_input", "agent_name": agent_name},
+            output=result.to_dict() if hasattr(result, "to_dict") else {"safe": result.is_safe},
+        )
     if result.is_safe:
         return None
 

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -295,11 +295,12 @@ class OmniCoreAgent:
             if not self._initialized:
                 await self.initialize()
 
-            blocked_response = execution.blocked_guardrail_response(
+            blocked_response = await execution.blocked_guardrail_response(
                 guardrail=self.guardrail,
                 query=query,
                 session_id=session_id,
                 agent_name=self.name,
+                telemetry_recorder=self.telemetry_recorder,
             )
             if blocked_response:
                 await self.telemetry_recorder.emit_event(
@@ -329,8 +330,8 @@ class OmniCoreAgent:
                 system_prompt=runtime_prompt,
                 query=query,
                 llm_connection=self.llm_connection,
-                add_message_to_history=self.memory_router.store_message,
-                message_history=self.memory_router.get_messages,
+                add_message_to_history=self._store_message_with_telemetry,
+                message_history=self._get_messages_with_telemetry,
                 debug=self.debug,
                 telemetry_recorder=self.telemetry_recorder,
                 **execution.build_agent_run_kwargs(
@@ -383,6 +384,94 @@ class OmniCoreAgent:
                     status=TraceStatus.FAILED,
                     error={"type": exc.__class__.__name__, "message": str(exc)},
                 )
+            raise
+
+    async def _store_message_with_telemetry(
+        self,
+        role: str,
+        content: str,
+        metadata: dict | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        if self.telemetry_recorder is None:
+            await self.memory_router.store_message(role, content, metadata, session_id)
+            return
+        span = await self.telemetry_recorder.start_span(
+            name="memory.write",
+            kind="memory.write",
+            actor=TelemetryActor(type=ActorType.MEMORY),
+            input={
+                "role": role,
+                "session_id": session_id,
+                "metadata_keys": sorted((metadata or {}).keys()),
+            },
+        )
+        try:
+            await self.memory_router.store_message(role, content, metadata, session_id)
+            await self.telemetry_recorder.emit_event(
+                "memory_write",
+                actor=TelemetryActor(type=ActorType.MEMORY),
+                input={"role": role, "session_id": session_id},
+                output={"stored": True},
+            )
+            await self.telemetry_recorder.end_span(
+                span.span_id,
+                status="ok",
+                output={"stored": True},
+            )
+        except Exception as exc:
+            await self.telemetry_recorder.emit_event(
+                "memory_write",
+                actor=TelemetryActor(type=ActorType.MEMORY),
+                input={"role": role, "session_id": session_id},
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
+            await self.telemetry_recorder.end_span(
+                span.span_id,
+                status="error",
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
+            raise
+
+    async def _get_messages_with_telemetry(
+        self,
+        session_id: str,
+        agent_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        if self.telemetry_recorder is None:
+            return await self.memory_router.get_messages(session_id, agent_name)
+        span = await self.telemetry_recorder.start_span(
+            name="memory.read",
+            kind="memory.read",
+            actor=TelemetryActor(type=ActorType.MEMORY),
+            input={"session_id": session_id, "agent_name": agent_name},
+        )
+        try:
+            messages = await self.memory_router.get_messages(session_id, agent_name)
+            await self.telemetry_recorder.emit_event(
+                "memory_read",
+                actor=TelemetryActor(type=ActorType.MEMORY),
+                input={"session_id": session_id, "agent_name": agent_name},
+                output={"message_count": len(messages)},
+            )
+            await self.telemetry_recorder.end_span(
+                span.span_id,
+                status="ok",
+                output={"message_count": len(messages)},
+            )
+            return messages
+        except Exception as exc:
+            await self.telemetry_recorder.emit_event(
+                "memory_read",
+                actor=TelemetryActor(type=ActorType.MEMORY),
+                input={"session_id": session_id, "agent_name": agent_name},
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
+            await self.telemetry_recorder.end_span(
+                span.span_id,
+                status="error",
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
             raise
 
     async def get_metrics(self) -> Dict[str, Any]:

--- a/src/omnicoreagent/core/telemetry/models.py
+++ b/src/omnicoreagent/core/telemetry/models.py
@@ -65,6 +65,7 @@ FOUNDATION_SPAN_KINDS = frozenset(
         "memory.write",
         "workspace.read",
         "workspace.write",
+        "workspace.delete",
         "tool.offload",
         "guardrail.check",
         "subagent.run",

--- a/src/omnicoreagent/core/telemetry/recorder.py
+++ b/src/omnicoreagent/core/telemetry/recorder.py
@@ -368,7 +368,19 @@ class TelemetryRecorder:
         ):
             return None
         if (
-            source in {"tool.call", "mcp.tool.call", "tool_result", "mcp_tool_result"}
+            source
+            in {
+                "tool.call",
+                "mcp.tool.call",
+                "workspace.read",
+                "workspace.write",
+                "workspace.delete",
+                "tool_result",
+                "mcp_tool_result",
+                "workspace_read",
+                "workspace_write",
+                "workspace_delete",
+            }
             and not self.config.record_tool_results
         ):
             return None

--- a/src/omnicoreagent/core/tools/tool_batch_runner.py
+++ b/src/omnicoreagent/core/tools/tool_batch_runner.py
@@ -164,6 +164,16 @@ class ToolBatchRunner:
                     ]
                 )
 
+            if telemetry_recorder is not None:
+                await telemetry_recorder.emit_event(
+                    "observation_pipeline_start",
+                    actor=TelemetryActor(type=ActorType.SYSTEM),
+                    input={
+                        "tool_batch_name": tool_batch_name,
+                        "tool_count": len(tool_outputs),
+                    },
+                )
+
             observation = await parse_tool_observation(
                 {
                     "status": (
@@ -189,8 +199,20 @@ class ToolBatchRunner:
                 await telemetry_recorder.emit_event(
                     "observation_pipeline_end",
                     actor=TelemetryActor(type=ActorType.SYSTEM),
-                    output={"observation": obs_text},
+                    output={
+                        "observation": obs_text,
+                        "tool_count": len(tools_results),
+                    },
                 )
+                if "[TOOL RESPONSE OFFLOADED]" in obs_text:
+                    await telemetry_recorder.emit_event(
+                        "workspace_offload",
+                        actor=TelemetryActor(type=ActorType.WORKSPACE),
+                        output={
+                            "tool_batch_name": tool_batch_name,
+                            "offloaded": True,
+                        },
+                    )
                 await telemetry_recorder.emit_event(
                     "tool_batch_end",
                     actor=TelemetryActor(type=ActorType.TOOL),
@@ -208,6 +230,14 @@ class ToolBatchRunner:
             obs_text = TOOL_CALL_TIMEOUT_MESSAGE
             logger.warning(obs_text)
             if telemetry_recorder is not None and batch_span is not None:
+                await telemetry_recorder.emit_event(
+                    "observation_pipeline_error",
+                    actor=TelemetryActor(type=ActorType.SYSTEM),
+                    error={
+                        "type": "TimeoutError",
+                        "message": obs_text,
+                    },
+                )
                 await telemetry_recorder.emit_event(
                     "tool_batch_error",
                     actor=TelemetryActor(type=ActorType.TOOL),
@@ -236,6 +266,11 @@ class ToolBatchRunner:
             obs_text = f"Error executing tool: {str(e)}"
             logger.error(obs_text)
             if telemetry_recorder is not None and batch_span is not None:
+                await telemetry_recorder.emit_event(
+                    "observation_pipeline_error",
+                    actor=TelemetryActor(type=ActorType.SYSTEM),
+                    error={"type": e.__class__.__name__, "message": str(e)},
+                )
                 await telemetry_recorder.emit_event(
                     "tool_batch_error",
                     actor=TelemetryActor(type=ActorType.TOOL),
@@ -275,26 +310,27 @@ class ToolBatchRunner:
                 session_id=session_id,
             )
 
+        telemetry_shape = _tool_telemetry_shape(single_tool)
+        telemetry_input = {
+            "tool_name": single_tool.tool_name,
+            "tool_args": single_tool.tool_args,
+            "tool_call_id": single_tool.tool_call_id,
+            "tool_provider": single_tool.tool_provider,
+            "tool_server": single_tool.tool_server,
+        }
         span = await telemetry_recorder.start_span(
             name=single_tool.tool_name,
-            kind="tool.call",
-            actor=TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
-            input={
-                "tool_name": single_tool.tool_name,
-                "tool_args": single_tool.tool_args,
-                "tool_call_id": single_tool.tool_call_id,
-            },
+            kind=telemetry_shape["span_kind"],
+            actor=telemetry_shape["actor"],
+            input=telemetry_input,
         )
         try:
-            await telemetry_recorder.emit_event(
-                "tool_call",
-                actor=TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
-                input={
-                    "tool_name": single_tool.tool_name,
-                    "tool_args": single_tool.tool_args,
-                    "tool_call_id": single_tool.tool_call_id,
-                },
-            )
+            if not telemetry_shape["single_event"]:
+                await telemetry_recorder.emit_event(
+                    telemetry_shape["call_event"],
+                    actor=telemetry_shape["actor"],
+                    input=telemetry_input,
+                )
             result = await single_tool.tool_executor.execute(
                 agent_name=self.agent_name,
                 tool_args=single_tool.tool_args,
@@ -304,16 +340,19 @@ class ToolBatchRunner:
                 session_id=session_id,
             )
             if result.get("status") == "error":
-                await telemetry_recorder.emit_event(
-                    "tool_error",
-                    actor=TelemetryActor(
-                        type=ActorType.TOOL, name=single_tool.tool_name
-                    ),
-                    output=result,
-                    error={
+                event_kwargs = {
+                    "actor": telemetry_shape["actor"],
+                    "output": result,
+                    "error": {
                         "type": "ToolError",
                         "message": result.get("message") or "Tool returned error",
                     },
+                }
+                if telemetry_shape["single_event"]:
+                    event_kwargs["input"] = telemetry_input
+                await telemetry_recorder.emit_event(
+                    telemetry_shape["error_event"],
+                    **event_kwargs,
                 )
                 await telemetry_recorder.end_span(
                     span.span_id,
@@ -325,12 +364,12 @@ class ToolBatchRunner:
                     },
                 )
             else:
+                event_kwargs = {"actor": telemetry_shape["actor"], "output": result}
+                if telemetry_shape["single_event"]:
+                    event_kwargs["input"] = telemetry_input
                 await telemetry_recorder.emit_event(
-                    "tool_result",
-                    actor=TelemetryActor(
-                        type=ActorType.TOOL, name=single_tool.tool_name
-                    ),
-                    output=result,
+                    telemetry_shape["result_event"],
+                    **event_kwargs,
                 )
                 await telemetry_recorder.end_span(
                     span.span_id,
@@ -339,14 +378,71 @@ class ToolBatchRunner:
                 )
             return result
         except Exception as exc:
-            await telemetry_recorder.record_exception(
-                exc,
-                event_type="tool_error",
-                actor=TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
-            )
+            if telemetry_shape["single_event"]:
+                await telemetry_recorder.emit_event(
+                    telemetry_shape["error_event"],
+                    actor=telemetry_shape["actor"],
+                    input=telemetry_input,
+                    error={"type": exc.__class__.__name__, "message": str(exc)},
+                )
+            else:
+                await telemetry_recorder.record_exception(
+                    exc,
+                    event_type=telemetry_shape["error_event"],
+                    actor=telemetry_shape["actor"],
+                )
             await telemetry_recorder.end_span(
                 span.span_id,
                 status=SpanStatus.ERROR,
                 error={"type": exc.__class__.__name__, "message": str(exc)},
             )
             raise
+
+
+def _tool_telemetry_shape(single_tool: ToolCallResult) -> dict[str, Any]:
+    if single_tool.tool_provider == "mcp":
+        return {
+            "span_kind": "mcp.tool.call",
+            "call_event": "mcp_tool_call",
+            "result_event": "mcp_tool_result",
+            "error_event": "mcp_tool_error",
+            "single_event": False,
+            "actor": TelemetryActor(
+                type=ActorType.MCP_SERVER,
+                name=single_tool.tool_server or single_tool.tool_name,
+            ),
+        }
+    workspace_shape = _workspace_tool_telemetry_shape(single_tool.tool_name)
+    if workspace_shape is not None:
+        return workspace_shape
+    return {
+        "span_kind": "tool.call",
+        "call_event": "tool_call",
+        "result_event": "tool_result",
+        "error_event": "tool_error",
+        "single_event": False,
+        "actor": TelemetryActor(type=ActorType.TOOL, name=single_tool.tool_name),
+    }
+
+
+def _workspace_tool_telemetry_shape(tool_name: str) -> dict[str, Any] | None:
+    if not tool_name.startswith("workspace_file_"):
+        return None
+    operation = tool_name.removeprefix("workspace_file_")
+    if operation == "view":
+        span_kind = "workspace.read"
+        event = "workspace_read"
+    elif operation in {"delete", "clear"}:
+        span_kind = "workspace.delete"
+        event = "workspace_delete"
+    else:
+        span_kind = "workspace.write"
+        event = "workspace_write"
+    return {
+        "span_kind": span_kind,
+        "call_event": event,
+        "result_event": event,
+        "error_event": event,
+        "single_event": True,
+        "actor": TelemetryActor(type=ActorType.WORKSPACE, name=tool_name),
+    }

--- a/src/omnicoreagent/core/tools/tool_call_resolver.py
+++ b/src/omnicoreagent/core/tools/tool_call_resolver.py
@@ -59,6 +59,8 @@ class ToolCallResolver:
             tool_executor=ToolExecutor(tool_handler=mcp_tool_handler),
             tool_name=match.tool_name,
             tool_args=normalize_tool_args(action.parameters),
+            tool_provider="mcp",
+            tool_server=match.server_name,
         )
 
     def resolve_local_tool_action(
@@ -78,6 +80,7 @@ class ToolCallResolver:
             tool_executor=ToolExecutor(tool_handler=local_tool_handler),
             tool_name=local_tool_name,
             tool_args=normalize_tool_args(action.parameters),
+            tool_provider="local",
         )
 
     async def resolve_single_action(

--- a/src/omnicoreagent/core/types.py
+++ b/src/omnicoreagent/core/types.py
@@ -132,6 +132,8 @@ class ToolCallResult(SerializableRecord):
     tool_name: str
     tool_args: dict
     tool_call_id: str | None = None
+    tool_provider: str = "local"
+    tool_server: str | None = None
 
 
 @dataclass

--- a/src/omnicoreagent/serve/routes/runs.py
+++ b/src/omnicoreagent/serve/routes/runs.py
@@ -1,16 +1,19 @@
 """Agent run routes for OmniServe."""
 
 import asyncio
+from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from omnicoreagent.core.logging import logger
+from omnicoreagent.core.telemetry import TraceStatus
 
 from ..models import ErrorResponse, RunRequest, RunResponse
 from ..serialization import normalize_run_result
 from ..sse import run_agent_stream
 from ..state import get_agent, get_agent_name, get_config, resolve_session_id
+from ..telemetry import build_run_kwargs, finish_serve_trace, start_serve_trace
 
 
 def create_runs_router() -> APIRouter:
@@ -68,8 +71,22 @@ def create_runs_router() -> APIRouter:
             f"query_length={len(body.query)}"
         )
 
+        serve_trace = None
         try:
-            run_coro = agent.run(body.query, session_id=session_id)
+            run_id = f"run_{uuid4().hex}"
+            serve_trace = await start_serve_trace(
+                agent,
+                method="POST",
+                path="/run/sync",
+                session_id=session_id,
+                run_id=run_id,
+                query=body.query,
+                streaming=False,
+            )
+            run_coro = agent.run(
+                body.query,
+                **build_run_kwargs(agent, session_id=session_id, run_id=run_id),
+            )
             if config.request_timeout > 0:
                 result = await asyncio.wait_for(
                     run_coro,
@@ -78,14 +95,32 @@ def create_runs_router() -> APIRouter:
             else:
                 result = await run_coro
             normalized = normalize_run_result(result, agent_name=get_agent_name(agent))
+            normalized["run_id"] = normalized.get("run_id") or run_id
+            await finish_serve_trace(
+                serve_trace,
+                output={
+                    "status": "completed",
+                    "agent_trace_id": normalized.get("trace_id"),
+                },
+            )
             return RunResponse(session_id=session_id, **normalized)
         except asyncio.TimeoutError:
+            await finish_serve_trace(
+                serve_trace,
+                status=TraceStatus.TIMEOUT,
+                error={"type": "TimeoutError", "message": "Request timed out"},
+            )
             raise HTTPException(
                 status_code=504,
                 detail=f"Request timed out after {config.request_timeout} seconds",
             )
         except Exception as exc:
             logger.error(f"OmniServe: Run error - {exc}")
+            await finish_serve_trace(
+                serve_trace,
+                status=TraceStatus.FAILED,
+                error={"type": exc.__class__.__name__, "message": str(exc)},
+            )
             raise HTTPException(status_code=500, detail=str(exc))
 
     return router

--- a/src/omnicoreagent/serve/sse.py
+++ b/src/omnicoreagent/serve/sse.py
@@ -8,7 +8,7 @@ import asyncio
 import contextlib
 import json
 from dataclasses import dataclass
-from inspect import Parameter, isawaitable, signature
+from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 from uuid import uuid4
 
@@ -16,6 +16,7 @@ from omnicoreagent.core.logging import logger
 
 from .serialization import normalize_event, normalize_run_result
 from .state import get_agent_name
+from .telemetry import build_run_kwargs, finish_serve_trace, start_serve_trace
 
 if TYPE_CHECKING:
     from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent as AgentType
@@ -169,24 +170,10 @@ async def _run_agent_with_timeout(
     timeout_seconds: int | None,
     run_id: str,
 ) -> Any:
-    kwargs: dict[str, Any] = {"session_id": session_id}
-    try:
-        run_signature = signature(agent.run)
-        if _accepts_keyword(run_signature, "run_id"):
-            kwargs["run_id"] = run_id
-    except (TypeError, ValueError):
-        kwargs["run_id"] = run_id
-    run_coro = agent.run(query, **kwargs)
+    run_coro = agent.run(query, **build_run_kwargs(agent, session_id=session_id, run_id=run_id))
     if timeout_seconds and timeout_seconds > 0:
         return await asyncio.wait_for(run_coro, timeout=timeout_seconds)
     return await run_coro
-
-
-def _accepts_keyword(run_signature, name: str) -> bool:
-    return name in run_signature.parameters or any(
-        parameter.kind == Parameter.VAR_KEYWORD
-        for parameter in run_signature.parameters.values()
-    )
 
 
 async def _drain_event_queue(
@@ -240,8 +227,18 @@ async def run_agent_stream(
     next_event_task: asyncio.Task[Any] | None = None
     seen_event_ids: set[str] = set()
     run_id = f"run_{uuid4().hex}"
+    serve_trace = None
 
     try:
+        serve_trace = await start_serve_trace(
+            agent,
+            method="POST",
+            path="/run",
+            session_id=session_id,
+            run_id=run_id,
+            query=query,
+            streaming=True,
+        )
         cursor = await _get_telemetry_stream_cursor(agent, session_id)
         pump_task = asyncio.create_task(
             _pump_session_events(agent, session_id, event_queue, cursor, run_id)
@@ -327,6 +324,14 @@ async def run_agent_stream(
                 }
                 complete_payload["run_id"] = normalized.get("run_id") or run_id
 
+                await finish_serve_trace(
+                    serve_trace,
+                    output={
+                        "status": "completed",
+                        "agent_trace_id": complete_payload.get("trace_id"),
+                    },
+                )
+                serve_trace = None
                 yield format_sse_event(
                     "complete",
                     complete_payload,
@@ -349,6 +354,12 @@ async def run_agent_stream(
 
     except asyncio.TimeoutError:
         logger.error(f"OmniServe SSE: Agent run timed out after {timeout_seconds}s")
+        await finish_serve_trace(
+            serve_trace,
+            status="timeout",
+            error={"type": "TimeoutError", "message": "Request timed out"},
+        )
+        serve_trace = None
         yield format_sse_event(
             "error",
             {
@@ -360,6 +371,12 @@ async def run_agent_stream(
 
     except Exception as e:
         logger.error(f"OmniServe SSE: Agent run error: {e}")
+        await finish_serve_trace(
+            serve_trace,
+            status="failed",
+            error={"type": e.__class__.__name__, "message": str(e)},
+        )
+        serve_trace = None
         yield format_sse_event(
             "error",
             {
@@ -369,6 +386,12 @@ async def run_agent_stream(
             },
         )
     finally:
+        if serve_trace is not None:
+            await finish_serve_trace(
+                serve_trace,
+                status="cancelled",
+                error={"type": "CancelledError", "message": "SSE stream closed"},
+            )
         await _cancel_task(next_event_task)
         await _cancel_task(run_task)
         await _cancel_task(pump_task)

--- a/src/omnicoreagent/serve/telemetry.py
+++ b/src/omnicoreagent/serve/telemetry.py
@@ -1,0 +1,115 @@
+"""Telemetry helpers for OmniServe request boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from inspect import Parameter, Signature, signature
+from typing import Any
+
+from omnicoreagent.core.telemetry import (
+    AbstractTelemetryStore,
+    ActorType,
+    TelemetryActor,
+    TelemetryRecorder,
+    TraceStatus,
+)
+
+
+@dataclass
+class ServeTelemetryTrace:
+    recorder: TelemetryRecorder
+    trace_id: str
+
+
+def accepts_keyword(run_signature: Signature, name: str) -> bool:
+    return name in run_signature.parameters or any(
+        parameter.kind == Parameter.VAR_KEYWORD
+        for parameter in run_signature.parameters.values()
+    )
+
+
+def build_run_kwargs(agent: Any, *, session_id: str, run_id: str) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"session_id": session_id}
+    try:
+        run_signature = signature(agent.run)
+        if accepts_keyword(run_signature, "run_id"):
+            kwargs["run_id"] = run_id
+    except (TypeError, ValueError):
+        kwargs["run_id"] = run_id
+    return kwargs
+
+
+async def start_serve_trace(
+    agent: Any,
+    *,
+    method: str,
+    path: str,
+    session_id: str,
+    run_id: str,
+    query: str | None = None,
+    streaming: bool = False,
+) -> ServeTelemetryTrace | None:
+    store = _telemetry_store(agent)
+    if store is None:
+        return None
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        name="serve.request",
+        kind="serve.request",
+        actor=TelemetryActor(type=ActorType.SERVE, name="OmniServe"),
+        run_id=run_id,
+        session_id=session_id,
+        metadata={"tags": ["serve"]},
+        input={
+            "method": method,
+            "path": path,
+            "query_length": len(query or ""),
+            "streaming": streaming,
+        },
+    )
+    await recorder.emit_event(
+        "serve_request_start",
+        actor=TelemetryActor(type=ActorType.SERVE, name="OmniServe"),
+        input={"method": method, "path": path, "streaming": streaming},
+    )
+    return ServeTelemetryTrace(recorder=recorder, trace_id=context.trace_id)
+
+
+async def finish_serve_trace(
+    trace: ServeTelemetryTrace | None,
+    *,
+    status: TraceStatus | str = TraceStatus.COMPLETED,
+    output: dict[str, Any] | None = None,
+    error: dict[str, Any] | None = None,
+) -> None:
+    if trace is None:
+        return
+    event_type = "serve_request_error" if error else "serve_request_end"
+    await trace.recorder.emit_event(
+        event_type,
+        actor=TelemetryActor(type=ActorType.SERVE, name="OmniServe"),
+        output=output,
+        error=error,
+    )
+    await trace.recorder.end_trace(status=status, output=output, error=error)
+
+
+def _telemetry_store(agent: Any) -> Any | None:
+    ensure_telemetry = getattr(agent, "_ensure_telemetry", None)
+    if callable(ensure_telemetry):
+        ensure_telemetry()
+    store = getattr(agent, "telemetry_store", None)
+    if _is_telemetry_store(store):
+        return store
+    stream = getattr(agent, "telemetry_stream", None)
+    stream_store = getattr(stream, "store", None)
+    if _is_telemetry_store(stream_store):
+        return stream_store
+    fallback_store = getattr(agent, "store", None)
+    if _is_telemetry_store(fallback_store):
+        return fallback_store
+    return None
+
+
+def _is_telemetry_store(store: Any) -> bool:
+    return isinstance(store, AbstractTelemetryStore)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -10,6 +10,12 @@ from omnicoreagent.core.runtime.harness_tools import (
 )
 from omnicoreagent.core.runtime import builder, execution
 from omnicoreagent.core.runtime.normalization import normalize_local_tools
+from omnicoreagent.core.telemetry import (
+    ActorType,
+    InMemoryTelemetryStore,
+    TelemetryActor,
+    TelemetryRecorder,
+)
 from omnicoreagent.core.runtime.summaries import extract_summary_text, render_history
 from omnicoreagent.core.tools.local_tools_registry import Tool
 
@@ -217,35 +223,49 @@ def test_build_agent_runtime_wires_components(monkeypatch):
     }
 
 
-def test_blocked_guardrail_response_returns_none_without_guardrail():
-    assert (
-        execution.blocked_guardrail_response(
-            guardrail=None,
-            query="hello",
-            session_id="session",
-            agent_name="agent",
-        )
-        is None
+@pytest.mark.asyncio
+async def test_blocked_guardrail_response_returns_none_without_guardrail():
+    response = await execution.blocked_guardrail_response(
+        guardrail=None,
+        query="hello",
+        session_id="session",
+        agent_name="agent",
     )
 
+    assert response is None
 
-def test_blocked_guardrail_response_returns_none_for_safe_input():
+
+@pytest.mark.asyncio
+async def test_blocked_guardrail_response_returns_none_for_safe_input():
     guardrail = SimpleNamespace(
         check=lambda query: SimpleNamespace(is_safe=True, message="", to_dict=dict)
     )
-
-    assert (
-        execution.blocked_guardrail_response(
-            guardrail=guardrail,
-            query="hello",
-            session_id="session",
-            agent_name="agent",
-        )
-        is None
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-guardrail-safe",
+        run_id="run-guardrail-safe",
+        session_id="session",
+        actor=TelemetryActor(type=ActorType.AGENT, name="agent"),
     )
 
+    response = await execution.blocked_guardrail_response(
+        guardrail=guardrail,
+        query="hello",
+        session_id="session",
+        agent_name="agent",
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace()
 
-def test_blocked_guardrail_response_formats_unsafe_input():
+    trace = await store.get_trace(context.trace_id)
+    assert response is None
+    assert [event.event_type for event in trace.events] == ["guardrail_check"]
+    assert trace.events[0].actor.type == ActorType.GUARDRAIL
+
+
+@pytest.mark.asyncio
+async def test_blocked_guardrail_response_formats_unsafe_input():
     result = SimpleNamespace(
         is_safe=False,
         message="unsafe",
@@ -253,7 +273,7 @@ def test_blocked_guardrail_response_formats_unsafe_input():
     )
     guardrail = SimpleNamespace(check=lambda query: result)
 
-    response = execution.blocked_guardrail_response(
+    response = await execution.blocked_guardrail_response(
         guardrail=guardrail,
         query="bad",
         session_id="session",

--- a/tests/test_llm_step.py
+++ b/tests/test_llm_step.py
@@ -6,6 +6,12 @@ import pytest
 
 from omnicoreagent.core.agents import llm_step
 from omnicoreagent.core.agents.llm_step import AgentLlmStepRunner
+from omnicoreagent.core.telemetry import (
+    ActorType,
+    InMemoryTelemetryStore,
+    TelemetryActor,
+    TelemetryRecorder,
+)
 from omnicoreagent.core.token_usage import Usage, UsageLimits
 from omnicoreagent.core.types import AgentState, Message, SessionState
 from omnicoreagent.core.agents.loop_detection import RobustLoopDetector
@@ -33,6 +39,9 @@ class TriggeringContextManager:
     async def manage_context(self, *, messages, summarize_fn):
         summary = await summarize_fn(messages)
         return [Message(role="system", content=summary)]
+
+    def get_stats(self):
+        return {"compressions": 1}
 
 
 def make_runner(context_manager=None, *, limits_enabled=False, request_limit=0):
@@ -102,6 +111,49 @@ async def test_llm_step_manages_context_before_model_call(monkeypatch):
     assert result.response == "<final_answer>done</final_answer>"
     assert session_state.messages == [Message(role="system", content="summary")]
     assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_llm_step_records_context_compression_telemetry(monkeypatch):
+    monkeypatch.setattr(llm_step, "usage", Usage())
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-context-compression",
+        run_id="run-context-compression",
+        session_id="chat-context",
+        actor=TelemetryActor(type=ActorType.AGENT, name="agent"),
+    )
+
+    class LlmConnection:
+        async def llm_call(self, messages):
+            if isinstance(messages[0], dict):
+                return "summary"
+            return "<final_answer>done</final_answer>"
+
+    session_state = make_session_state()
+    result = await make_runner(TriggeringContextManager()).run(
+        session_state=session_state,
+        llm_connection=LlmConnection(),
+        run_usage=Usage(),
+        session_id="chat-context",
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace()
+
+    trace = await store.get_trace(context.trace_id)
+    assert result.response == "<final_answer>done</final_answer>"
+    assert session_state.messages == [Message(role="system", content="summary")]
+    assert {span.kind for span in trace.spans} >= {
+        "context.compression",
+        "model.call",
+    }
+    event = next(
+        event for event in trace.events if event.event_type == "context_compression"
+    )
+    assert event.input == {"message_count": 1}
+    assert event.output["message_count"] == 1
+    assert event.output["stats"] == {"compressions": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -801,6 +801,23 @@ class TestEndpoints:
         assert data["response"] == "Agent response"
         assert data["agent_name"] == "EndpointTestAgent"
 
+    def test_sync_run_records_serve_request_trace(self, server_client):
+        resp = server_client.post("/run/sync", json={"query": "Hello"})
+
+        assert resp.status_code == 200
+        traces = asyncio.run(server_client.app.state.agent.telemetry_store.list_traces())
+        serve_trace = next(
+            trace
+            for trace in traces
+            if any(span.kind == "serve.request" for span in trace.spans)
+        )
+        assert serve_trace.session_id == "test-endpoint-session"
+        assert serve_trace.run_id == resp.json()["run_id"]
+        assert [event.event_type for event in serve_trace.events] == [
+            "serve_request_start",
+            "serve_request_end",
+        ]
+
     def test_metrics_endpoint(self, server_client):
         resp = server_client.get("/metrics")
         assert resp.status_code == 200
@@ -852,14 +869,37 @@ class TestEndpoints:
         resp = client.post("/run/sync", json={"query": "Hello"})
 
         assert resp.status_code == 200
-        assert resp.json() == {
+        data = resp.json()
+        assert data["run_id"].startswith("run_")
+        assert data == {
             "response": "plain response",
             "session_id": "string-session",
             "agent_name": "StringAgent",
             "metric": None,
             "trace_id": None,
-            "run_id": None,
+            "run_id": data["run_id"],
         }
+
+    def test_sync_run_ignores_non_telemetry_business_store(self):
+        class LightweightAgent:
+            name = "BusinessStoreAgent"
+
+            def __init__(self):
+                self.store = {"business": "state"}
+
+            def generate_session_id(self):
+                return "business-store-session"
+
+            async def run(self, query, *, session_id):
+                return {"response": f"ok:{query}", "session_id": session_id}
+
+        server = OmniServe(agent=LightweightAgent(), config=OmniServeConfig())
+        client = TestClient(server.app)
+
+        resp = client.post("/run/sync", json={"query": "Hello"})
+
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "ok:Hello"
 
     def test_request_timeout_is_enforced_for_sync_run(self):
         agent = MagicMock(spec=OmniCoreAgent)

--- a/tests/test_omniserve_sse.py
+++ b/tests/test_omniserve_sse.py
@@ -10,6 +10,7 @@ from omnicoreagent.core.telemetry import (
     TelemetryConfig,
     TelemetryRecorder,
     TelemetryStream,
+    TraceStatus,
 )
 from omnicoreagent.serve.sse import run_agent_stream, stream_session_events
 
@@ -113,10 +114,11 @@ class _NoRunIdAgent:
 
 @pytest.mark.asyncio
 async def test_run_agent_stream_yields_telemetry_before_complete():
+    agent = _TelemetryAgent()
     chunks = [
         chunk
         async for chunk in run_agent_stream(
-            _TelemetryAgent(),
+            agent,
             "hello",
             "session-a",
             timeout_seconds=1,
@@ -135,6 +137,46 @@ async def test_run_agent_stream_yields_telemetry_before_complete():
     assert event_names.index("final_answer") < event_names.index("complete")
     assert _event_data(chunks[1])["session_id"] == "session-a"
     assert _event_data(chunks[3])["response"] == "done:hello"
+
+    traces = await agent.store.list_traces()
+    serve_trace = next(
+        trace for trace in traces if any(span.kind == "serve.request" for span in trace.spans)
+    )
+    assert serve_trace.run_id == _event_data(chunks[3])["run_id"]
+    assert [event.event_type for event in serve_trace.events] == [
+        "serve_request_start",
+        "serve_request_end",
+    ]
+    assert serve_trace.events[-1].output["agent_trace_id"] == _event_data(chunks[3])[
+        "trace_id"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_stream_finishes_serve_trace_before_terminal_chunk_close():
+    agent = _TelemetryAgent()
+    stream = run_agent_stream(
+        agent,
+        "hello",
+        "session-close-after-complete",
+        timeout_seconds=1,
+    )
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+        if _event_name(chunk) == "complete":
+            break
+    await stream.aclose()
+
+    traces = await agent.store.list_traces()
+    serve_trace = next(
+        trace for trace in traces if any(span.kind == "serve.request" for span in trace.spans)
+    )
+    assert serve_trace.status == TraceStatus.COMPLETED
+    assert [event.event_type for event in serve_trace.events] == [
+        "serve_request_start",
+        "serve_request_end",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_telemetry_wiring.py
+++ b/tests/test_runtime_telemetry_wiring.py
@@ -148,10 +148,12 @@ async def test_run_records_guardrail_block_as_aborted_trace() -> None:
     assert trace.status == TraceStatus.ABORTED_SAFETY_GUARD
     assert [event.event_type for event in trace.events] == [
         "user_message",
+        "guardrail_check",
         "guardrail_violation",
         "final_answer",
     ]
     assert trace.events[1].output == {"is_safe": False, "message": "blocked"}
+    assert trace.events[2].output == {"is_safe": False, "message": "blocked"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_subagent_runner.py
+++ b/tests/test_subagent_runner.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -22,10 +23,18 @@ class FakeAgent:
 
     async def run(self, task=None, session_id=None):
         self.kwargs = {"task": task, "session_id": session_id}
+        if isinstance(self.result, Exception):
+            raise self.result
         return self.result
 
     async def cleanup_mcp_servers(self):
         self.cleaned = True
+
+
+class CancellingAgent(FakeAgent):
+    async def run(self, task=None, session_id=None):
+        self.kwargs = {"task": task, "session_id": session_id}
+        raise asyncio.CancelledError
 
 
 def _session_state():
@@ -78,6 +87,11 @@ async def test_subagent_runner_records_successful_outputs():
         "subagent_spawn",
         "subagent_result",
     ]
+    subagent_spans = [span for span in trace.spans if span.kind == "subagent.run"]
+    assert len(subagent_spans) == 1
+    assert subagent_spans[0].status == "ok"
+    assert trace.events[0].span_id == subagent_spans[0].span_id
+    assert trace.events[1].span_id == subagent_spans[0].span_id
     assert len(state.messages) == 2
 
 
@@ -111,11 +125,51 @@ async def test_subagent_runner_returns_error_observation_for_failed_agent():
     await recorder.end_trace()
 
     assert "boom" in history[-1]["content"]
+    assert failing_agent.cleaned is True
     trace = await store.get_trace(context.trace_id)
     assert [event.event_type for event in trace.events] == [
         "subagent_spawn",
         "subagent_error",
     ]
+    subagent_spans = [span for span in trace.spans if span.kind == "subagent.run"]
+    assert len(subagent_spans) == 1
+    assert subagent_spans[0].status == "error"
+    assert subagent_spans[0].error.message == "boom"
+    assert trace.events[0].span_id == subagent_spans[0].span_id
+    assert trace.events[1].span_id == subagent_spans[0].span_id
+
+
+@pytest.mark.asyncio
+async def test_subagent_runner_cleans_up_cancelled_agent():
+    runner = SubAgentCallRunner(agent_name="parent")
+    cancelling_agent = CancellingAgent("worker", None)
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-subagent-cancelled",
+        run_id="run-subagent-cancelled",
+        session_id="s1",
+        actor=TelemetryActor(type="agent", name="parent"),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._execute_single_agent(
+            {"agent": "worker", "parameters": {"task": "stop"}},
+            [cancelling_agent],
+            "s1",
+            telemetry_recorder=recorder,
+        )
+    await recorder.end_trace(status="cancelled")
+
+    trace = await store.get_trace(context.trace_id)
+    subagent_span = next(span for span in trace.spans if span.kind == "subagent.run")
+    assert cancelling_agent.cleaned is True
+    assert subagent_span.status == "cancelled"
+    assert [event.event_type for event in trace.events] == [
+        "subagent_spawn",
+        "subagent_error",
+    ]
+    assert all(event.span_id == subagent_span.span_id for event in trace.events)
 
 
 def test_subagent_runner_extracts_result_output():

--- a/tests/test_tool_batch_runner.py
+++ b/tests/test_tool_batch_runner.py
@@ -1,6 +1,13 @@
 import pytest
 import asyncio
 
+from omnicoreagent.core.telemetry import (
+    ActorType,
+    InMemoryTelemetryStore,
+    TelemetryConfig,
+    TelemetryActor,
+    TelemetryRecorder,
+)
 from omnicoreagent.core.tools.tool_batch_runner import (
     TOOL_CALL_TIMEOUT_MESSAGE,
     ToolBatchRunner,
@@ -277,3 +284,203 @@ async def test_execute_timeout_records_error_for_each_tool(session_state):
     assert obs_text == TOOL_CALL_TIMEOUT_MESSAGE
     assert [result["status"] for result in tools_results] == ["error", "error"]
     assert [item["metadata"]["tool"] for item in history] == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_execute_records_mcp_workspace_and_observation_telemetry(
+    runner, session_state
+):
+    history = []
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-tool-batch-shapes",
+        run_id="run-tool-batch-shapes",
+        session_id="chat800",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            await add_message_to_history(
+                role="tool",
+                content=f"{tool_name}:ok",
+                metadata={
+                    "tool_call_id": tool_call_id,
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "agent_name": agent_name,
+                },
+                session_id=session_id,
+            )
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": f"{tool_name}:ok",
+                "message": None,
+            }
+
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=FakeExecutor(),
+            tool_name="search_docs",
+            tool_args={"query": "telemetry"},
+            tool_call_id="tool-call-mcp",
+            tool_provider="mcp",
+            tool_server="docs-server",
+        ),
+        ToolCallResult(
+            tool_executor=FakeExecutor(),
+            tool_name="workspace_file_view",
+            tool_args={"path": "notes.md"},
+            tool_call_id="tool-call-workspace",
+        ),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return "[TOOL RESPONSE OFFLOADED] workspace://tool-output"
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat800",
+        tool_batch_name="search_docs, workspace_file_view",
+        tool_batch_args=[{"query": "telemetry"}, {"path": "notes.md"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace()
+
+    trace = await store.get_trace(context.trace_id)
+    assert obs_text == "[TOOL RESPONSE OFFLOADED] workspace://tool-output"
+    assert [result["tool_name"] for result in tools_results] == [
+        "search_docs",
+        "workspace_file_view",
+    ]
+    assert {span.kind for span in trace.spans} >= {
+        "tool.batch",
+        "mcp.tool.call",
+        "workspace.read",
+    }
+    assert {event.event_type for event in trace.events} >= {
+        "tool_batch_start",
+        "mcp_tool_call",
+        "mcp_tool_result",
+        "workspace_read",
+        "observation_pipeline_start",
+        "observation_pipeline_end",
+        "workspace_offload",
+        "tool_batch_end",
+    }
+    assert [event.event_type for event in trace.events].count("workspace_read") == 1
+    mcp_call = next(event for event in trace.events if event.event_type == "mcp_tool_call")
+    assert mcp_call.actor.type == ActorType.MCP_SERVER
+    assert mcp_call.actor.name == "docs-server"
+
+
+@pytest.mark.asyncio
+async def test_workspace_tool_telemetry_respects_tool_result_suppression(
+    runner, session_state
+):
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store, TelemetryConfig(record_tool_results=False))
+    context = await recorder.start_trace(
+        trace_id="trace-workspace-redaction",
+        run_id="run-workspace-redaction",
+        session_id="chat801",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            await add_message_to_history(
+                role="tool",
+                content="secret file contents",
+                metadata={
+                    "tool_call_id": tool_call_id,
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "agent_name": agent_name,
+                },
+                session_id=session_id,
+            )
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": "secret file contents",
+                "message": None,
+            }
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return "workspace observation"
+
+    await runner.execute(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=FakeExecutor(),
+                tool_name="workspace_file_view",
+                tool_args={"path": "notes.md"},
+                tool_call_id="tool-call-workspace-redacted",
+            )
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat801",
+        tool_batch_name="workspace_file_view",
+        tool_batch_args=[{"path": "notes.md"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace()
+
+    trace = await store.get_trace(context.trace_id)
+    workspace_span = next(span for span in trace.spans if span.kind == "workspace.read")
+    workspace_event = next(
+        event for event in trace.events if event.event_type == "workspace_read"
+    )
+    assert workspace_span.output is None
+    assert workspace_event.output is None


### PR DESCRIPTION
## Summary
- add telemetry spans/events for context compression, memory read/write, MCP and workspace tools, observation pipeline, workspace offload, subagent execution, guardrail checks, and OmniServe run boundaries
- add OmniServe serve.request telemetry helpers with safe store detection and run_id correlation for sync/SSE requests
- align internal telemetry architecture/spec docs with the current telemetry-owned streaming path and removed event-router direction
- add regression coverage for SSE terminal close behavior, non-telemetry business stores, workspace payload suppression, subagent span correlation, cancellation cleanup, and tool classification

## Verification
- uv run ruff check .
- uv run python -m compileall -q src/omnicoreagent tests
- git diff --check
- uv run pytest -q  # 747 passed, 8 skipped

## Reviewer Pass
- Spawned three read-only reviewer/QA/DX agents. Addressed findings around SSE terminal trace finalization, non-telemetry agent.store handling, workspace result redaction, subagent span event correlation, cleanup failures, and cancellation cleanup.