### PR TITLE
Harden telemetry contract

### DIFF
--- a/docs/how-to-guides/observability.mdx
+++ b/docs/how-to-guides/observability.mdx
@@ -89,6 +89,14 @@ for event in trace["events"]:
     print(event["event_type"], event.get("input"), event.get("output"))
 ```
 
+You can also retrieve the latest trace for a session or the trace for a run:
+
+```python
+latest = await agent.get_latest_trace("research_1")
+same_run = await agent.get_trace(run_id=result["run_id"])
+normalized = await agent.get_trace(result["trace_id"], normalize=True)
+```
+
 The trace is intentionally internal and dependency-free. It is a compact
 debugging view built from telemetry events and spans, not a full tracing or
 evaluation system.

--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -415,6 +415,16 @@ The stream is a view over `TelemetryStore`; it is not a separate truth source.
 Initial stream backends may reuse implementation ideas from current in-memory
 queues and Redis streams, but the public contract should be telemetry-native.
 
+Trace retrieval follows the same evidence boundary:
+
+- exact trace lookup is by `trace_id`
+- run lookup is by `run_id`
+- latest session lookup is by deterministic trace ordering for `session_id`
+- partial, failed, cancelled, timeout, safety-halted, and resource-halted traces
+  are returned as evidence, not hidden behind summaries
+- OmniServe trace summary endpoints read the latest telemetry trace, not a
+  separate session event summary
+
 ## Trace Normalizer
 
 The normalizer converts raw runtime telemetry into a stable schema for future
@@ -428,9 +438,11 @@ The normalizer should:
 - sort spans and events deterministically
 - validate parent/child references
 - preserve evidence ids
+- generate deterministic evidence ids for synthetic normalizer findings
 - classify span and event kinds
 - produce behavior-relevant summaries
 - flag incomplete traces without hiding them
+- preserve errors and statuses exactly
 
 ## Evidence Contract
 

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -424,12 +424,19 @@ end_span(trace_id: str, span_id: str, patch: dict) -> None
 upsert_trace(trace: TelemetryTrace) -> None
 get_trace(trace_id: str) -> TelemetryTrace | None
 list_traces(filter: TraceFilter) -> list[TelemetryTrace]
+get_stream_cursor(scope: TelemetryStreamScope) -> str | None
+stream_after(scope: TelemetryStreamScope, cursor: str | None) -> AsyncIterator[TelemetryEvent]
+get_events_after(scope: TelemetryStreamScope, cursor: str | None) -> list[TelemetryEvent]
 ```
 
 Rules:
 
 - stores must preserve trace-local sequence order.
+- trace listing must use a deterministic order. The current contract sorts by
+  `started_at`, then `trace_id`, so latest-session lookup is stable.
 - JSONL records must be append-friendly.
+- JSONL reload must preserve trace lookup, scoped event replay, and run/session
+  filtering behavior.
 - in-memory store is for tests and local development.
 - Redis stream is not the canonical trace store.
 - storage failure behavior depends on recorder strict/best-effort mode.
@@ -515,14 +522,16 @@ Output requirements:
 - validated event/span references
 - canonical event type names
 - canonical span kind names
-- explicit incomplete/missing evidence markers
+- explicit incomplete/missing evidence markers with deterministic event ids
 - behavior summary inputs preserved for future extraction
 
 Rules:
 
 - evaluators consume normalized traces only.
 - normalizer must not discard errors.
+- normalizer must preserve statuses.
 - normalizer must not hide incomplete traces.
+- normalizer must produce the same output for the same raw trace.
 - unsupported experimental events must be preserved with metadata explaining the
   source type.
 
@@ -605,9 +614,15 @@ Current runtime facade coverage:
   replay/follow helpers.
 - successful and guardrail-blocked public run responses include `trace_id` and
   `run_id`.
-- `get_trace(trace_id)` returns a telemetry trace when passed a returned
-  telemetry `trace_id`; `get_trace(session_id=...)` returns the latest telemetry
-  trace for that session.
+- `get_trace(trace_id=...)` returns an exact telemetry trace for any trace id
+  string.
+- `get_trace(run_id=...)` returns the trace for that run id.
+- `get_trace(session_id=...)` and `get_latest_trace(session_id)` return the
+  latest telemetry trace for that session using deterministic store ordering.
+- `get_trace(identifier)` first tries exact trace-id lookup, then treats the
+  identifier as a session id for latest-session lookup.
+- partial, failed, cancelled, timeout, safety-halted, and resource-halted traces
+  must be returned with their status intact.
 - if callers inject telemetry components directly, `telemetry_store`,
   `telemetry_recorder.store`, and `telemetry_stream.store` must refer to the
   same store instance. The runtime rejects mismatches instead of silently

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -20,6 +20,7 @@ from omnicoreagent.core.runtime.imports import (
 from omnicoreagent.core.telemetry import (
     ActorType,
     TelemetryActor,
+    TelemetryNormalizer,
     TelemetryRecorder,
     TelemetryStream,
     TelemetryStreamScope,
@@ -538,25 +539,53 @@ class OmniCoreAgent:
         *,
         session_id: str | None = None,
         trace_id: str | None = None,
+        run_id: str | None = None,
+        normalize: bool = False,
     ) -> Dict[str, Any] | None:
         """
         Return telemetry trace data.
         """
+        filters = [value is not None for value in (session_id, trace_id, run_id)]
+        if identifier is not None and any(filters):
+            raise ValueError("Use either identifier or trace lookup keyword arguments")
+        if sum(filters) > 1:
+            raise ValueError("Use only one of trace_id, run_id, or session_id")
         if trace_id is not None:
-            return await self.get_telemetry_trace(trace_id)
-        if session_id is not None:
-            traces = await self.list_telemetry_traces(session_id=session_id)
+            return await self.get_telemetry_trace(trace_id, normalize=normalize)
+        if run_id is not None:
+            traces = await self.list_telemetry_traces(run_id=run_id, normalize=normalize)
             return traces[-1] if traces else None
+        if session_id is not None:
+            return await self.get_latest_trace(session_id, normalize=normalize)
         if identifier is None:
             raise TypeError("get_trace() requires trace_id or session_id")
-        if identifier.startswith("trace_"):
-            return await self.get_telemetry_trace(identifier)
-        traces = await self.list_telemetry_traces(session_id=identifier)
+        exact_trace = await self.get_telemetry_trace(identifier, normalize=normalize)
+        if exact_trace is not None:
+            return exact_trace
+        return await self.get_latest_trace(identifier, normalize=normalize)
+
+    async def get_latest_trace(
+        self,
+        session_id: str,
+        *,
+        normalize: bool = False,
+    ) -> Dict[str, Any] | None:
+        traces = await self.list_telemetry_traces(
+            session_id=session_id,
+            normalize=normalize,
+        )
         return traces[-1] if traces else None
 
-    async def get_telemetry_trace(self, trace_id: str) -> Dict[str, Any] | None:
+    async def get_telemetry_trace(
+        self,
+        trace_id: str,
+        *,
+        normalize: bool = False,
+    ) -> Dict[str, Any] | None:
         self._ensure_telemetry()
         trace = await self.telemetry_store.get_trace(trace_id)
+        if trace and normalize:
+            trace = TelemetryNormalizer().normalize(trace)
         return trace.model_dump() if trace else None
 
     async def list_telemetry_traces(
@@ -571,6 +600,7 @@ class OmniCoreAgent:
         workflow_id: str | None = None,
         model: str | None = None,
         status: TraceStatus | str | None = None,
+        normalize: bool = False,
     ) -> list[Dict[str, Any]]:
         self._ensure_telemetry()
         if trace_filter is not None and any(
@@ -601,6 +631,9 @@ class OmniCoreAgent:
                 status=status,
             )
         traces = await self.telemetry_store.list_traces(trace_filter)
+        if normalize:
+            normalizer = TelemetryNormalizer()
+            traces = [normalizer.normalize(trace) for trace in traces]
         return [trace.model_dump() for trace in traces]
 
     async def get_telemetry_stream_cursor(

--- a/src/omnicoreagent/core/telemetry/normalizer.py
+++ b/src/omnicoreagent/core/telemetry/normalizer.py
@@ -6,13 +6,13 @@ from omnicoreagent.core.telemetry.models import (
     TelemetryActor,
     TelemetryEvent,
     TelemetryTrace,
-    telemetry_id,
 )
 
 
 class TelemetryNormalizer:
     def normalize(self, trace: TelemetryTrace) -> TelemetryTrace:
         normalized = TelemetryTrace.from_dict(trace.model_dump())
+        normalized.metadata.tags = sorted(set(normalized.metadata.tags))
         normalized.spans.sort(key=lambda span: (span.started_at, span.span_id))
         normalized.events.sort(
             key=lambda event: (event.sequence_number, event.timestamp, event.event_id)
@@ -22,6 +22,7 @@ class TelemetryNormalizer:
         normalized.events.sort(
             key=lambda event: (event.sequence_number, event.timestamp, event.event_id)
         )
+        _normalize_span_event_ids(normalized)
         return normalized
 
     def _mark_missing_references(self, trace: TelemetryTrace) -> None:
@@ -51,7 +52,7 @@ class TelemetryNormalizer:
                 return
             trace.events.append(
                 TelemetryEvent(
-                    event_id=telemetry_id("missing_evidence"),
+                    event_id=_normalizer_event_id(trace, "missing_evidence"),
                     trace_id=trace.trace_id,
                     sequence_number=_next_sequence(trace),
                     timestamp=trace.started_at,
@@ -70,7 +71,7 @@ class TelemetryNormalizer:
             return
         trace.events.append(
             TelemetryEvent(
-                event_id=telemetry_id("incomplete_trace"),
+                event_id=_normalizer_event_id(trace, "incomplete_trace"),
                 trace_id=trace.trace_id,
                 sequence_number=_next_sequence(trace),
                 timestamp=trace.started_at,
@@ -86,3 +87,30 @@ def _next_sequence(trace: TelemetryTrace) -> int:
     if not trace.events:
         return 1
     return max(event.sequence_number for event in trace.events) + 1
+
+
+def _normalize_span_event_ids(trace: TelemetryTrace) -> None:
+    event_order = {
+        event.event_id: index
+        for index, event in enumerate(trace.events)
+    }
+    for span in trace.spans:
+        deduped_ids = list(dict.fromkeys(span.event_ids))
+        span.event_ids = sorted(
+            deduped_ids,
+            key=lambda event_id: (
+                event_order.get(event_id, len(event_order)),
+                deduped_ids.index(event_id),
+            ),
+        )
+
+
+def _normalizer_event_id(trace: TelemetryTrace, reason: str) -> str:
+    base = f"event_normalizer_{trace.trace_id}_{reason}"
+    existing_ids = {event.event_id for event in trace.events}
+    if base not in existing_ids:
+        return base
+    index = 1
+    while f"{base}_{index}" in existing_ids:
+        index += 1
+    return f"{base}_{index}"

--- a/src/omnicoreagent/core/telemetry/store.py
+++ b/src/omnicoreagent/core/telemetry/store.py
@@ -145,10 +145,10 @@ class InMemoryTelemetryStore(AbstractTelemetryStore):
         async with self._lock:
             traces = [_copy_trace(trace) for trace in self._traces.values()]
         if filter is None:
-            return sorted(traces, key=lambda trace: trace.started_at)
+            return _sort_traces(traces)
         return sorted(
             [trace for trace in traces if filter.matches(trace)],
-            key=lambda trace: trace.started_at,
+            key=_trace_sort_key,
         )
 
     async def get_stream_cursor(self, scope: TelemetryStreamScope) -> str | None:
@@ -425,6 +425,14 @@ def _copy_span(span: TelemetrySpan) -> TelemetrySpan:
 
 def _copy_trace(trace: TelemetryTrace) -> TelemetryTrace:
     return TelemetryTrace.from_dict(trace.model_dump())
+
+
+def _trace_sort_key(trace: TelemetryTrace) -> tuple[Any, str]:
+    return (trace.started_at, trace.trace_id)
+
+
+def _sort_traces(traces: list[TelemetryTrace]) -> list[TelemetryTrace]:
+    return sorted(traces, key=_trace_sort_key)
 
 
 def _find_span(trace: TelemetryTrace, span_id: str) -> TelemetrySpan | None:

--- a/src/omnicoreagent/serve/routes/sessions.py
+++ b/src/omnicoreagent/serve/routes/sessions.py
@@ -56,8 +56,8 @@ def create_sessions_router() -> APIRouter:
     )
     async def get_trace(request: Request, session_id: str) -> TraceResponse:
         agent = get_agent(request)
-        traces = await agent.list_telemetry_traces(session_id=session_id)
-        trace = traces[-1] if traces else {}
+        trace = await agent.get_latest_trace(session_id)
+        trace = trace or {}
         events = trace.get("events", [])
         spans = trace.get("spans", [])
 

--- a/src/omnicoreagent/serve/sse.py
+++ b/src/omnicoreagent/serve/sse.py
@@ -105,10 +105,14 @@ async def _put_stream_item(queue: asyncio.Queue[Any], item: Any) -> bool:
         return False
 
 
-async def _get_telemetry_stream_cursor(agent: AgentType, session_id: str) -> str | None:
+async def _get_telemetry_stream_cursor(
+    agent: AgentType,
+    session_id: str,
+    run_id: str | None = None,
+) -> str | None:
     cursor_method = getattr(agent, "get_telemetry_stream_cursor", None)
     if callable(cursor_method):
-        result = cursor_method(session_id=session_id)
+        result = cursor_method(session_id=session_id, run_id=run_id)
         if isawaitable(result):
             return await result
         return result
@@ -239,7 +243,7 @@ async def run_agent_stream(
             query=query,
             streaming=True,
         )
-        cursor = await _get_telemetry_stream_cursor(agent, session_id)
+        cursor = await _get_telemetry_stream_cursor(agent, session_id, run_id)
         pump_task = asyncio.create_task(
             _pump_session_events(agent, session_id, event_queue, cursor, run_id)
         )

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -609,16 +609,14 @@ class TestEndpoints:
         agent.run = AsyncMock(return_value={"response": "Agent response"})
         # Mock get_metrics
         agent.get_metrics = AsyncMock(return_value={"total_tokens": 100})
-        agent.list_telemetry_traces = AsyncMock(
-            return_value=[
-                {
-                    "trace_id": "trace_endpoint",
-                    "run_id": "run_endpoint",
-                    "status": "completed",
-                    "events": [{"event_type": "user_message"}],
-                    "spans": [{"kind": "agent.run"}],
-                }
-            ]
+        agent.get_latest_trace = AsyncMock(
+            return_value={
+                "trace_id": "trace_endpoint",
+                "run_id": "run_endpoint",
+                "status": "completed",
+                "events": [{"event_type": "user_message"}],
+                "spans": [{"kind": "agent.run"}],
+            }
         )
         store = InMemoryTelemetryStore()
         agent.telemetry_store = store
@@ -841,7 +839,7 @@ class TestEndpoints:
     def test_trace_endpoint_uses_telemetry_trace_accessor(self, server_client):
         server_client.get("/events/trace_like_session/trace")
         agent = server_client.app.state.agent
-        agent.list_telemetry_traces.assert_awaited_with(session_id="trace_like_session")
+        agent.get_latest_trace.assert_awaited_with("trace_like_session")
 
     def test_events_list_endpoint_uses_telemetry_events_accessor(self, server_client):
         resp = server_client.get("/events/test-endpoint-session/list")

--- a/tests/test_omniserve_sse.py
+++ b/tests/test_omniserve_sse.py
@@ -33,9 +33,11 @@ class _TelemetryAgent:
         self.telemetry_config = telemetry_config
         self.run_started = asyncio.Event()
 
-    async def get_telemetry_stream_cursor(self, *, session_id: str):
+    async def get_telemetry_stream_cursor(
+        self, *, session_id: str, run_id: str | None = None
+    ):
         return await self.telemetry_stream.get_stream_cursor(
-            self._scope(session_id=session_id)
+            self._scope(session_id=session_id, run_id=run_id)
         )
 
     async def stream_telemetry_after(

--- a/tests/test_runtime_telemetry_wiring.py
+++ b/tests/test_runtime_telemetry_wiring.py
@@ -12,8 +12,12 @@ from omnicoreagent.core.telemetry import (
     InMemoryTelemetryStore,
     TelemetryStream,
     TelemetryRecorder,
+    TelemetryActor,
+    TelemetrySpan,
+    TelemetryTrace,
     TraceFilter,
     TraceStatus,
+    ActorType,
 )
 
 
@@ -323,6 +327,125 @@ async def test_get_trace_accepts_returned_trace_id_and_session_id_keyword() -> N
 
     assert telemetry_trace["trace_id"] == result["trace_id"]
     assert session_trace["trace_id"] == result["trace_id"]
+
+
+@pytest.mark.asyncio
+async def test_get_trace_treats_identifier_as_exact_trace_id_before_session() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    recorder = TelemetryRecorder(store)
+    await recorder.start_trace(
+        trace_id="custom-trace-id",
+        session_id="custom-trace-id",
+        run_id="run-custom",
+    )
+    await recorder.end_trace()
+    await store.upsert_trace(
+        TelemetryTrace(
+            trace_id="other-trace",
+            root_span_id="other-root",
+            session_id="custom-trace-id",
+            run_id="run-other",
+            spans=[
+                TelemetrySpan(
+                    trace_id="other-trace",
+                    span_id="other-root",
+                    name="agent.run",
+                    kind="agent.run",
+                    actor=TelemetryActor(type=ActorType.AGENT),
+                )
+            ],
+        )
+    )
+
+    trace = await agent.get_trace("custom-trace-id")
+
+    assert trace["trace_id"] == "custom-trace-id"
+    assert trace["run_id"] == "run-custom"
+
+
+@pytest.mark.asyncio
+async def test_get_latest_trace_returns_latest_session_trace() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    agent.agent.run = AsyncMock(side_effect=["first", "second"])
+
+    first = await agent.run("first", session_id="session-latest")
+    second = await agent.run("second", session_id="session-latest")
+
+    latest = await agent.get_latest_trace("session-latest")
+
+    assert latest["trace_id"] == second["trace_id"]
+    assert latest["trace_id"] != first["trace_id"]
+    assert latest["run_id"] == second["run_id"]
+
+
+@pytest.mark.asyncio
+async def test_get_trace_accepts_run_id_keyword() -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+
+    result = await agent.run("hello", session_id="session-run-lookup")
+
+    trace = await agent.get_trace(run_id=result["run_id"])
+
+    assert trace["trace_id"] == result["trace_id"]
+    assert trace["run_id"] == result["run_id"]
+    assert trace["session_id"] == "session-run-lookup"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status",
+    [
+        TraceStatus.PARTIAL,
+        TraceStatus.FAILED,
+        TraceStatus.CANCELLED,
+        TraceStatus.TIMEOUT,
+        TraceStatus.ABORTED_RESOURCE_GUARD,
+    ],
+)
+async def test_get_trace_returns_non_completed_trace_statuses(status) -> None:
+    store = InMemoryTelemetryStore()
+    agent = _initialized_agent(store=store)
+    trace_id = f"trace-{status.value}"
+    await store.upsert_trace(
+        TelemetryTrace(
+            trace_id=trace_id,
+            root_span_id=f"span-{status.value}",
+            status=status,
+            session_id=f"session-{status.value}",
+            run_id=f"run-{status.value}",
+            spans=[
+                TelemetrySpan(
+                    trace_id=trace_id,
+                    span_id=f"span-{status.value}",
+                    name="agent.run",
+                    kind="agent.run",
+                    actor=TelemetryActor(type=ActorType.AGENT),
+                )
+            ],
+        )
+    )
+
+    trace = await agent.get_trace(trace_id=trace_id)
+    normalized = await agent.get_trace(trace_id=trace_id, normalize=True)
+
+    assert trace["status"] == status.value
+    assert normalized["status"] == status.value
+    if status == TraceStatus.PARTIAL:
+        assert "incomplete_trace" in normalized["metadata"]["tags"]
+
+
+@pytest.mark.asyncio
+async def test_get_trace_rejects_ambiguous_filter_keywords() -> None:
+    agent = _initialized_agent()
+
+    with pytest.raises(ValueError, match="Use only one"):
+        await agent.get_trace(trace_id="trace-one", session_id="session-one")
+
+    with pytest.raises(ValueError, match="Use either identifier"):
+        await agent.get_trace("trace-one", session_id="session-one")
 
 
 @pytest.mark.asyncio

--- a/tests/test_telemetry_foundation.py
+++ b/tests/test_telemetry_foundation.py
@@ -199,6 +199,40 @@ async def test_jsonl_store_persists_trace_events_and_spans(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_jsonl_store_reloads_stream_scope_by_run_id(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    store = JsonlTelemetryStore(path)
+    first = TelemetryRecorder(store)
+    await first.start_trace(
+        trace_id="trace-jsonl-first",
+        session_id="session-jsonl-shared",
+        run_id="run-jsonl-first",
+    )
+    await first.emit_event("user_message", input={"message": "first"})
+    await first.end_trace()
+    second = TelemetryRecorder(store)
+    await second.start_trace(
+        trace_id="trace-jsonl-second",
+        session_id="session-jsonl-shared",
+        run_id="run-jsonl-second",
+    )
+    await second.emit_event("user_message", input={"message": "second"})
+    await second.end_trace()
+
+    reloaded = JsonlTelemetryStore(path)
+    events = await reloaded.get_events_after(
+        TelemetryStreamScope(
+            session_id="session-jsonl-shared",
+            run_id="run-jsonl-second",
+        ),
+        None,
+    )
+
+    assert [event.trace_id for event in events] == ["trace-jsonl-second"]
+    assert [event.input for event in events] == [{"message": "second"}]
+
+
+@pytest.mark.asyncio
 async def test_store_filters_traces():
     store = InMemoryTelemetryStore()
     recorder = TelemetryRecorder(store)
@@ -260,6 +294,100 @@ def test_normalizer_is_idempotent_for_missing_and_incomplete_trace():
     assert len(second.events) == len(first.events)
     assert "missing_evidence" in second.metadata.tags
     assert "incomplete_trace" in second.metadata.tags
+
+
+def test_normalizer_uses_stable_synthetic_event_ids_for_same_raw_trace():
+    trace = TelemetryTrace(trace_id="trace-stable-normalize", root_span_id="missing")
+    normalizer = TelemetryNormalizer()
+
+    first = normalizer.normalize(trace)
+    second = normalizer.normalize(trace)
+
+    assert first.model_dump() == second.model_dump()
+    assert {
+        event.event_id
+        for event in first.events
+        if event.metadata.get("normalizer")
+    } == {
+        "event_normalizer_trace-stable-normalize_missing_evidence",
+        "event_normalizer_trace-stable-normalize_incomplete_trace",
+    }
+
+
+def test_normalizer_avoids_synthetic_event_id_collision_with_raw_events():
+    trace = TelemetryTrace(
+        trace_id="trace-collision",
+        root_span_id="missing",
+        events=[
+            TelemetryEvent(
+                trace_id="trace-collision",
+                event_id="event_normalizer_trace-collision_missing_evidence",
+                event_type="runtime_error",
+                actor=TelemetryActor(type=ActorType.SYSTEM),
+                metadata={"experimental": True},
+            )
+        ],
+    )
+
+    normalized = TelemetryNormalizer().normalize(trace)
+    event_ids = [event.event_id for event in normalized.events]
+
+    assert len(event_ids) == len(set(event_ids))
+    assert "event_normalizer_trace-collision_missing_evidence" in event_ids
+    assert "event_normalizer_trace-collision_missing_evidence_1" in event_ids
+
+
+def test_normalizer_preserves_errors_status_and_sorts_event_ids():
+    span = TelemetrySpan(
+        trace_id="trace-preserve",
+        span_id="span-root",
+        name="agent.run",
+        kind="agent.run",
+        actor=TelemetryActor(type=ActorType.AGENT),
+        status=SpanStatus.ERROR,
+        error={"type": "RuntimeError", "message": "boom"},
+        event_ids=["event-2", "event-1", "event-2"],
+    )
+    trace = TelemetryTrace(
+        trace_id="trace-preserve",
+        root_span_id="span-root",
+        status=TraceStatus.FAILED,
+        spans=[span],
+        events=[
+            TelemetryEvent(
+                trace_id="trace-preserve",
+                event_id="event-2",
+                span_id="span-root",
+                sequence_number=2,
+                event_type="runtime_error",
+                actor=TelemetryActor(type=ActorType.SYSTEM),
+                error={"type": "RuntimeError", "message": "boom"},
+            ),
+            TelemetryEvent(
+                trace_id="trace-preserve",
+                event_id="event-1",
+                span_id="span-root",
+                sequence_number=1,
+                event_type="user_message",
+                actor=TelemetryActor(type=ActorType.USER),
+            ),
+        ],
+    )
+
+    normalized = TelemetryNormalizer().normalize(trace)
+
+    assert normalized.status == TraceStatus.FAILED
+    assert normalized.spans[0].status == SpanStatus.ERROR
+    assert normalized.spans[0].error.type == "RuntimeError"
+    assert normalized.spans[0].event_ids == ["event-1", "event-2"]
+    assert [event.event_id for event in normalized.events[:2]] == [
+        "event-1",
+        "event-2",
+    ]
+    assert normalized.events[-1].event_id == (
+        "event_normalizer_trace-preserve_incomplete_trace"
+    )
+    assert normalized.events[1].error.type == "RuntimeError"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- harden trace retrieval for exact trace ids, latest session traces, run-id lookup, normalized traces, and non-completed trace statuses
- keep telemetry stream contract store-backed and tighten OmniServe run SSE cursor scoping by run_id
- make trace normalization deterministic for synthetic evidence ids while preserving status, error, event order, and span event references
- align telemetry architecture/spec/docs with the hardened contract

## Verification
- uv run ruff check .
- uv run python -m compileall -q src/omnicoreagent tests
- git diff --check
- uv run pytest tests/test_runtime_telemetry_wiring.py tests/test_telemetry_foundation.py tests/test_omniserve_sse.py tests/test_omniserve_full.py tests/test_docs_claims.py -q (148 passed)
- uv run pytest -q (769 passed, 8 skipped)

## Evaluator agents
- trace retrieval reviewer: no blockers; requested direct get_trace(run_id=...) coverage, added
- telemetry stream reviewer: no blockers
- normalizer/old-events reviewer: found span event-id ordering and synthetic id collision issues, fixed both
