### PR TITLE
Harden telemetry runtime coverage

### DIFF
--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -201,7 +201,7 @@ the run workspace `events.jsonl` file for durable replay and debugging.
 
 ## OmniServe Endpoints
 
-OmniServe exposes the same background task lifecycle over HTTP:
+OmniServe exposes the same background run lifecycle over HTTP:
 
 ```bash
 curl -X POST http://localhost:8000/background/tasks \

--- a/docs/how-to-guides/observability.mdx
+++ b/docs/how-to-guides/observability.mdx
@@ -43,7 +43,7 @@ tracing service.
 ## Telemetry Events
 
 OmniCoreAgent emits typed telemetry events for user messages, tool calls, tool
-results, final answers, subagent calls, and background task lifecycle changes.
+results, final answers, subagent calls, and background run lifecycle changes.
 Use events when you need a live UI, session debugging, or a lightweight
 execution record.
 

--- a/engineering/architecture/background-agents.md
+++ b/engineering/architecture/background-agents.md
@@ -187,7 +187,7 @@ Responsibilities:
 - keep the process-local event cache
 - persist lifecycle events to workspace `events.jsonl`
 - write run snapshots to workspace `run.json`
-- append lifecycle events into telemetry stream
+- append normalized lifecycle evidence into `TelemetryStore`
 - replay the strongest complete event source for a run
 - tolerate workspace or telemetry visibility failures without blocking task
   execution

--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -11,6 +11,9 @@ Evaluation system.
 Live streaming and replay are required harness capabilities. They are served
 from telemetry: `TelemetryRecorder` writes evidence, `TelemetryStore` holds the
 trace records, and `TelemetryStream` is the live/replay adapter over that store.
+Background run lifecycle evidence is the one runtime adapter exception:
+`BackgroundEventLog` writes normalized background events and spans directly to
+`TelemetryStore` because it owns background event ordering and workspace mirrors.
 
 ## Purpose
 
@@ -34,6 +37,10 @@ runtime execution
   -> telemetry store
        -> telemetry stream -> OmniServe SSE / live clients
        -> trace normalizer -> future observability / future evaluation / future exporters
+
+background event log
+  -> telemetry store
+       -> telemetry stream -> OmniServe SSE / live clients
 ```
 
 ## Non-Goals
@@ -209,9 +216,13 @@ The runtime loop instrumentation phase provides:
   the model sees formatted observations
 - workspace offload events when large tool results are replaced by workspace
   references
+- artifact read/tail/search/list tools recorded as workspace reads because
+  offloaded artifacts live inside the workspace artifacts namespace
 - subagent execution spans with `subagent_spawn`, `subagent_result`, and
   `subagent_error` events
-- background task/run lifecycle spans and events
+- usage-limit halts as `runtime.control` spans and `resource_guard_halt` events
+- background run lifecycle spans and events, including workspace writes for
+  run snapshots and event-log appends
 - OmniServe `serve.request` traces/events for synchronous and SSE run
   boundaries, correlated to the same `session_id` and `run_id` as the agent run
 
@@ -490,7 +501,9 @@ the subset of telemetry events needed by clients.
 Background agents already persist lifecycle events, run ids, attempts,
 workspace paths, and heartbeat records.
 
-Telemetry should unify these facts into the trace model:
+Telemetry should unify these facts into the trace model. Current runtime
+coverage emits `background.run`; `background.task` is reserved for task-level
+schedule/config telemetry when that layer is wired.
 
 - `background.task`
 - `background.run`

--- a/engineering/specifications/background-agents.md
+++ b/engineering/specifications/background-agents.md
@@ -992,8 +992,9 @@ Common payload fields:
 
 Run-scoped events are always captured in the manager process cache. When
 workspace event mirroring is enabled, they are also appended to the run
-workspace `events.jsonl` file. When an telemetry stream is configured, the manager
-mirrors events to it on a best-effort bounded path.
+workspace `events.jsonl` file. The background event-log adapter also writes
+normalized lifecycle evidence to `TelemetryStore` on a best-effort bounded path;
+`TelemetryStream` serves live and replay clients over that store.
 
 Every background event includes `run_id` for run-scoped events. Telemetry and
 workspace replay must filter by `run_id` when returning a run trace.
@@ -1011,8 +1012,8 @@ Selection rules:
   `background_run_timeout`, `background_run_cancelled`, or
   `background_run_skipped`.
 - If one or more complete sources exist, return the longest complete trace.
-- If no complete source exists, prefer telemetry stream, then process cache, then
-  workspace mirror.
+- If no complete source exists, prefer the process cache, then the workspace
+  mirror.
 - Returned events must be ordered by `sequence`, then `timestamp`.
 - Sources with missing, non-positive, malformed, or duplicate run-local
   `sequence` values are ignored during replay selection. A valid replay source
@@ -1147,7 +1148,7 @@ Run the same contract tests against every backend:
 - cancels run
 - lists runs
 - lists attempts
-- reads run events from telemetry stream or workspace mirror
+- reads run events from the process cache or workspace mirror
 - shuts down scheduler and workers
 - does not import optional scheduler/storage dependencies during root import
 - does not import optional scheduler/storage dependencies during

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -576,7 +576,7 @@ Telemetry must eventually capture:
 - context compression and dropped/restored fields
 - workspace reads/writes/offloads
 - subagent spawn/result/error
-- background task/run lifecycle and heartbeat
+- background run lifecycle and heartbeat
 - OmniServe request start/end/error
 - final answer
 - final state when available
@@ -634,9 +634,14 @@ Current runtime loop coverage:
 - parsed tool observations emit `observation_pipeline_start`,
   `observation_pipeline_end`, and `observation_pipeline_error` events.
 - workspace offloading emits `workspace_offload`.
+- artifact access tools (`read_artifact`, `tail_artifact`, `search_artifact`,
+  `list_artifacts`) are recorded as workspace reads because artifacts live in
+  the workspace artifacts namespace.
 - dynamic subagent execution creates `subagent.run` spans and emits
   `subagent_spawn`, `subagent_result`, and `subagent_error` events.
-- background task/run lifecycle emits background spans and events.
+- usage-limit halts emit `resource_guard_halt` and a `runtime.control` span.
+- background run lifecycle emits `background.run` spans and events. Background
+  run workspace snapshots and event-log appends emit `workspace_write` events.
 - OmniServe synchronous and SSE run boundaries create `serve.request` traces and
   emit `serve_request_start`, `serve_request_end`, and `serve_request_error`
   events. Serve traces are correlated to agent traces by `session_id` and
@@ -644,10 +649,9 @@ Current runtime loop coverage:
 
 Current remaining runtime internals:
 
-- direct workspace storage internals outside workspace file tools and offload
-- artifact-specific read/tail/search operations that still appear as generic
-  tools until artifact telemetry is specified
-- approval/resource guard telemetry paths that are reserved but not fully wired
+- direct workspace storage internals outside workspace file tools, artifact
+  tools, offload, and background run workspace writes
+- approval telemetry paths that are reserved but not fully wired
 - cross-trace links between `serve.request`, background runs, subagents, and
   agent traces
 - durable telemetry stores beyond in-memory and JSONL
@@ -661,6 +665,11 @@ Runtime evidence has one canonical ownership path:
 ```text
 TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
 ```
+
+Background run lifecycle events are emitted by the background event-log adapter
+directly into `TelemetryStore`. That adapter is the runtime boundary that already
+owns background event ordering and workspace mirrors; it must still write the
+same normalized telemetry models and feed the same `TelemetryStream` path.
 
 There must not be a parallel event stack:
 
@@ -687,10 +696,11 @@ Canonical event mapping:
 | memory history read | `memory_read` | `memory.read` |
 | memory history write | `memory_write` | `memory.write` |
 | context compressed | `context_compression` | `context.compression` |
-| observation formatted | `observation_pipeline_end` | `tool.batch` |
+| observation formatted | `observation_pipeline_end` | `observation.pipeline` |
 | workspace file read | `workspace_read` | `workspace.read` |
 | workspace file write | `workspace_write` | `workspace.write` |
 | workspace file delete | `workspace_delete` | `workspace.delete` |
+| background workspace persistence | `workspace_write` | `background.run` |
 | subagent starts | `subagent_spawn` | `subagent.run` |
 | subagent completes | `subagent_result` | `subagent.run` |
 | serve request starts | `serve_request_start` | `serve.request` |

--- a/src/omnicoreagent/background/event_log.py
+++ b/src/omnicoreagent/background/event_log.py
@@ -53,6 +53,13 @@ class BackgroundEventLog:
     async def emit_run(
         self, event_name: str, run: BackgroundRun, **extra_payload: Any
     ) -> None:
+        snapshot_written_before_terminal = False
+        if event_name in TERMINAL_EVENT_NAMES:
+            try:
+                await self.write_run_snapshot(run)
+                snapshot_written_before_terminal = True
+            except Exception:
+                pass
         try:
             await self.emit(
                 event_name,
@@ -75,7 +82,10 @@ class BackgroundEventLog:
             )
         except Exception:
             pass
-        if event_name != "background_run_heartbeat":
+        if (
+            event_name != "background_run_heartbeat"
+            and not snapshot_written_before_terminal
+        ):
             try:
                 await self.write_run_snapshot(run)
             except Exception:
@@ -96,6 +106,18 @@ class BackgroundEventLog:
             run_id, event_name, events
         )
         events.append(event)
+        if event_name in TERMINAL_EVENT_NAMES:
+            pending_events_drained = await self.drain_event_tasks(
+                run_id, cancel_on_timeout=True
+            )
+            if pending_events_drained:
+                try:
+                    await self.write_run_event(event)
+                except Exception:
+                    pass
+            await self.append_telemetry_event(event_name, event)
+            return
+
         await self.append_telemetry_event(event_name, event)
         if event_name in INITIAL_EVENT_NAMES:
             try:
@@ -131,7 +153,9 @@ class BackgroundEventLog:
         self.event_tasks.add(task)
         task.add_done_callback(self.event_tasks.discard)
 
-    async def drain_event_tasks(self, run_id: str) -> None:
+    async def drain_event_tasks(
+        self, run_id: str, *, cancel_on_timeout: bool = False
+    ) -> bool:
         pending = [
             task
             for task in self.event_tasks
@@ -139,14 +163,19 @@ class BackgroundEventLog:
             and getattr(task, "_omnicoreagent_run_id", None) == run_id
         ]
         if not pending:
-            return
+            return True
         try:
             await asyncio.wait_for(
                 asyncio.shield(asyncio.gather(*pending, return_exceptions=True)),
                 timeout=self.replay_timeout_seconds,
             )
         except asyncio.TimeoutError:
-            return
+            if cancel_on_timeout:
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+            return False
+        return True
 
     async def cancel_event_tasks(self) -> None:
         pending = [task for task in self.event_tasks if not task.done()]
@@ -194,6 +223,12 @@ class BackgroundEventLog:
         if task and not task.workspace_policy.write_run_json:
             return
         self.workspace_io.write_run_snapshot(run)
+        await self.append_workspace_telemetry_event(
+            run=run,
+            event_type="workspace_write",
+            path=f"{run.workspace_path}/run.json",
+            operation="background_run_snapshot",
+        )
 
     async def write_run_event(self, event: dict[str, Any]) -> None:
         task_id = event.get("task_id")
@@ -202,6 +237,15 @@ class BackgroundEventLog:
             if task and not task.workspace_policy.write_events_jsonl:
                 return
         self.workspace_io.append_event(event)
+        run_id = event.get("run_id")
+        run = await self.task_store.get_run(run_id) if run_id else None
+        if run is not None:
+            await self.append_workspace_telemetry_event(
+                run=run,
+                event_type="workspace_write",
+                path=f"{run.workspace_path}/events.jsonl",
+                operation="background_run_event",
+            )
 
     async def append_telemetry_event(
         self,
@@ -217,6 +261,73 @@ class BackgroundEventLog:
             )
         except Exception:
             return
+
+    async def append_workspace_telemetry_event(
+        self,
+        *,
+        run: BackgroundRun,
+        event_type: str,
+        path: str,
+        operation: str,
+    ) -> None:
+        if self.telemetry_store is None:
+            return
+        try:
+            await asyncio.wait_for(
+                self._append_workspace_telemetry_event(
+                    run=run,
+                    event_type=event_type,
+                    path=path,
+                    operation=operation,
+                ),
+                timeout=self.append_timeout_seconds,
+            )
+        except Exception:
+            return
+
+    async def _append_workspace_telemetry_event(
+        self,
+        *,
+        run: BackgroundRun,
+        event_type: str,
+        path: str,
+        operation: str,
+    ) -> None:
+        if self.telemetry_store is None:
+            return
+        trace_id = self._telemetry_trace_id(run.run_id)
+        span_id = self._telemetry_span_id(run.run_id)
+        await self._ensure_telemetry_trace(
+            trace_id,
+            span_id,
+            {
+                "run_id": run.run_id,
+                "session_id": run.session_id,
+                "task_id": run.task_id,
+                "agent_id": run.agent_id,
+                "workspace_path": run.workspace_path,
+                "status": run.status.value,
+                "attempt": run.attempt,
+            },
+        )
+        await self.telemetry_store.append_event(
+            trace_id,
+            TelemetryEvent(
+                trace_id=trace_id,
+                span_id=span_id,
+                event_type=event_type,
+                actor=TelemetryActor(type=ActorType.WORKSPACE),
+                output={"path": path, "operation": operation},
+                metadata={
+                    "run_id": run.run_id,
+                    "session_id": run.session_id,
+                    "task_id": run.task_id,
+                    "agent_id": run.agent_id,
+                    "workspace_path": run.workspace_path,
+                    "operation": operation,
+                },
+            ),
+        )
 
     async def _append_telemetry_event(
         self,

--- a/src/omnicoreagent/core/agents/llm_step.py
+++ b/src/omnicoreagent/core/agents/llm_step.py
@@ -7,7 +7,7 @@ from omnicoreagent.core.agents.llm_response import (
     extract_response_content,
     extract_response_usage,
 )
-from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor
+from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor, TraceStatus
 from omnicoreagent.core.system_prompts import FAST_CONVERSATION_SUMMARY_PROMPT
 from omnicoreagent.core.token_usage import (
     Usage,
@@ -138,8 +138,18 @@ class AgentLlmStepRunner:
         except UsageLimitExceeded as e:
             error_message = f"Usage limit error: {e}"
             logger.error(error_message)
+            if telemetry_recorder is not None:
+                await self._record_resource_guard_halt(
+                    telemetry_recorder=telemetry_recorder,
+                    error_message=error_message,
+                    run_usage=run_usage,
+                )
             return AgentLlmStepResult(
-                error_result={"answer": error_message, "usage": run_usage}
+                error_result={
+                    "answer": error_message,
+                    "usage": run_usage,
+                    "_trace_status": TraceStatus.ABORTED_RESOURCE_GUARD.value,
+                }
             )
 
         except Exception as e:
@@ -222,6 +232,37 @@ class AgentLlmStepRunner:
             return extract_response_content(response, default="")
 
         return summarize_for_context
+
+    async def _record_resource_guard_halt(
+        self,
+        *,
+        telemetry_recorder: Any,
+        error_message: str,
+        run_usage: Usage,
+    ) -> None:
+        span = await telemetry_recorder.start_span(
+            name="runtime.control",
+            kind="runtime.control",
+            actor=TelemetryActor(type=ActorType.SYSTEM),
+            input={
+                "control": "usage_limit",
+                "usage": self._usage_payload(run_usage),
+            },
+        )
+        await telemetry_recorder.emit_event(
+            "resource_guard_halt",
+            actor=TelemetryActor(type=ActorType.SYSTEM),
+            input={
+                "control": "usage_limit",
+                "usage": self._usage_payload(run_usage),
+            },
+            error={"type": "UsageLimitExceeded", "message": error_message},
+        )
+        await telemetry_recorder.end_span(
+            span.span_id,
+            status=SpanStatus.ERROR,
+            error={"type": "UsageLimitExceeded", "message": error_message},
+        )
 
     async def _record_response(
         self,

--- a/src/omnicoreagent/core/runtime/execution.py
+++ b/src/omnicoreagent/core/runtime/execution.py
@@ -70,11 +70,14 @@ def format_run_response(
     if isinstance(response, dict) and "usage" in response:
         usage = response["usage"]
         usage_getter().incr(usage)
-        return {
+        normalized = {
             "response": response["answer"],
             "session_id": session_id,
             "agent_name": agent_name,
             "metric": usage,
         }
+        if response.get("_trace_status"):
+            normalized["_trace_status"] = response["_trace_status"]
+        return normalized
 
     return {"response": response, "session_id": session_id, "agent_name": agent_name}

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -348,13 +348,16 @@ class OmniCoreAgent:
                 agent_name=self.name,
                 usage_getter=self._usage,
             )
+            trace_status = TraceStatus(
+                formatted_response.pop("_trace_status", TraceStatus.COMPLETED.value)
+            )
             await self.telemetry_recorder.emit_event(
                 "final_answer",
                 actor=self._telemetry_actor(),
                 output={"response": formatted_response.get("response")},
             )
             await self.telemetry_recorder.end_trace(
-                status=TraceStatus.COMPLETED,
+                status=trace_status,
                 output={"response": formatted_response.get("response")},
             )
             formatted_response["trace_id"] = trace_context.trace_id

--- a/src/omnicoreagent/core/telemetry/recorder.py
+++ b/src/omnicoreagent/core/telemetry/recorder.py
@@ -375,11 +375,14 @@ class TelemetryRecorder:
                 "workspace.read",
                 "workspace.write",
                 "workspace.delete",
+                "observation.pipeline",
+                "tool.batch",
                 "tool_result",
                 "mcp_tool_result",
                 "workspace_read",
                 "workspace_write",
                 "workspace_delete",
+                "observation_pipeline_end",
             }
             and not self.config.record_tool_results
         ):

--- a/src/omnicoreagent/core/tools/tool_batch_runner.py
+++ b/src/omnicoreagent/core/tools/tool_batch_runner.py
@@ -53,6 +53,8 @@ class ToolBatchRunner:
         session_id: str | None,
         tool_batch_name: str,
         telemetry_recorder: Any = None,
+        record_history: bool = True,
+        emit_telemetry: bool = True,
     ) -> list[dict[str, Any]]:
         for single_tool in tool_call_results:
             session_state.loop_detector.record_tool_call(
@@ -61,20 +63,21 @@ class ToolBatchRunner:
                 error_message,
             )
 
-        for single_tool in tool_call_results:
-            await add_message_to_history(
-                role="tool",
-                content=error_message,
-                metadata={
-                    "tool_call_id": single_tool.tool_call_id,
-                    "tool": single_tool.tool_name,
-                    "args": single_tool.tool_args,
-                    "agent_name": self.agent_name,
-                },
-                session_id=session_id,
-            )
+        if record_history:
+            for single_tool in tool_call_results:
+                await add_message_to_history(
+                    role="tool",
+                    content=error_message,
+                    metadata={
+                        "tool_call_id": single_tool.tool_call_id,
+                        "tool": single_tool.tool_name,
+                        "args": single_tool.tool_args,
+                        "agent_name": self.agent_name,
+                    },
+                    session_id=session_id,
+                )
 
-        if telemetry_recorder is not None:
+        if telemetry_recorder is not None and emit_telemetry:
             await telemetry_recorder.emit_event(
                 "tool_batch_error",
                 actor=TelemetryActor(type=ActorType.TOOL),
@@ -130,6 +133,7 @@ class ToolBatchRunner:
         telemetry_recorder: Any = None,
     ) -> tuple[str, list[dict[str, Any]]]:
         batch_span = None
+        observation_span = None
         if telemetry_recorder is not None:
             batch_span = await telemetry_recorder.start_span(
                 name="tool.batch",
@@ -163,8 +167,65 @@ class ToolBatchRunner:
                         for single_tool in tool_call_results
                     ]
                 )
+        except asyncio.TimeoutError:
+            obs_text = TOOL_CALL_TIMEOUT_MESSAGE
+            logger.warning(obs_text)
+            await self._record_batch_failure_telemetry(
+                telemetry_recorder=telemetry_recorder,
+                batch_span=batch_span,
+                observation_span=observation_span,
+                error_type="TimeoutError",
+                error_message=obs_text,
+                span_status=SpanStatus.TIMEOUT,
+                emit_observation_error=False,
+            )
+            tools_results = await self.handle_execution_error(
+                tool_call_results=tool_call_results,
+                error_message=obs_text,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                tool_batch_name=tool_batch_name,
+                telemetry_recorder=telemetry_recorder,
+                emit_telemetry=False,
+            )
+            return obs_text, tools_results
 
+        except Exception as e:
+            obs_text = f"Error executing tool: {str(e)}"
+            logger.error(obs_text)
+            await self._record_batch_failure_telemetry(
+                telemetry_recorder=telemetry_recorder,
+                batch_span=batch_span,
+                observation_span=observation_span,
+                error_type=e.__class__.__name__,
+                error_message=str(e),
+                span_status=SpanStatus.ERROR,
+                emit_observation_error=False,
+            )
+            tools_results = await self.handle_execution_error(
+                tool_call_results=tool_call_results,
+                error_message=obs_text,
+                session_state=session_state,
+                add_message_to_history=add_message_to_history,
+                session_id=session_id,
+                tool_batch_name=tool_batch_name,
+                telemetry_recorder=telemetry_recorder,
+                emit_telemetry=False,
+            )
+            return obs_text, tools_results
+
+        try:
             if telemetry_recorder is not None:
+                observation_span = await telemetry_recorder.start_span(
+                    name="observation.pipeline",
+                    kind="observation.pipeline",
+                    actor=TelemetryActor(type=ActorType.SYSTEM),
+                    input={
+                        "tool_batch_name": tool_batch_name,
+                        "tool_count": len(tool_outputs),
+                    },
+                )
                 await telemetry_recorder.emit_event(
                     "observation_pipeline_start",
                     actor=TelemetryActor(type=ActorType.SYSTEM),
@@ -174,26 +235,28 @@ class ToolBatchRunner:
                     },
                 )
 
-            observation = await parse_tool_observation(
-                {
-                    "status": (
-                        "error"
-                        if any(
-                            result.get("status") == "error" for result in tool_outputs
-                        )
-                        else "success"
-                    ),
-                    "tools_results": tool_outputs,
-                }
-            )
+            async with asyncio.timeout(self.tool_call_timeout):
+                observation = await parse_tool_observation(
+                    {
+                        "status": (
+                            "error"
+                            if any(
+                                result.get("status") == "error"
+                                for result in tool_outputs
+                            )
+                            else "success"
+                        ),
+                        "tools_results": tool_outputs,
+                    }
+                )
 
-            tools_results = observation.get("tools_results", [])
-            obs_text = build_tool_results_observation(
-                tool_call_results,
-                tools_results,
-                session_state,
-                session_id,
-            )
+                tools_results = observation.get("tools_results", [])
+                obs_text = build_tool_results_observation(
+                    tool_call_results,
+                    tools_results,
+                    session_state,
+                    session_id,
+                )
 
             if telemetry_recorder is not None:
                 await telemetry_recorder.emit_event(
@@ -204,6 +267,15 @@ class ToolBatchRunner:
                         "tool_count": len(tools_results),
                     },
                 )
+                if observation_span is not None:
+                    await telemetry_recorder.end_span(
+                        observation_span.span_id,
+                        status=SpanStatus.OK,
+                        output={
+                            "observation": obs_text,
+                            "tool_count": len(tools_results),
+                        },
+                    )
                 if "[TOOL RESPONSE OFFLOADED]" in obs_text:
                     await telemetry_recorder.emit_event(
                         "workspace_offload",
@@ -229,28 +301,15 @@ class ToolBatchRunner:
         except asyncio.TimeoutError:
             obs_text = TOOL_CALL_TIMEOUT_MESSAGE
             logger.warning(obs_text)
-            if telemetry_recorder is not None and batch_span is not None:
-                await telemetry_recorder.emit_event(
-                    "observation_pipeline_error",
-                    actor=TelemetryActor(type=ActorType.SYSTEM),
-                    error={
-                        "type": "TimeoutError",
-                        "message": obs_text,
-                    },
-                )
-                await telemetry_recorder.emit_event(
-                    "tool_batch_error",
-                    actor=TelemetryActor(type=ActorType.TOOL),
-                    error={
-                        "type": "TimeoutError",
-                        "message": obs_text,
-                    },
-                )
-                await telemetry_recorder.end_span(
-                    batch_span.span_id,
-                    status=SpanStatus.TIMEOUT,
-                    error={"type": "TimeoutError", "message": obs_text},
-                )
+            await self._record_batch_failure_telemetry(
+                telemetry_recorder=telemetry_recorder,
+                batch_span=batch_span,
+                observation_span=observation_span,
+                error_type="TimeoutError",
+                error_message=obs_text,
+                span_status=SpanStatus.TIMEOUT,
+                emit_observation_error=True,
+            )
             tools_results = await self.handle_execution_error(
                 tool_call_results=tool_call_results,
                 error_message=obs_text,
@@ -259,28 +318,23 @@ class ToolBatchRunner:
                 session_id=session_id,
                 tool_batch_name=tool_batch_name,
                 telemetry_recorder=telemetry_recorder,
+                record_history=False,
+                emit_telemetry=False,
             )
             return obs_text, tools_results
 
         except Exception as e:
             obs_text = f"Error executing tool: {str(e)}"
             logger.error(obs_text)
-            if telemetry_recorder is not None and batch_span is not None:
-                await telemetry_recorder.emit_event(
-                    "observation_pipeline_error",
-                    actor=TelemetryActor(type=ActorType.SYSTEM),
-                    error={"type": e.__class__.__name__, "message": str(e)},
-                )
-                await telemetry_recorder.emit_event(
-                    "tool_batch_error",
-                    actor=TelemetryActor(type=ActorType.TOOL),
-                    error={"type": e.__class__.__name__, "message": str(e)},
-                )
-                await telemetry_recorder.end_span(
-                    batch_span.span_id,
-                    status=SpanStatus.ERROR,
-                    error={"type": e.__class__.__name__, "message": str(e)},
-                )
+            await self._record_batch_failure_telemetry(
+                telemetry_recorder=telemetry_recorder,
+                batch_span=batch_span,
+                observation_span=observation_span,
+                error_type=e.__class__.__name__,
+                error_message=str(e),
+                span_status=SpanStatus.ERROR,
+                emit_observation_error=True,
+            )
             tools_results = await self.handle_execution_error(
                 tool_call_results=tool_call_results,
                 error_message=obs_text,
@@ -289,8 +343,47 @@ class ToolBatchRunner:
                 session_id=session_id,
                 tool_batch_name=tool_batch_name,
                 telemetry_recorder=telemetry_recorder,
+                record_history=False,
+                emit_telemetry=False,
             )
             return obs_text, tools_results
+
+    async def _record_batch_failure_telemetry(
+        self,
+        *,
+        telemetry_recorder: Any,
+        batch_span: Any,
+        observation_span: Any,
+        error_type: str,
+        error_message: str,
+        span_status: SpanStatus,
+        emit_observation_error: bool,
+    ) -> None:
+        if telemetry_recorder is None or batch_span is None:
+            return
+        error = {"type": error_type, "message": error_message}
+        if emit_observation_error:
+            await telemetry_recorder.emit_event(
+                "observation_pipeline_error",
+                actor=TelemetryActor(type=ActorType.SYSTEM),
+                error=error,
+            )
+            if observation_span is not None:
+                await telemetry_recorder.end_span(
+                    observation_span.span_id,
+                    status=span_status,
+                    error=error,
+                )
+        await telemetry_recorder.emit_event(
+            "tool_batch_error",
+            actor=TelemetryActor(type=ActorType.TOOL),
+            error=error,
+        )
+        await telemetry_recorder.end_span(
+            batch_span.span_id,
+            status=span_status,
+            error=error,
+        )
 
     async def _execute_single_tool(
         self,
@@ -415,6 +508,9 @@ def _tool_telemetry_shape(single_tool: ToolCallResult) -> dict[str, Any]:
     workspace_shape = _workspace_tool_telemetry_shape(single_tool.tool_name)
     if workspace_shape is not None:
         return workspace_shape
+    artifact_shape = _artifact_tool_telemetry_shape(single_tool.tool_name)
+    if artifact_shape is not None:
+        return artifact_shape
     return {
         "span_kind": "tool.call",
         "call_event": "tool_call",
@@ -443,6 +539,24 @@ def _workspace_tool_telemetry_shape(tool_name: str) -> dict[str, Any] | None:
         "call_event": event,
         "result_event": event,
         "error_event": event,
+        "single_event": True,
+        "actor": TelemetryActor(type=ActorType.WORKSPACE, name=tool_name),
+    }
+
+
+def _artifact_tool_telemetry_shape(tool_name: str) -> dict[str, Any] | None:
+    if tool_name not in {
+        "read_artifact",
+        "tail_artifact",
+        "search_artifact",
+        "list_artifacts",
+    }:
+        return None
+    return {
+        "span_kind": "workspace.read",
+        "call_event": "workspace_read",
+        "result_event": "workspace_read",
+        "error_event": "workspace_read",
         "single_event": True,
         "actor": TelemetryActor(type=ActorType.WORKSPACE, name=tool_name),
     }

--- a/src/omnicoreagent/core/workspace/artifact_tools.py
+++ b/src/omnicoreagent/core/workspace/artifact_tools.py
@@ -48,10 +48,14 @@ def build_tool_registry_artifact_tool(
             "additionalProperties": False,
         },
     )
-    def read_artifact(artifact_id: str) -> str:
+    def read_artifact(artifact_id: str) -> str | dict[str, str | None]:
         content = offloader.read_artifact(artifact_id)
         if content is None:
-            return f"Error: Artifact '{artifact_id}' not found. Check the artifact ID and try again."
+            return {
+                "status": "error",
+                "data": None,
+                "message": f"Artifact '{artifact_id}' not found. Check the artifact ID and try again.",
+            }
         return content
 
     @registry.register_tool(
@@ -79,10 +83,14 @@ def build_tool_registry_artifact_tool(
             "additionalProperties": False,
         },
     )
-    def tail_artifact(artifact_id: str, lines: int = 50) -> str:
+    def tail_artifact(artifact_id: str, lines: int = 50) -> str | dict[str, str | None]:
         content = offloader.tail_artifact(artifact_id, lines)
         if content is None:
-            return f"Error: Artifact '{artifact_id}' not found."
+            return {
+                "status": "error",
+                "data": None,
+                "message": f"Artifact '{artifact_id}' not found.",
+            }
         return content
 
     @registry.register_tool(
@@ -110,10 +118,14 @@ def build_tool_registry_artifact_tool(
             "additionalProperties": False,
         },
     )
-    def search_artifact(artifact_id: str, query: str) -> str:
+    def search_artifact(artifact_id: str, query: str) -> str | dict[str, str | None]:
         content = offloader.search_artifact(artifact_id, query)
         if content is None:
-            return f"Error: Artifact '{artifact_id}' not found."
+            return {
+                "status": "error",
+                "data": None,
+                "message": f"Artifact '{artifact_id}' not found.",
+            }
         return content
 
     @registry.register_tool(

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -42,6 +42,7 @@ from omnicoreagent.background.models import (
     next_cron_due,
     next_schedule_due,
 )
+from omnicoreagent.background.event_log import BackgroundEventLog
 from omnicoreagent.background.recovery import BackgroundRunRecovery
 from omnicoreagent.background.transitions import BackgroundRunTransitions
 from omnicoreagent.core.telemetry import TelemetryStreamScope
@@ -1051,7 +1052,11 @@ async def test_background_run_lifecycle_events_emit_to_telemetry():
         None,
     )
 
-    event_names = [event.event_type for event in events]
+    event_names = [
+        event.event_type
+        for event in events
+        if event.event_type.startswith("background_")
+    ]
     assert event_names == [
         "background_run_queued",
         "background_run_claimed",
@@ -1063,6 +1068,12 @@ async def test_background_run_lifecycle_events_emit_to_telemetry():
     assert trace is not None
     assert trace.run_id == run.run_id
     assert trace.status.value == "completed"
+    assert trace.events[-1].event_type == "background_run_completed"
+    assert any(
+        event.event_type == "workspace_write"
+        and event.output["path"].endswith(("run.json", "events.jsonl"))
+        for event in trace.events
+    )
 
 
 @pytest.mark.asyncio
@@ -1086,6 +1097,123 @@ async def test_background_run_events_replay_from_workspace_when_cache_cleared(tm
         ("background_run_claimed", 2),
         ("background_run_started", 3),
         ("background_run_completed", 4),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_terminal_background_event_waits_for_pending_event_write():
+    class FakeWorkspaceIO:
+        def __init__(self):
+            self.written_events = []
+
+        def read_events(self, workspace_path):
+            return []
+
+        def append_event(self, event):
+            self.written_events.append(event["event"])
+
+    workspace_io = FakeWorkspaceIO()
+    event_log = BackgroundEventLog(
+        task_store=InMemoryTaskStore(),
+        workspace_io=workspace_io,
+        replay_timeout_seconds=1,
+    )
+    original_write_run_event = event_log.write_run_event
+    pending_started = asyncio.Event()
+    release_started = asyncio.Event()
+
+    async def slow_write_run_event(event):
+        if event["event"] == "background_run_started":
+            pending_started.set()
+            await release_started.wait()
+        await original_write_run_event(event)
+
+    event_log.write_run_event = slow_write_run_event
+
+    payload = {
+        "agent_id": "agent",
+        "task_id": "task",
+        "run_id": "run-terminal-order",
+        "session_id": "session",
+        "status": "running",
+        "workspace_path": "background/task/run-terminal-order",
+    }
+    await event_log.emit("background_run_queued", **payload)
+    await event_log.emit("background_run_started", **payload)
+    await asyncio.wait_for(pending_started.wait(), timeout=1)
+
+    terminal_task = asyncio.create_task(
+        event_log.emit(
+            "background_run_completed",
+            **{**payload, "status": "completed"},
+        )
+    )
+    await asyncio.sleep(0)
+    assert not terminal_task.done()
+
+    release_started.set()
+    await asyncio.wait_for(terminal_task, timeout=1)
+
+    assert workspace_io.written_events == [
+        "background_run_queued",
+        "background_run_started",
+        "background_run_completed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_terminal_background_event_does_not_write_gap_after_drain_timeout():
+    class FakeWorkspaceIO:
+        def __init__(self):
+            self.written_events = []
+
+        def read_events(self, workspace_path):
+            return []
+
+        def append_event(self, event):
+            self.written_events.append(
+                {"event": event["event"], "sequence": event["sequence"]}
+            )
+
+    workspace_io = FakeWorkspaceIO()
+    event_log = BackgroundEventLog(
+        task_store=InMemoryTaskStore(),
+        workspace_io=workspace_io,
+        replay_timeout_seconds=0.01,
+    )
+    original_write_run_event = event_log.write_run_event
+    pending_started = asyncio.Event()
+
+    async def stuck_write_run_event(event):
+        if event["event"] == "background_run_started":
+            pending_started.set()
+            await asyncio.Event().wait()
+        await original_write_run_event(event)
+
+    event_log.write_run_event = stuck_write_run_event
+
+    payload = {
+        "agent_id": "agent",
+        "task_id": "task",
+        "run_id": "run-terminal-gap",
+        "session_id": "session",
+        "status": "running",
+        "workspace_path": "background/task/run-terminal-gap",
+    }
+    await event_log.emit("background_run_queued", **payload)
+    await event_log.emit("background_run_started", **payload)
+    await asyncio.wait_for(pending_started.wait(), timeout=1)
+
+    await event_log.emit(
+        "background_run_completed",
+        **{**payload, "status": "completed"},
+    )
+
+    assert workspace_io.written_events == [
+        {"event": "background_run_queued", "sequence": 1}
+    ]
+    assert event_log.prepare_event_trace(workspace_io.written_events) == [
+        {"event": "background_run_queued", "sequence": 1}
     ]
 
 

--- a/tests/test_llm_step.py
+++ b/tests/test_llm_step.py
@@ -173,6 +173,35 @@ async def test_llm_step_returns_usage_limit_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_llm_step_records_usage_limit_as_resource_guard_halt(monkeypatch):
+    monkeypatch.setattr(llm_step, "usage", Usage())
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-resource-guard",
+        run_id="run-resource-guard",
+        session_id="chat-resource",
+        actor=TelemetryActor(type=ActorType.AGENT, name="agent"),
+    )
+
+    result = await make_runner(limits_enabled=True, request_limit=1).run(
+        session_state=make_session_state(),
+        llm_connection=SimpleNamespace(llm_call=None),
+        run_usage=Usage(requests=1),
+        session_id="chat-resource",
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace(status="failed")
+
+    trace = await store.get_trace(context.trace_id)
+    assert result.response is None
+    assert result.error_result["answer"].startswith("Usage limit error:")
+    assert any(span.kind == "runtime.control" for span in trace.spans)
+    event = next(event for event in trace.events if event.event_type == "resource_guard_halt")
+    assert event.error.type == "UsageLimitExceeded"
+
+
+@pytest.mark.asyncio
 async def test_llm_step_returns_model_error(monkeypatch):
     monkeypatch.setattr(llm_step, "usage", Usage())
 

--- a/tests/test_runtime_telemetry_wiring.py
+++ b/tests/test_runtime_telemetry_wiring.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent
+from omnicoreagent.core.token_usage import Usage
 from omnicoreagent.core.telemetry import (
     InMemoryTelemetryStore,
     TelemetryStream,
@@ -154,6 +155,32 @@ async def test_run_records_guardrail_block_as_aborted_trace() -> None:
     ]
     assert trace.events[1].output == {"is_safe": False, "message": "blocked"}
     assert trace.events[2].output == {"is_safe": False, "message": "blocked"}
+
+
+@pytest.mark.asyncio
+async def test_run_records_resource_guard_halt_as_aborted_trace() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    agent.agent.run = AsyncMock(
+        return_value={
+            "answer": "Usage limit error: request limit reached",
+            "usage": Usage(requests=1),
+            "_trace_status": TraceStatus.ABORTED_RESOURCE_GUARD.value,
+        }
+    )
+
+    result = await agent.run("too much", session_id="session-resource-guard")
+
+    assert result["response"] == "Usage limit error: request limit reached"
+    assert "_trace_status" not in result
+    traces = await store.list_traces(TraceFilter(session_id="session-resource-guard"))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.status == TraceStatus.ABORTED_RESOURCE_GUARD
+    assert [event.event_type for event in trace.events] == [
+        "user_message",
+        "final_answer",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_batch_runner.py
+++ b/tests/test_tool_batch_runner.py
@@ -387,6 +387,7 @@ async def test_execute_records_mcp_workspace_and_observation_telemetry(
         "tool.batch",
         "mcp.tool.call",
         "workspace.read",
+        "observation.pipeline",
     }
     assert {event.event_type for event in trace.events} >= {
         "tool_batch_start",
@@ -402,6 +403,78 @@ async def test_execute_records_mcp_workspace_and_observation_telemetry(
     mcp_call = next(event for event in trace.events if event.event_type == "mcp_tool_call")
     assert mcp_call.actor.type == ActorType.MCP_SERVER
     assert mcp_call.actor.name == "docs-server"
+
+
+@pytest.mark.asyncio
+async def test_artifact_tools_are_recorded_as_workspace_reads(runner, session_state):
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-artifact-read",
+        run_id="run-artifact-read",
+        session_id="chat-artifact",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": "artifact content",
+                "message": None,
+            }
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    await runner.execute(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=FakeExecutor(),
+                tool_name="read_artifact",
+                tool_args={"artifact_id": "search_123"},
+                tool_call_id="tool-call-artifact",
+            )
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat-artifact",
+        tool_batch_name="read_artifact",
+        tool_batch_args=[{"artifact_id": "search_123"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace()
+
+    trace = await store.get_trace(context.trace_id)
+    artifact_span = next(span for span in trace.spans if span.name == "read_artifact")
+    artifact_event = next(
+        event
+        for event in trace.events
+        if event.event_type == "workspace_read"
+        and event.actor.name == "read_artifact"
+    )
+    assert artifact_span.kind == "workspace.read"
+    assert artifact_event.input["tool_args"] == {"artifact_id": "search_123"}
 
 
 @pytest.mark.asyncio
@@ -482,5 +555,306 @@ async def test_workspace_tool_telemetry_respects_tool_result_suppression(
     workspace_event = next(
         event for event in trace.events if event.event_type == "workspace_read"
     )
+    observation_span = next(
+        span for span in trace.spans if span.kind == "observation.pipeline"
+    )
+    tool_batch_span = next(span for span in trace.spans if span.kind == "tool.batch")
+    observation_event = next(
+        event
+        for event in trace.events
+        if event.event_type == "observation_pipeline_end"
+    )
     assert workspace_span.output is None
     assert workspace_event.output is None
+    assert observation_span.output is None
+    assert tool_batch_span.output is None
+    assert observation_event.output is None
+
+
+@pytest.mark.asyncio
+async def test_artifact_error_result_is_recorded_as_workspace_read_error(
+    runner, session_state
+):
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-artifact-error",
+        run_id="run-artifact-error",
+        session_id="chat-artifact-error",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "error",
+                "data": None,
+                "message": "Artifact 'missing' not found.",
+            }
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=FakeExecutor(),
+                tool_name="read_artifact",
+                tool_args={"artifact_id": "missing"},
+                tool_call_id="tool-call-artifact-error",
+            )
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat-artifact-error",
+        tool_batch_name="read_artifact",
+        tool_batch_args=[{"artifact_id": "missing"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace()
+
+    trace = await store.get_trace(context.trace_id)
+    artifact_span = next(span for span in trace.spans if span.name == "read_artifact")
+    artifact_event = next(
+        event
+        for event in trace.events
+        if event.event_type == "workspace_read"
+        and event.actor.name == "read_artifact"
+    )
+    assert obs_text == "Artifact 'missing' not found."
+    assert tools_results[0]["status"] == "error"
+    assert artifact_span.status == "error"
+    assert artifact_span.error.message == "Artifact 'missing' not found."
+    assert artifact_event.error.message == "Artifact 'missing' not found."
+
+
+@pytest.mark.asyncio
+async def test_artifact_error_result_is_normalized_without_telemetry(
+    runner, session_state
+):
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "error",
+                "data": None,
+                "message": "Artifact 'missing' not found.",
+            }
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=FakeExecutor(),
+                tool_name="read_artifact",
+                tool_args={"artifact_id": "missing"},
+                tool_call_id="tool-call-artifact-error",
+            )
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat-artifact-error-no-telemetry",
+        tool_batch_name="read_artifact",
+        tool_batch_args=[{"artifact_id": "missing"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert obs_text == "Artifact 'missing' not found."
+    assert tools_results[0]["status"] == "error"
+    assert tools_results[0]["data"] is None
+    assert tools_results[0]["message"] == "Artifact 'missing' not found."
+
+
+@pytest.mark.asyncio
+async def test_artifact_content_starting_with_error_stays_success(
+    runner, session_state
+):
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": "Error: compiler output from stored artifact",
+                "message": None,
+            }
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=FakeExecutor(),
+                tool_name="read_artifact",
+                tool_args={"artifact_id": "compiler-log"},
+                tool_call_id="tool-call-artifact-error-content",
+            )
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat-artifact-error-content",
+        tool_batch_name="read_artifact",
+        tool_batch_args=[{"artifact_id": "compiler-log"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert obs_text == "Error: compiler output from stored artifact"
+    assert tools_results[0]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_observation_parser_timeout_uses_tool_timeout_path(session_state):
+    runner = ToolBatchRunner(agent_name="test_agent", tool_call_timeout=0.1)
+    history = []
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    context = await recorder.start_trace(
+        trace_id="trace-observation-timeout",
+        run_id="run-observation-timeout",
+        session_id="chat-observation-timeout",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    class FakeExecutor:
+        async def execute(
+            self,
+            agent_name,
+            tool_args,
+            tool_name,
+            tool_call_id,
+            add_message_to_history,
+            session_id,
+        ):
+            await add_message_to_history(
+                role="tool",
+                content="ok",
+                metadata={
+                    "tool_call_id": tool_call_id,
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "agent_name": agent_name,
+                },
+                session_id=session_id,
+            )
+            return {
+                "tool_name": tool_name,
+                "args": tool_args,
+                "status": "success",
+                "data": "ok",
+                "message": None,
+            }
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def parse_tool_observation(raw_output):
+        await asyncio.sleep(1)
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        raise AssertionError("Timed out observation should not be formatted")
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=[
+            ToolCallResult(
+                tool_executor=FakeExecutor(),
+                tool_name="alpha",
+                tool_args={},
+                tool_call_id="tool-call-alpha",
+            )
+        ],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="chat-observation-timeout",
+        tool_batch_name="alpha",
+        tool_batch_args=[{}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace(status="timeout")
+
+    trace = await store.get_trace(context.trace_id)
+    observation_span = next(
+        span for span in trace.spans if span.kind == "observation.pipeline"
+    )
+    error_event = next(
+        event
+        for event in trace.events
+        if event.event_type == "observation_pipeline_error"
+    )
+    assert obs_text == TOOL_CALL_TIMEOUT_MESSAGE
+    assert tools_results[0]["status"] == "error"
+    assert [item["metadata"]["tool_call_id"] for item in history] == [
+        "tool-call-alpha"
+    ]
+    assert [event.event_type for event in trace.events].count("tool_batch_error") == 1
+    assert observation_span.status == "timeout"
+    assert error_event.span_id == observation_span.span_id

--- a/tests/test_tool_response_offloader.py
+++ b/tests/test_tool_response_offloader.py
@@ -688,8 +688,9 @@ class TestArtifactToolRegistration:
         tool = self.registry.tools["read_artifact"]
         result = tool.function(artifact_id="nonexistent")
 
-        assert "Error" in result
-        assert "not found" in result
+        assert result["status"] == "error"
+        assert result["data"] is None
+        assert "not found" in result["message"]
 
     def test_list_artifacts_tool_works(self):
         """Test registered list_artifacts tool function works."""


### PR DESCRIPTION
## Summary
- add runtime telemetry coverage for artifact access tools, observation pipeline spans, resource guard halts, and background workspace persistence
- tighten background terminal event ordering so workspace replay does not get sequence gaps
- make artifact missing errors explicit structured tool errors while preserving valid artifact content that starts with Error:
- align internal specs, architecture notes, cookbook, and observability docs with the current background run and telemetry behavior

## Verification
- uv run ruff check .
- uv run python -m compileall -q src/omnicoreagent tests
- git diff --check
- uv run pytest tests/test_tool_batch_runner.py tests/test_tool_response_offloader.py tests/test_background_agent.py tests/test_llm_step.py tests/test_runtime_telemetry_wiring.py -q
- uv run pytest tests/test_background_agent.py tests/test_omniserve_background.py tests/test_background_cookbook.py tests/test_docs_claims.py -q
- uv run pytest tests/test_tool_batch_runner.py tests/test_llm_step.py tests/test_runtime_telemetry_wiring.py tests/test_loop_telemetry_instrumentation.py tests/test_telemetry_foundation.py tests/test_tool_response_offloader.py -q
- uv run pytest -q (756 passed, 8 skipped)

## Review
- ran reviewer, QA, and docs/DX evaluator agents twice
- fixed findings around no-telemetry artifact errors, observation timeout duplicate history/events, background terminal event ordering, stale docs/spec wording, raw artifact content beginning with Error:, and terminal timeout sequence gaps