### PR TITLE
Finalize telemetry docs and run-scoped streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ uses.
 | **Agent Skills** | Loads packaged capabilities implemented with Python, Bash, or Node.js. |
 | **BM25 Tool Retrieval** | Selects relevant tools from large tool sets so the prompt stays focused. |
 | **Guardrails** | Adds prompt-injection screening inside the observation path with configurable behavior. |
-| **Telemetry Events** | Emits typed telemetry events for agent runs, tool calls, background work, and streaming integrations. |
+| **Telemetry and Traces** | Emits typed telemetry events and retrieves traces by exact `trace_id`, latest session, or `run_id` correlation for debugging and streaming integrations. |
 | **Workflow Orchestration** | Provides sequential, parallel, and router agents for multi-step application workflows. |
 | **Durable Background Tasks** | Runs manual or scheduled agent work with task state, run history, retries, cancellation, and workspace output. |
 | **Universal Models** | Supports OpenAI, Anthropic, Gemini, Groq, Ollama, DeepSeek, Mistral, OpenRouter, Azure, and Cencori through the runtime model layer. |

--- a/cookbook/getting_started/README.mdx
+++ b/cookbook/getting_started/README.mdx
@@ -17,7 +17,7 @@ Welcome to the **OmniCoreAgent** learning path. This guide takes you from writin
 | 5 | [agent_with_all_tools.py](./agent_with_all_tools.py) | **Hybrid Architecture**: Combine local + MCP tools |
 | 6 | [agent_with_memory.py](./agent_with_memory.py) | **Persistence**: Store conversations in Redis, Postgres, MongoDB |
 | 7 | [agent_with_memory_switching.py](./agent_with_memory_switching.py) | **Runtime Switching**: Change memory backends on the fly |
-| 8 | [agent_with_events.py](./agent_with_events.py) | **Observability**: Read and stream telemetry events |
+| 8 | [agent_with_events.py](./agent_with_events.py) | **Telemetry**: Replay run events, stream progress, and retrieve traces |
 | 9 | [agent_with_context_management.py](./agent_with_context_management.py) | **🆕 Context Management**: Keep long conversations within a configured context budget |
 | 10 | [agent_with_guardrails.py](./agent_with_guardrails.py) | **🆕 Guardrails**: Protect against prompt injection |
 | 11 | [agent_with_metrics.py](./agent_with_metrics.py) | **🆕 Metrics**: Track tokens, requests, and latency |

--- a/cookbook/getting_started/agent_with_events.py
+++ b/cookbook/getting_started/agent_with_events.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Agent with Event Streaming
+Agent with Telemetry Events and Traces
 
-Stream real-time telemetry events from your agent.
+Replay run-scoped telemetry, follow live events, and retrieve traces.
 Track: user messages, model calls, tool calls, observations, and final answers.
 
 Build on: agent_with_memory_switching.py
@@ -20,11 +20,37 @@ from omnicoreagent import OmniCoreAgent, MemoryRouter
 from _bootstrap import model_config, require_llm_api_key, response_text
 
 
+async def collect_run_visibility(agent: OmniCoreAgent, result: dict) -> dict:
+    """Collect run-scoped events plus exact and latest-session trace views."""
+    session_id = result["session_id"]
+    run_id = result["run_id"]
+    trace_id = result["trace_id"]
+
+    events = await agent.get_telemetry_events_after(
+        cursor=None,
+        session_id=session_id,
+        run_id=run_id,
+    )
+    exact_trace = await agent.get_trace(trace_id)
+    latest_session_trace = await agent.get_latest_trace(session_id)
+    normalized_trace = await agent.get_trace(trace_id, normalize=True)
+
+    return {
+        "session_id": session_id,
+        "run_id": run_id,
+        "trace_id": trace_id,
+        "events": events,
+        "exact_trace": exact_trace,
+        "latest_session_trace": latest_session_trace,
+        "normalized_trace": normalized_trace,
+    }
+
+
 async def main():
     require_llm_api_key()
 
     print("=" * 50)
-    print("AGENT WITH EVENT STREAMING")
+    print("AGENT WITH TELEMETRY EVENTS AND TRACES")
     print("=" * 50)
 
     agent = OmniCoreAgent(
@@ -34,30 +60,42 @@ async def main():
         memory_router=MemoryRouter("in_memory"),
     )
 
-    # Run a query
+    # Run a query. The returned identifiers are the handles for telemetry.
     session_id = "event_demo_session"
     print(f"\nRunning query with session: {session_id}")
     result = await agent.run(
         "What is 2 + 2? Explain step by step.", session_id=session_id
     )
     print(f"Response: {response_text(result)[:200]}...")
+    print(f"run_id={result['run_id']}")
+    print(f"trace_id={result['trace_id']}")
 
-    # Get telemetry events after the query
+    # Replay only this run's events. run_id keeps concurrent runs in the same
+    # session isolated from each other.
     print("\n" + "=" * 50)
-    print("EVENTS FROM SESSION")
+    print("EVENTS FROM RUN")
     print("=" * 50)
 
-    events = await agent.get_telemetry_events_after(cursor=None, session_id=session_id)
-    for event in events:
-        print(f"  [{event.event_type}]: {event.model_dump()}")
+    visibility = await collect_run_visibility(agent, result)
+    for event in visibility["events"]:
+        print(f"  [{event.event_type}] trace={event.trace_id}")
+
+    print("\n" + "=" * 50)
+    print("TRACE LOOKUPS")
+    print("=" * 50)
+    print(f"exact trace status={visibility['exact_trace']['status']}")
+    print(
+        f"latest session trace id={visibility['latest_session_trace']['trace_id']}"
+    )
+    print(f"normalized events={len(visibility['normalized_trace']['events'])}")
 
     await agent.cleanup()
 
 
 async def demo_streaming():
     """
-    Demo real-time event streaming.
-    This shows how to build UIs that display agent progress.
+    Demo real-time run-scoped telemetry streaming.
+    This shows how to build UIs that display one agent run's progress.
     """
 
     print("\n" + "=" * 50)

--- a/docs/core-concepts/events.mdx
+++ b/docs/core-concepts/events.mdx
@@ -29,6 +29,11 @@ events = await agent.get_telemetry_events_after(
 
 for event in events:
     print(event.event_type, event.model_dump())
+
+exact_trace = await agent.get_trace(result["trace_id"])
+latest_session_trace = await agent.get_latest_trace(result["session_id"])
+run_correlated_trace = await agent.get_trace(run_id=result["run_id"])
+normalized_trace = await agent.get_trace(result["trace_id"], normalize=True)
 ```
 
 ---
@@ -84,14 +89,19 @@ OmniServe uses the same telemetry stream:
 - `POST /run` streams telemetry for the run it starts and finishes with
   `complete`.
 - `GET /events/{session_id}` replays stored telemetry for a session and follows
-  new telemetry.
-- `GET /events/{session_id}/list` returns stored telemetry events as JSON.
+  new telemetry. Add `?run_id=...` to isolate one run inside that session.
+- `GET /events/{session_id}/list` returns stored telemetry events as JSON. Add
+  `?run_id=...` for the same run-scoped filtering.
 - `GET /events/{session_id}/trace` returns a compact telemetry summary for the
-  latest session trace.
+  latest session trace. Add `?run_id=...` to retrieve the trace for that run.
 
 Every telemetry event includes its `trace_id`. Runtime-created events also carry
 correlation metadata such as `run_id`, `session_id`, and `agent_id` when that
 context exists.
+
+Use `trace_id` for exact trace lookup. Use `run_id` to filter or correlate one
+runtime execution inside a session. If several traces share one `run_id`, the
+run lookup returns the latest matching trace.
 
 ---
 

--- a/docs/how-to-guides/basic-usage.mdx
+++ b/docs/how-to-guides/basic-usage.mdx
@@ -148,7 +148,8 @@ specific to your application.
 
 ## Event Streaming
 
-Read telemetry events for UIs, logging, and debugging:
+Read telemetry events for UIs, logging, and debugging. Use `run_id` when
+multiple runs can share the same `session_id`.
 
 ```python
 agent = OmniCoreAgent(
@@ -159,10 +160,20 @@ agent = OmniCoreAgent(
 
 result = await agent.run("What can you do?")
 session_id = result["session_id"]
+run_id = result["run_id"]
+trace_id = result["trace_id"]
 
-events = await agent.get_telemetry_events_after(cursor=None, session_id=session_id)
+events = await agent.get_telemetry_events_after(
+    cursor=None,
+    session_id=session_id,
+    run_id=run_id,
+)
 for event in events:
     print(event.event_type, event.model_dump())
+
+exact_trace = await agent.get_trace(trace_id)
+latest_session_trace = await agent.get_latest_trace(session_id)
+normalized_trace = await agent.get_trace(trace_id, normalize=True)
 ```
 
 ---

--- a/docs/how-to-guides/observability.mdx
+++ b/docs/how-to-guides/observability.mdx
@@ -61,7 +61,10 @@ for event in events:
 
 When serving through OmniServe, `POST /run` streams the live run over SSE and
 `GET /events/{session_id}` replays stored telemetry events for that session
-before following new live telemetry events.
+before following new live telemetry events. Add `?run_id=...` to
+`/events/{session_id}`, `/events/{session_id}/list`, or
+`/events/{session_id}/trace` when a UI needs to isolate one run inside a shared
+session.
 
 ```bash
 curl -N -X POST http://localhost:8000/run \
@@ -69,6 +72,8 @@ curl -N -X POST http://localhost:8000/run \
   -d '{"query": "Research this topic", "session_id": "research_1"}'
 
 curl -N http://localhost:8000/events/research_1
+curl http://localhost:8000/events/research_1/list?run_id=RUN_ID
+curl http://localhost:8000/events/research_1/trace?run_id=RUN_ID
 ```
 
 ---
@@ -89,13 +94,18 @@ for event in trace["events"]:
     print(event["event_type"], event.get("input"), event.get("output"))
 ```
 
-You can also retrieve the latest trace for a session or the trace for a run:
+You can also retrieve the latest trace for a session or a trace correlated to a
+run:
 
 ```python
-latest = await agent.get_latest_trace("research_1")
-same_run = await agent.get_trace(run_id=result["run_id"])
+latest_session_trace = await agent.get_latest_trace("research_1")
+run_correlated_trace = await agent.get_trace(run_id=result["run_id"])
 normalized = await agent.get_trace(result["trace_id"], normalize=True)
 ```
+
+`trace_id` is the exact trace handle. `run_id` is a correlation and filtering
+handle; when more than one trace is correlated to the same run, `get_trace(
+run_id=...)` returns the latest matching trace.
 
 The trace is intentionally internal and dependency-free. It is a compact
 debugging view built from telemetry events and spans, not a full tracing or

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -205,9 +205,9 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/prometheus` | No | Prometheus metrics |
 | `GET` | `/tools` | Yes* | List available tools |
 | `GET` | `/metrics` | Yes* | Agent usage metrics |
-| `GET` | `/events/{session_id}` | Yes* | Replay stored telemetry events, then follow live telemetry events over SSE |
-| `GET` | `/events/{session_id}/list` | Yes* | Return stored telemetry events as JSON |
-| `GET` | `/events/{session_id}/trace` | Yes* | Compact telemetry trace summary |
+| `GET` | `/events/{session_id}` | Yes* | Replay stored telemetry events, then follow live telemetry events over SSE; add `?run_id=...` to isolate one run |
+| `GET` | `/events/{session_id}/list` | Yes* | Return stored telemetry events as JSON; add `?run_id=...` to isolate one run |
+| `GET` | `/events/{session_id}/trace` | Yes* | Compact telemetry trace summary for the latest session trace, or `?run_id=...` for one run |
 | `GET` | `/docs` | No | Swagger UI |
 | `GET` | `/redoc` | No | ReDoc UI |
 
@@ -263,10 +263,19 @@ curl -X POST http://localhost:8000/run \
 # Replay and follow one session's events
 curl -N http://localhost:8000/events/user123
 
+# Replay one run inside a shared session
+curl -N "http://localhost:8000/events/user123?run_id=RUN_ID"
+curl "http://localhost:8000/events/user123/list?run_id=RUN_ID"
+curl "http://localhost:8000/events/user123/trace?run_id=RUN_ID"
+
 # List tools
 curl http://localhost:8000/tools \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
+
+For telemetry traces, `trace_id` is the exact lookup handle returned by the
+agent runtime. OmniServe's `run_id` query parameter is a session-scoped
+correlation filter for event replay and trace summaries.
 
 ### Background Task Example
 

--- a/engineering/architecture/telemetry.md
+++ b/engineering/architecture/telemetry.md
@@ -74,9 +74,9 @@ TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE
 canonical evidence store. `TelemetryStream` is a live/replay adapter over that
 same store. It is not a second event system.
 
-The old event-router idea is removed from the architecture. Routes such as
-`/events/{session_id}/trace` may keep their HTTP shape for developer ergonomics,
-but their data must be derived from telemetry traces and events.
+Routes such as `/events/{session_id}/trace` may keep their HTTP shape for
+developer ergonomics, but their data must be derived from telemetry traces and
+events.
 
 ## Core Concepts
 
@@ -192,6 +192,9 @@ The runtime facade wiring phase provides:
 - runtime helper methods for trace lookup and telemetry stream replay/follow
 - public `run(...)` responses include `trace_id` and `run_id` so application
   code can retrieve or stream the exact trace it just created
+- OmniServe session telemetry routes support `run_id` filtering so same-session
+  concurrent runs can be replayed, followed, and summarized without mixing
+  evidence
 - injected `telemetry_store`, `telemetry_recorder`, and `telemetry_stream`
   components must share the same store instance
 
@@ -226,8 +229,8 @@ The runtime loop instrumentation phase provides:
 - OmniServe `serve.request` traces/events for synchronous and SSE run
   boundaries, correlated to the same `session_id` and `run_id` as the agent run
 
-Remaining runtime coverage should be added directly through telemetry. No new
-event router, side-channel stream, or feature-specific event store should be
+Remaining runtime coverage should be added directly through telemetry. No
+parallel side-channel stream or feature-specific event store should be
 introduced.
 
 Runtime controls may also emit telemetry:
@@ -396,10 +399,8 @@ Redis streams are not the canonical long-term trace store.
 
 ## Telemetry Stream
 
-The telemetry stream is the live/replay adapter over telemetry records.
-
-It replaces the old event-router responsibility without becoming another
-truth source.
+The telemetry stream is the live/replay adapter over telemetry records. It is
+not another truth source.
 
 Responsibilities:
 

--- a/engineering/specifications/telemetry.md
+++ b/engineering/specifications/telemetry.md
@@ -32,7 +32,7 @@ This specification covers:
 - live/replay stream contract
 - normalization contract
 - redaction and payload policy
-- removal of the old event-router path in favor of telemetry-owned streaming
+- telemetry-owned streaming with no parallel event stack
 - required tests
 
 This specification does not cover:
@@ -492,7 +492,12 @@ Rules:
 - stream scopes must isolate sessions, runs, and traces.
 - `/run` SSE streams events for the trace/run it started.
 - `/events/{session_id}` remains as an HTTP route shape, but it must read from
-  telemetry records.
+  telemetry records. `?run_id=...` narrows replay and live follow to one run
+  inside that session.
+- `/events/{session_id}/list?run_id=...` returns stored telemetry events for
+  one run inside the session.
+- `/events/{session_id}/trace` returns the latest session trace; adding
+  `?run_id=...` returns the trace for that run.
 - stream failures must not corrupt the stored trace.
 - Redis streams may be used as an implementation backend for live fanout, but
   Redis stream records are not a separate canonical evidence model.
@@ -686,10 +691,9 @@ directly into `TelemetryStore`. That adapter is the runtime boundary that alread
 owns background event ordering and workspace mirrors; it must still write the
 same normalized telemetry models and feed the same `TelemetryStream` path.
 
-There must not be a parallel event stack:
+There must not be a parallel event stack. The canonical path is:
 
 ```text
-EventRouter -> EventStore
 TelemetryRecorder -> TelemetryStore
 ```
 
@@ -808,7 +812,7 @@ This design PR is acceptable when:
 - architecture and specification are accepted
 - telemetry owns the target streaming path:
   `TelemetryRecorder -> TelemetryStore -> TelemetryStream -> OmniServe SSE`
-- old event-router concerns are removed from the target architecture
+- the target architecture has no parallel event stack
 - the spec defines the schema, recorder, store, stream, normalizer, redaction,
   streaming, and future evaluation evidence contracts
 - docs clearly separate telemetry from observability and evaluation
@@ -822,6 +826,6 @@ The telemetry foundation implementation is acceptable when:
 - telemetry store can persist and retrieve traces locally
 - telemetry stream can replay/follow selected telemetry events
 - OmniServe SSE is backed by `TelemetryStream`
-- no code path writes to a separate EventRouter/EventStore
+- no code path writes to a separate event stack
 - normalizer can produce deterministic normalized traces
 - future evaluation can reference `trace_id`, `span_id`, and `event_id`

--- a/src/omnicoreagent/serve/routes/sessions.py
+++ b/src/omnicoreagent/serve/routes/sessions.py
@@ -1,6 +1,6 @@
 """Session and event routes for OmniServe."""
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
 from ..models import EventsResponse, SessionHistoryResponse, TraceResponse
@@ -18,10 +18,17 @@ def create_sessions_router() -> APIRouter:
         summary="Stream telemetry events (SSE)",
         description="Replay stored telemetry events for a session, then follow live telemetry events over SSE.",
     )
-    async def stream_telemetry_events(request: Request, session_id: str):
+    async def stream_telemetry_events(
+        request: Request,
+        session_id: str,
+        run_id: str | None = Query(
+            default=None,
+            description="Optional run id to isolate one run inside the session.",
+        ),
+    ):
         agent = get_agent(request)
         return StreamingResponse(
-            stream_session_events(agent, session_id),
+            stream_session_events(agent, session_id, run_id=run_id),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
@@ -36,10 +43,21 @@ def create_sessions_router() -> APIRouter:
         summary="Get telemetry events",
         description="Get stored telemetry events for a specific session as JSON.",
     )
-    async def list_telemetry_events(request: Request, session_id: str) -> EventsResponse:
+    async def list_telemetry_events(
+        request: Request,
+        session_id: str,
+        run_id: str | None = Query(
+            default=None,
+            description="Optional run id to isolate one run inside the session.",
+        ),
+    ) -> EventsResponse:
         agent = get_agent(request)
         events = normalize_events(
-            await agent.get_telemetry_events_after(cursor=None, session_id=session_id)
+            await agent.get_telemetry_events_after(
+                cursor=None,
+                session_id=session_id,
+                run_id=run_id,
+            )
         )
 
         return EventsResponse(
@@ -54,10 +72,25 @@ def create_sessions_router() -> APIRouter:
         summary="Get telemetry trace summary",
         description="Build a compact summary from the latest stored telemetry trace for the session.",
     )
-    async def get_trace(request: Request, session_id: str) -> TraceResponse:
+    async def get_trace(
+        request: Request,
+        session_id: str,
+        run_id: str | None = Query(
+            default=None,
+            description="Optional run id. When omitted, the latest session trace is returned.",
+        ),
+    ) -> TraceResponse:
         agent = get_agent(request)
-        trace = await agent.get_latest_trace(session_id)
+        trace = (
+            await agent.get_trace(run_id=run_id)
+            if run_id is not None
+            else await agent.get_latest_trace(session_id)
+        )
         trace = trace or {}
+        if run_id is not None and trace.get("session_id") != session_id:
+            trace = {}
+        elif run_id is None and trace.get("session_id") not in {None, session_id}:
+            trace = {}
         events = trace.get("events", [])
         spans = trace.get("spans", [])
 

--- a/src/omnicoreagent/serve/sse.py
+++ b/src/omnicoreagent/serve/sse.py
@@ -406,6 +406,7 @@ async def run_agent_stream(
 async def stream_session_events(
     agent: AgentType,
     session_id: str,
+    run_id: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Replay stored telemetry events, then stream live session telemetry via SSE.
@@ -416,25 +417,28 @@ async def stream_session_events(
     Args:
         agent: The agent
         session_id: Session ID to stream events for
+        run_id: Optional run ID to isolate one run inside a shared session
 
     Yields:
         SSE-formatted event strings
     """
-    yield format_sse_event("session", {"session_id": session_id, "status": "streaming"})
+    yield format_sse_event(
+        "session", {"session_id": session_id, "run_id": run_id, "status": "streaming"}
+    )
 
     event_queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=_SSE_EVENT_QUEUE_SIZE)
     pump_task: asyncio.Task[Any] | None = None
     seen_event_ids: set[str] = set()
 
     try:
-        cursor = await _get_telemetry_stream_cursor(agent, session_id)
+        cursor = await _get_telemetry_stream_cursor(agent, session_id, run_id)
         pump_task = asyncio.create_task(
-            _pump_session_events(agent, session_id, event_queue, cursor)
+            _pump_session_events(agent, session_id, event_queue, cursor, run_id)
         )
 
         try:
             replay_events = await asyncio.wait_for(
-                _get_telemetry_events_after_cursor(agent, session_id, None),
+                _get_telemetry_events_after_cursor(agent, session_id, None, run_id),
                 timeout=_EVENT_REPLAY_TIMEOUT_SECONDS,
             )
         except Exception as exc:
@@ -442,11 +446,13 @@ async def stream_session_events(
             replay_events = []
             yield format_sse_event(
                 "error",
-                {"error": str(exc), "session_id": session_id},
+                {"error": str(exc), "session_id": session_id, "run_id": run_id},
             )
 
         for event in replay_events:
             event_type, event_data = _normalize_event_for_sse(event, session_id)
+            if not _event_matches_run(event_data, run_id):
+                continue
             event_id = event_data.get("event_id")
             if event_id is not None:
                 seen_event_ids.add(str(event_id))
@@ -458,6 +464,8 @@ async def stream_session_events(
                 raise event.error
 
             event_type, event_data = _normalize_event_for_sse(event, session_id)
+            if not _event_matches_run(event_data, run_id):
+                continue
             event_id = event_data.get("event_id")
             if event_id is not None and str(event_id) in seen_event_ids:
                 continue
@@ -467,8 +475,12 @@ async def stream_session_events(
             yield format_sse_event(event_type, event_data)
     except Exception as e:
         logger.error(f"OmniServe SSE: Event replay error: {e}")
-        yield format_sse_event("error", {"error": str(e), "session_id": session_id})
+        yield format_sse_event(
+            "error", {"error": str(e), "session_id": session_id, "run_id": run_id}
+        )
     finally:
         await _cancel_task(pump_task)
 
-    yield format_sse_event("session", {"session_id": session_id, "status": "ended"})
+    yield format_sse_event(
+        "session", {"session_id": session_id, "run_id": run_id, "status": "ended"}
+    )

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -319,3 +319,71 @@ def test_background_docs_include_durable_backend_selection_guidance():
         text = path.read_text(encoding="utf-8")
         missing = sorted(phrase for phrase in expected if phrase not in text)
         assert not missing, f"{path} is missing backend selection guidance: {missing}"
+
+
+def test_telemetry_docs_describe_trace_lookup_and_run_scoped_streaming():
+    docs = [
+        Path("docs/core-concepts/events.mdx"),
+        Path("docs/how-to-guides/basic-usage.mdx"),
+        Path("docs/how-to-guides/observability.mdx"),
+    ]
+    expected = {
+        'result["trace_id"]',
+        'result["run_id"]',
+        "get_trace",
+        "get_latest_trace",
+        "normalize=True",
+    }
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        missing = sorted(phrase for phrase in expected if phrase not in text)
+        assert not missing, f"{path} is missing telemetry contract docs: {missing}"
+
+    omniserve_text = Path("docs/how-to-guides/omniserve.mdx").read_text(
+        encoding="utf-8"
+    )
+    for expected_route in {
+        "/events/{session_id}",
+        "/events/{session_id}/list",
+        "/events/{session_id}/trace",
+        "?run_id=",
+    }:
+        assert expected_route in omniserve_text
+
+    for path in [
+        Path("docs/core-concepts/events.mdx"),
+        Path("docs/how-to-guides/observability.mdx"),
+        Path("docs/how-to-guides/omniserve.mdx"),
+    ]:
+        text = path.read_text(encoding="utf-8")
+        assert "?run_id=" in text
+
+
+def test_telemetry_docs_do_not_reference_old_event_router():
+    docs = [
+        Path("README.md"),
+        Path("docs"),
+        Path("cookbook"),
+        Path("engineering/architecture/telemetry.md"),
+        Path("engineering/specifications/telemetry.md"),
+    ]
+    forbidden = {
+        "EventRouter",
+        "event router",
+        "event-router",
+        "core/events",
+    }
+    offenders: list[str] = []
+
+    for path in docs:
+        files = [path] if path.is_file() else path.rglob("*")
+        for file_path in files:
+            if file_path.suffix not in {".md", ".mdx", ".py"}:
+                continue
+            text = file_path.read_text(encoding="utf-8")
+            found = sorted(phrase for phrase in forbidden if phrase in text)
+            if found:
+                offenders.append(f"{file_path}: {', '.join(found)}")
+
+    assert not offenders, "Old event-router wording remains:\n" + "\n".join(offenders)

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -618,6 +618,16 @@ class TestEndpoints:
                 "spans": [{"kind": "agent.run"}],
             }
         )
+        agent.get_trace = AsyncMock(
+            return_value={
+                "trace_id": "trace_endpoint_by_run",
+                "run_id": "run_endpoint",
+                "session_id": "test-endpoint-session",
+                "status": "completed",
+                "events": [{"event_type": "final_answer"}],
+                "spans": [{"kind": "agent.run"}],
+            }
+        )
         store = InMemoryTelemetryStore()
         agent.telemetry_store = store
         agent.get_telemetry_events_after = AsyncMock(
@@ -841,6 +851,62 @@ class TestEndpoints:
         agent = server_client.app.state.agent
         agent.get_latest_trace.assert_awaited_with("trace_like_session")
 
+    def test_trace_endpoint_can_filter_by_run_id(self, server_client):
+        resp = server_client.get(
+            "/events/test-endpoint-session/trace?run_id=run_endpoint"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["trace_id"] == "trace_endpoint_by_run"
+        assert data["summary"]["run_id"] == "run_endpoint"
+        assert data["steps"][0]["event_type"] == "final_answer"
+        agent = server_client.app.state.agent
+        agent.get_trace.assert_awaited_with(run_id="run_endpoint")
+
+    def test_trace_endpoint_rejects_run_id_from_another_session(self, server_client):
+        agent = server_client.app.state.agent
+        agent.get_trace.return_value = {
+            "trace_id": "trace_other",
+            "run_id": "run_other",
+            "session_id": "other-session",
+            "status": "completed",
+            "events": [{"event_type": "user_message"}],
+            "spans": [{"kind": "agent.run"}],
+        }
+
+        resp = server_client.get("/events/test-endpoint-session/trace?run_id=run_other")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "test-endpoint-session"
+        assert data["summary"] == {
+            "trace_id": None,
+            "run_id": None,
+            "status": None,
+            "event_count": 0,
+            "span_count": 0,
+        }
+        assert data["steps"] == []
+
+    def test_trace_endpoint_returns_empty_summary_for_missing_run_id(
+        self, server_client
+    ):
+        agent = server_client.app.state.agent
+        agent.get_trace.return_value = None
+
+        resp = server_client.get(
+            "/events/test-endpoint-session/trace?run_id=run_missing"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["trace_id"] is None
+        assert data["summary"]["run_id"] is None
+        assert data["summary"]["event_count"] == 0
+        assert data["summary"]["span_count"] == 0
+        assert data["steps"] == []
+
     def test_events_list_endpoint_uses_telemetry_events_accessor(self, server_client):
         resp = server_client.get("/events/test-endpoint-session/list")
 
@@ -853,6 +919,20 @@ class TestEndpoints:
         agent.get_telemetry_events_after.assert_awaited_with(
             cursor=None,
             session_id="test-endpoint-session",
+            run_id=None,
+        )
+
+    def test_events_list_endpoint_can_filter_by_run_id(self, server_client):
+        resp = server_client.get(
+            "/events/test-endpoint-session/list?run_id=run_endpoint"
+        )
+
+        assert resp.status_code == 200
+        agent = server_client.app.state.agent
+        agent.get_telemetry_events_after.assert_awaited_with(
+            cursor=None,
+            session_id="test-endpoint-session",
+            run_id="run_endpoint",
         )
 
     def test_run_normalizes_string_agent_result(self):

--- a/tests/test_omniserve_sse.py
+++ b/tests/test_omniserve_sse.py
@@ -311,3 +311,60 @@ async def test_stream_session_events_replays_existing_telemetry():
         "final_answer",
     ]
     assert _event_data(chunks[1])["run_id"] == "run_existing"
+
+
+@pytest.mark.asyncio
+async def test_stream_session_events_filters_existing_telemetry_by_run_id():
+    agent = _TelemetryAgent()
+    await agent.run("first", session_id="session-shared", run_id="run_first")
+    await agent.run("second", session_id="session-shared", run_id="run_second")
+
+    stream = stream_session_events(agent, "session-shared", run_id="run_second")
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+        if _event_name(chunk) == "final_answer":
+            break
+    await stream.aclose()
+
+    event_chunks = [
+        chunk for chunk in chunks if _event_name(chunk) not in {"session", "complete"}
+    ]
+    assert [_event_name(chunk) for chunk in event_chunks] == [
+        "user_message",
+        "final_answer",
+    ]
+    assert {_event_data(chunk)["run_id"] for chunk in event_chunks} == {"run_second"}
+    assert _event_data(chunks[0])["run_id"] == "run_second"
+
+
+@pytest.mark.asyncio
+async def test_stream_session_events_defensively_filters_when_agent_ignores_run_id():
+    agent = _UnfilteredTelemetryAgent(TelemetryConfig(max_payload_bytes=1))
+    await agent.run("first", session_id="session-shared-unfiltered", run_id="run_first")
+    await agent.run(
+        "second",
+        session_id="session-shared-unfiltered",
+        run_id="run_second",
+    )
+
+    stream = stream_session_events(
+        agent,
+        "session-shared-unfiltered",
+        run_id="run_second",
+    )
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+        if _event_name(chunk) == "final_answer":
+            break
+    await stream.aclose()
+
+    event_chunks = [
+        chunk for chunk in chunks if _event_name(chunk) not in {"session", "complete"}
+    ]
+    assert [_event_name(chunk) for chunk in event_chunks] == [
+        "user_message",
+        "final_answer",
+    ]
+    assert {_event_data(chunk)["run_id"] for chunk in event_chunks} == {"run_second"}

--- a/tests/test_telemetry_cookbook.py
+++ b/tests/test_telemetry_cookbook.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_PATH = ROOT / "cookbook" / "getting_started" / "agent_with_events.py"
+
+
+def load_events_example_module():
+    script_dir = str(EXAMPLE_PATH.parent)
+    sys.modules.pop("_bootstrap", None)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+    spec = importlib.util.spec_from_file_location("agent_with_events", EXAMPLE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeTelemetryAgent:
+    async def get_telemetry_events_after(self, *, cursor, session_id, run_id):
+        assert cursor is None
+        assert session_id == "session-cookbook"
+        assert run_id == "run-cookbook"
+        return [
+            SimpleNamespace(event_type="user_message", trace_id="trace-cookbook"),
+            SimpleNamespace(event_type="final_answer", trace_id="trace-cookbook"),
+        ]
+
+    async def get_trace(self, trace_id=None, *, run_id=None, normalize=False):
+        assert run_id is None
+        assert trace_id == "trace-cookbook"
+        return {
+            "trace_id": trace_id,
+            "run_id": "run-cookbook",
+            "session_id": "session-cookbook",
+            "status": "completed",
+            "events": [{"event_type": "user_message"}],
+            "spans": [{"kind": "agent.run"}],
+            "normalized": normalize,
+        }
+
+    async def get_latest_trace(self, session_id):
+        assert session_id == "session-cookbook"
+        return {
+            "trace_id": "trace-cookbook",
+            "run_id": "run-cookbook",
+            "session_id": session_id,
+            "status": "completed",
+            "events": [],
+            "spans": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_getting_started_events_example_collects_public_trace_surfaces():
+    module = load_events_example_module()
+    result = {
+        "session_id": "session-cookbook",
+        "run_id": "run-cookbook",
+        "trace_id": "trace-cookbook",
+    }
+
+    visibility = await module.collect_run_visibility(FakeTelemetryAgent(), result)
+
+    assert [event.event_type for event in visibility["events"]] == [
+        "user_message",
+        "final_answer",
+    ]
+    assert visibility["exact_trace"]["trace_id"] == "trace-cookbook"
+    assert visibility["latest_session_trace"]["trace_id"] == "trace-cookbook"
+    assert visibility["normalized_trace"]["normalized"] is True


### PR DESCRIPTION
## Summary
- document telemetry traces as exact trace_id lookup plus run_id correlation/filtering
- update the getting-started telemetry cookbook to show run-scoped event replay, exact trace lookup, latest session trace, and normalized trace retrieval
- add run_id filtering to OmniServe session event, list, and trace routes, with defensive SSE filtering when adapters ignore run_id
- align internal telemetry architecture/spec wording around telemetry-owned streaming with no parallel event stack

## Verification
- uv run pytest -q
- uv run pytest tests/test_docs_claims.py tests/test_telemetry_cookbook.py tests/test_telemetry_foundation.py tests/test_runtime_telemetry_wiring.py tests/test_omniserve_sse.py tests/test_omniserve_full.py -q
- uv run ruff check src/omnicoreagent/serve/sse.py src/omnicoreagent/serve/routes/sessions.py cookbook/getting_started/agent_with_events.py tests/test_telemetry_cookbook.py tests/test_omniserve_sse.py tests/test_omniserve_full.py tests/test_docs_claims.py
- uv run python -m compileall -q cookbook/getting_started/agent_with_events.py src/omnicoreagent/serve/routes/sessions.py src/omnicoreagent/serve/sse.py

## Reviewer Pass
- code contract evaluator found run_id defensive filtering and trace session-scope gaps; fixed with tests
- QA evaluator found missing unfiltered-adapter and cross-session/missing trace tests; fixed
- docs evaluator found trace_id vs run_id wording ambiguity; fixed
- final code/docs verifiers reported no blocking issues