### PR TITLE
Add real application harness examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ small.
 | Connect MCP server tools | [MCP tools cookbook](./cookbook/getting_started/agent_with_mcp_tools.py) |
 | Manage memory and context | [Getting started cookbook](./cookbook/getting_started) |
 | Save files, artifacts, and large tool results | [Tool offload cookbook](./cookbook/getting_started/agent_with_tool_offload.py) |
+| Build a production-shaped app harness | [Real applications cookbook](./cookbook/real_applications) |
 | Build multi-step workflows | [Workflows cookbook](./cookbook/workflows) |
 | Serve an agent over HTTP/SSE | [OmniServe cookbook](./cookbook/omniserve) |
 | Understand the runtime internals | [Implementation Map](#implementation-map) |
@@ -368,6 +369,7 @@ All examples live in the **[Cookbook](./cookbook)** and are organized by use cas
 | Category | What You'll Build |
 |----------|-------------------|
 | [Getting Started](./cookbook/getting_started) | First agent, tools, memory, events |
+| [Real Applications](./cookbook/real_applications) | Due diligence, support operations, and workspace code review harnesses |
 | [Workflows](./cookbook/workflows) | Sequential, Parallel, Router agents |
 | [Background Agents](./cookbook/background_agents) | Scheduled autonomous tasks |
 | [Production](./cookbook/production) | Guardrails, serving, and production patterns |

--- a/cookbook/README.mdx
+++ b/cookbook/README.mdx
@@ -46,6 +46,9 @@ print(result["response"])
 → **[getting_started/agent_with_sub_agents.py](./getting_started/agent_with_sub_agents.py)** — OmniCoreAgent dynamic subagents, workspace files, and orchestration.
 
 ### 🏭 I want to build a real application
+→ **[real_applications](./real_applications)** — Production-shaped app harness examples that show domain tools, workspace files, offloading, telemetry, guardrails, and workspace command tools across different apps.
+
+### 🧪 I want more domain demos
 → **[advanced_agent](./advanced_agent)** — E-commerce, flight booking, customer support, due diligence.
 
 ### 🌐 I want to deploy as an API
@@ -64,6 +67,7 @@ cookbook/
 ├── workflows/           # Multi-agent orchestration patterns
 ├── background_agents/   # Scheduled and autonomous agents
 ├── omniserve/           # 🆕 Deploy agents as REST/SSE APIs
+├── real_applications/   # End-to-end application harness examples
 ├── advanced_agent/      # Real-world application examples
 └── production/          # Production-ready configurations
 ```
@@ -74,6 +78,9 @@ cookbook/
 
 | Example | What You'll Build |
 |---------|-------------------|
+| [Research Due Diligence](./real_applications/research_due_diligence_agent.py) | Research agent with parallel tools, workspace reports, artifact readback, telemetry |
+| [Support Operations](./real_applications/support_operations_agent.py) | Support agent with customer/order tools, guardrails, escalation, workspace notes |
+| [Workspace Code Review](./real_applications/workspace_code_review_agent.py) | Code review agent using built-in workspace file commands instead of unrestricted shell |
 | [E-commerce Shopper](./advanced_agent/e_commerce_personal_shopper_agent.py) | Personal shopping assistant with cart, preferences, recommendations |
 | [Flight Booking](./advanced_agent/flightBooking_agent.py) | Travel agent with search, booking, and itinerary management |
 | [Customer Support](./advanced_agent/real_time_customer_support_agent.py) | Support agent with ticket handling and escalation |

--- a/cookbook/real_applications/README.mdx
+++ b/cookbook/real_applications/README.mdx
@@ -1,0 +1,35 @@
+# Real Application Harness Examples
+
+These examples show OmniCoreAgent as an application-facing agent harness, not a toy loop. Each app combines domain behavior with the built-in runtime pieces it needs: local tools, workspace files, tool offloading, guardrails, telemetry identifiers, and file commands.
+
+## Examples
+
+| Example | What it demonstrates |
+|---------|----------------------|
+| [Research due diligence](./research_due_diligence_agent.py) | Parallel research tools, context management, large evidence offload, artifact readback, workspace report output, telemetry identifiers |
+| [Support operations](./support_operations_agent.py) | Customer/order tools, support knowledge retrieval, guardrails, workspace ticket notes, telemetry |
+| [Workspace code review](./workspace_code_review_agent.py) | Built-in workspace command tools for file discovery, grep-style search, reading, editing, and writing review output |
+
+## Run an Example
+
+```bash
+export LLM_API_KEY=your_key
+uv run python cookbook/real_applications/research_due_diligence_agent.py
+```
+
+The examples default to the provider/model from `cookbook/shared.py`. Override them with:
+
+```bash
+export OMNICOREAGENT_PROVIDER=openai
+export OMNICOREAGENT_MODEL=gpt-5.4-mini
+```
+
+## Why these examples exist
+
+Application builders need to see where OmniCoreAgent owns the base harness and where their application code plugs in.
+
+- App code provides domain tools, instructions, data sources, and business rules.
+- OmniCoreAgent provides the model loop, tool execution, workspace files, structured observations, offloading, telemetry, memory, and guardrails.
+- The same application pattern can be served later through OmniServe or run through background tasks when the app needs those boundaries.
+
+Use these examples as starting points for your own application harness.

--- a/cookbook/real_applications/__init__.py
+++ b/cookbook/real_applications/__init__.py
@@ -1,0 +1,1 @@
+"""Real application examples for OmniCoreAgent."""

--- a/cookbook/real_applications/_bootstrap.py
+++ b/cookbook/real_applications/_bootstrap.py
@@ -1,0 +1,16 @@
+"""Import helpers for running real application examples as plain scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from cookbook.shared import (  # noqa: E402,F401
+    model_config,
+    require_llm_api_key,
+    response_text,
+)

--- a/cookbook/real_applications/research_due_diligence_agent.py
+++ b/cookbook/real_applications/research_due_diligence_agent.py
@@ -1,0 +1,129 @@
+"""Research due diligence agent built on OmniCoreAgent.
+
+The app supplies domain tools. OmniCoreAgent supplies the harness: model loop,
+parallel tool batches, workspace files, tool offloading, and telemetry traces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from omnicoreagent import MemoryRouter, OmniCoreAgent, ToolRegistry
+
+from _bootstrap import model_config, require_llm_api_key, response_text
+
+
+def build_research_tools() -> ToolRegistry:
+    """Create deterministic research tools for the due diligence workflow."""
+    tools = ToolRegistry()
+
+    @tools.register_tool("company_profile")
+    def company_profile(company: str) -> dict:
+        return {
+            "company": company,
+            "sector": "AI infrastructure",
+            "stage": "Series B",
+            "team": 84,
+            "revenue_band": "$10M-$25M",
+            "customers": ["fintech", "developer tools", "health operations"],
+        }
+
+    @tools.register_tool("market_signals")
+    def market_signals(company: str) -> dict:
+        return {
+            "company": company,
+            "tailwinds": [
+                "enterprise demand for agent infrastructure",
+                "migration from demos to production agent systems",
+                "budget moving toward governed automation",
+            ],
+            "headwinds": [
+                "crowded developer tooling market",
+                "long enterprise security review cycles",
+            ],
+        }
+
+    @tools.register_tool("risk_register")
+    def risk_register(company: str) -> dict:
+        return {
+            "company": company,
+            "risks": [
+                {"name": "platform dependency", "severity": "medium"},
+                {"name": "enterprise sales cycle", "severity": "medium"},
+                {"name": "model capability drift", "severity": "low"},
+            ],
+        }
+
+    @tools.register_tool("evidence_pack")
+    def evidence_pack(company: str) -> dict:
+        lines = [
+            f"{company} evidence line {index}: customer signal, market note, or diligence detail."
+            for index in range(180)
+        ]
+        return {
+            "company": company,
+            "documents": "\n".join(lines),
+            "source_count": len(lines),
+        }
+
+    return tools
+
+
+def build_agent(
+    workspace_dir: Path | str = "tmp/real_apps/due_diligence",
+) -> OmniCoreAgent:
+    return OmniCoreAgent(
+        name="due_diligence_agent",
+        system_instruction="""You are a due diligence analyst.
+Use independent tools in the same batch when their inputs do not depend on each other.
+Save durable notes and reports in workspace files. If a tool response is offloaded,
+use artifact readback tools when the full evidence is needed.""",
+        model_config=model_config(max_tokens=1200),
+        local_tools=build_research_tools(),
+        memory_router=MemoryRouter("in_memory"),
+        agent_config={
+            "max_steps": 12,
+            "tool_call_timeout": 20,
+            "enable_advanced_tool_use": True,
+            "enable_workspace_files": True,
+            "context_management": {
+                "enabled": True,
+                "mode": "token_budget",
+                "value": 20000,
+                "threshold_percent": 75,
+                "strategy": "truncate",
+            },
+            "tool_offload": {
+                "enabled": True,
+                "threshold_tokens": 250,
+                "threshold_bytes": 1200,
+                "max_preview_tokens": 120,
+            },
+            "workspace_config": {
+                "workspace_backend": "local",
+                "workspace_dir": str(workspace_dir),
+            },
+        },
+    )
+
+
+async def main() -> None:
+    require_llm_api_key()
+
+    agent = build_agent()
+    result = await agent.run(
+        "Run due diligence on OmniRetail AI. Gather profile, market signals, risk register, "
+        "and the evidence pack together where possible. Save a markdown memo at "
+        "reports/omniretail-diligence.md and return the investment view.",
+        session_id="real_app_due_diligence",
+    )
+
+    print(response_text(result))
+    print(f"trace_id={result['trace_id']}")
+    print(f"run_id={result['run_id']}")
+    await agent.cleanup()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/real_applications/support_operations_agent.py
+++ b/cookbook/real_applications/support_operations_agent.py
@@ -1,0 +1,100 @@
+"""Support operations agent built on OmniCoreAgent."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from omnicoreagent import MemoryRouter, OmniCoreAgent, ToolRegistry
+
+from _bootstrap import model_config, require_llm_api_key, response_text
+
+
+def build_support_tools() -> ToolRegistry:
+    tools = ToolRegistry()
+
+    @tools.register_tool("lookup_customer")
+    def lookup_customer(customer_id: str) -> dict:
+        return {
+            "customer_id": customer_id,
+            "name": "Ada Ventures",
+            "plan": "enterprise",
+            "region": "EMEA",
+            "account_health": "green",
+        }
+
+    @tools.register_tool("recent_orders")
+    def recent_orders(customer_id: str) -> dict:
+        return {
+            "customer_id": customer_id,
+            "orders": [
+                {"id": "ord-1001", "status": "delivered", "value": 4200},
+                {"id": "ord-1002", "status": "delayed", "value": 1800},
+            ],
+        }
+
+    @tools.register_tool("support_policy_search")
+    def support_policy_search(query: str) -> dict:
+        return {
+            "query": query,
+            "policy": (
+                "Enterprise delayed shipments above $1000 require a support note, "
+                "customer-visible timeline, and optional goodwill credit review."
+            ),
+        }
+
+    @tools.register_tool("create_escalation")
+    def create_escalation(ticket_id: str, severity: str, summary: str) -> dict:
+        return {
+            "ticket_id": ticket_id,
+            "severity": severity,
+            "summary": summary,
+            "status": "queued_for_specialist",
+        }
+
+    return tools
+
+
+def build_agent(
+    workspace_dir: Path | str = "tmp/real_apps/support_ops",
+) -> OmniCoreAgent:
+    return OmniCoreAgent(
+        name="support_operations_agent",
+        system_instruction="""You are a support operations agent.
+Use customer, order, and policy tools together when possible. Keep a durable
+ticket note in workspace files before returning the customer-facing plan.""",
+        model_config=model_config(max_tokens=1100),
+        local_tools=build_support_tools(),
+        memory_router=MemoryRouter("in_memory"),
+        agent_config={
+            "max_steps": 10,
+            "tool_call_timeout": 20,
+            "enable_workspace_files": True,
+            "guardrail_config": {"strict_mode": True},
+            "workspace_config": {
+                "workspace_backend": "local",
+                "workspace_dir": str(workspace_dir),
+            },
+        },
+    )
+
+
+async def main() -> None:
+    require_llm_api_key()
+
+    agent = build_agent()
+    result = await agent.run(
+        "Handle ticket tck-1042 for customer cust-001. The customer says order ord-1002 "
+        "is delayed and wants a clear plan. Gather the account, order, and policy context, "
+        "create an escalation if needed, and save notes at tickets/tck-1042.md.",
+        session_id="real_app_support_ops",
+    )
+
+    print(response_text(result))
+    print(f"trace_id={result['trace_id']}")
+    print(f"run_id={result['run_id']}")
+    await agent.cleanup()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/real_applications/workspace_code_review_agent.py
+++ b/cookbook/real_applications/workspace_code_review_agent.py
@@ -1,0 +1,92 @@
+"""Workspace code review agent using built-in workspace command tools."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from omnicoreagent import MemoryRouter, OmniCoreAgent
+
+from _bootstrap import model_config, require_llm_api_key, response_text
+
+
+def seed_workspace(workspace_dir: Path) -> None:
+    files_dir = workspace_dir / "files"
+    (files_dir / "src").mkdir(parents=True, exist_ok=True)
+    (files_dir / "tests").mkdir(parents=True, exist_ok=True)
+    billing_file = files_dir / "src" / "billing.py"
+    if not billing_file.exists():
+        billing_file.write_text(
+            "\n".join(
+                [
+                    "def calculate_total(items):",
+                    "    total = 0",
+                    "    for item in items:",
+                    "        total += item['price']",
+                    "    return total",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+    test_file = files_dir / "tests" / "test_billing.py"
+    if not test_file.exists():
+        test_file.write_text(
+            "\n".join(
+                [
+                    "from src.billing import calculate_total",
+                    "",
+                    "",
+                    "def test_calculate_total():",
+                    "    assert calculate_total([{'price': 5}, {'price': 7}]) == 12",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+
+def build_agent(
+    workspace_dir: Path | str = "tmp/real_apps/code_review",
+) -> OmniCoreAgent:
+    workspace_path = Path(workspace_dir)
+    seed_workspace(workspace_path)
+
+    return OmniCoreAgent(
+        name="workspace_code_review_agent",
+        system_instruction="""You are a code review agent operating only inside workspace files.
+Use ls, glob, grep, read_file, edit_file, and write_file to inspect and update files.
+Write your final review to reviews/billing-review.md.""",
+        model_config=model_config(max_tokens=1200),
+        memory_router=MemoryRouter("in_memory"),
+        agent_config={
+            "max_steps": 12,
+            "tool_call_timeout": 20,
+            "enable_workspace_files": True,
+            "workspace_config": {
+                "workspace_backend": "local",
+                "workspace_dir": str(workspace_path),
+            },
+        },
+    )
+
+
+async def main() -> None:
+    require_llm_api_key()
+
+    agent = build_agent()
+    result = await agent.run(
+        "Review the billing module. Inspect the workspace, search for calculate_total, "
+        "update src/billing.py so negative prices are rejected, and write a concise "
+        "review at reviews/billing-review.md.",
+        session_id="real_app_workspace_code_review",
+    )
+
+    print(response_text(result))
+    print(f"trace_id={result['trace_id']}")
+    print(f"run_id={result['run_id']}")
+    await agent.cleanup()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_real_application_examples.py
+++ b/tests/test_real_application_examples.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from omnicoreagent.core.agents.base import BaseReactAgent
+from omnicoreagent.core.telemetry import (
+    ActorType,
+    InMemoryTelemetryStore,
+    TelemetryActor,
+    TelemetryRecorder,
+)
+from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.workspace.config import WorkspaceConfig
+
+
+class HarnessHistory:
+    def __init__(self) -> None:
+        self.items: list[dict] = []
+
+    async def add_message_to_history(
+        self,
+        role: str,
+        content: str,
+        metadata: dict | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        self.items.append(
+            {
+                "role": role,
+                "content": content,
+                "metadata": metadata or {},
+                "session_id": session_id,
+            }
+        )
+
+    async def message_history(
+        self,
+        session_id: str,
+        agent_name: str | None = None,
+    ) -> list[dict]:
+        return [
+            item
+            for item in self.items
+            if item["session_id"] == session_id
+            and (agent_name is None or item["metadata"].get("agent_name") == agent_name)
+        ]
+
+    def called_tools(self) -> set[str]:
+        return {
+            item["metadata"].get("tool")
+            for item in self.items
+            if item["role"] == "tool"
+        }
+
+
+async def run_scripted_agent(
+    *,
+    tmp_path: Path,
+    agent_name: str,
+    llm,
+    local_tools: ToolRegistry | None = None,
+    workspace_files: bool = True,
+    advanced_tools: bool = False,
+    tool_offload: dict | None = None,
+    max_steps: int = 10,
+) -> tuple[dict, HarnessHistory, InMemoryTelemetryStore, Path]:
+    workspace_dir = tmp_path / agent_name
+    telemetry_store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(telemetry_store)
+    history = HarnessHistory()
+
+    agent = BaseReactAgent(
+        agent_name=agent_name,
+        max_steps=max_steps,
+        tool_call_timeout=5,
+        enable_advanced_tool_use=advanced_tools,
+        enable_workspace_files=workspace_files,
+        tool_offload_config=tool_offload or {"enabled": False},
+        workspace_config=WorkspaceConfig(workspace_dir=workspace_dir),
+    )
+    context = await recorder.start_trace(
+        name="agent.run",
+        kind="agent.run",
+        actor=TelemetryActor(type=ActorType.AGENT, name=agent_name),
+        session_id=f"session-{agent_name}",
+        run_id=f"run-{agent_name}",
+    )
+
+    result = await agent.run(
+        system_prompt=f"You are {agent_name}.",
+        query="Run the real application task.",
+        llm_connection=llm,
+        add_message_to_history=history.add_message_to_history,
+        message_history=history.message_history,
+        sessions={},
+        mcp_tools={},
+        local_tools=local_tools,
+        session_id=f"session-{agent_name}",
+        telemetry_recorder=recorder,
+    )
+    await recorder.end_trace(output={"answer": result["answer"]})
+    assert context.trace_id
+    return result, history, telemetry_store, workspace_dir
+
+
+class DueDiligenceLlm:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.artifact_id: str | None = None
+
+    async def llm_call(self, messages):
+        self.calls += 1
+        transcript = "\n".join(
+            getattr(message, "content", str(message)) for message in messages
+        )
+        if self.calls == 1:
+            return """
+<tool_calls>
+  <tool_call>
+    <tool_name>tools_retriever</tool_name>
+    <parameters>{"query": "company market risk evidence workspace report artifact"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>company_profile</tool_name>
+    <parameters>{"company": "OmniRetail AI"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>market_signals</tool_name>
+    <parameters>{"company": "OmniRetail AI"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>risk_register</tool_name>
+    <parameters>{"company": "OmniRetail AI"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>evidence_pack</tool_name>
+    <parameters>{"company": "OmniRetail AI"}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        if self.calls == 2:
+            match = re.search(r"read_artifact\('([^']+)'\)", transcript)
+            assert match, transcript
+            self.artifact_id = match.group(1)
+            return f"""
+<tool_calls>
+  <tool_call>
+    <tool_name>read_artifact</tool_name>
+    <parameters>{{"artifact_id": "{self.artifact_id}"}}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>write_file</tool_name>
+    <parameters>{{"path": "reports/omniretail-diligence.md", "content": "# OmniRetail AI\\n\\nInvestment view: proceed with focused risk review.", "mode": "create"}}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        return """
+<final_answer>Due diligence complete with profile, market signals, risks, evidence artifact, and workspace memo.</final_answer>
+"""
+
+
+def build_due_diligence_tools() -> ToolRegistry:
+    tools = ToolRegistry()
+
+    @tools.register_tool("company_profile")
+    def company_profile(company: str) -> dict:
+        return {"company": company, "stage": "Series B", "revenue": "$10M-$25M"}
+
+    @tools.register_tool("market_signals")
+    def market_signals(company: str) -> dict:
+        return {
+            "company": company,
+            "tailwinds": ["agent adoption", "enterprise automation"],
+        }
+
+    @tools.register_tool("risk_register")
+    def risk_register(company: str) -> dict:
+        return {
+            "company": company,
+            "risks": [{"name": "sales cycle", "severity": "medium"}],
+        }
+
+    @tools.register_tool("evidence_pack")
+    def evidence_pack(company: str) -> dict:
+        return {
+            "company": company,
+            "evidence": "\n".join(
+                f"{company} diligence evidence line {i}" for i in range(160)
+            ),
+        }
+
+    return tools
+
+
+@pytest.mark.asyncio
+async def test_due_diligence_real_application_uses_parallel_tools_artifacts_workspace_and_telemetry(
+    tmp_path,
+):
+    llm = DueDiligenceLlm()
+    result, history, telemetry_store, workspace_dir = await run_scripted_agent(
+        tmp_path=tmp_path,
+        agent_name="due_diligence_real_app",
+        llm=llm,
+        local_tools=build_due_diligence_tools(),
+        advanced_tools=True,
+        tool_offload={
+            "enabled": True,
+            "threshold_tokens": 20,
+            "threshold_bytes": 200,
+            "max_preview_tokens": 20,
+        },
+        max_steps=8,
+    )
+
+    assert "Due diligence complete" in result["answer"]
+    assert llm.artifact_id is not None
+    assert history.called_tools() >= {
+        "tools_retriever",
+        "company_profile",
+        "market_signals",
+        "risk_register",
+        "evidence_pack",
+        "read_artifact",
+        "write_file",
+    }
+    assert (workspace_dir / "files" / "reports" / "omniretail-diligence.md").exists()
+    assert list((workspace_dir / "artifacts").glob("evidence_pack_*.txt"))
+
+    traces = await telemetry_store.list_traces()
+    assert len(traces) == 1
+    event_types = {event.event_type for event in traces[0].events}
+    assert {
+        "tool_batch_start",
+        "tool_result",
+        "workspace_write",
+        "workspace_offload",
+    }.issubset(event_types)
+
+
+class SupportOperationsLlm:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def llm_call(self, messages):
+        self.calls += 1
+        if self.calls == 1:
+            return """
+<tool_calls>
+  <tool_call>
+    <tool_name>lookup_customer</tool_name>
+    <parameters>{"customer_id": "cust-001"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>recent_orders</tool_name>
+    <parameters>{"customer_id": "cust-001"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>support_policy_search</tool_name>
+    <parameters>{"query": "enterprise delayed shipment escalation"}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        if self.calls == 2:
+            return """
+<tool_calls>
+  <tool_call>
+    <tool_name>create_escalation</tool_name>
+    <parameters>{"ticket_id": "tck-1042", "severity": "medium", "summary": "Delayed enterprise shipment needs timeline and goodwill review."}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>write_file</tool_name>
+    <parameters>{"path": "tickets/tck-1042.md", "content": "# tck-1042\\n\\nEscalated delayed shipment for Ada Ventures.", "mode": "create"}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        return """
+<final_answer>Support plan ready: explain the delay, share timeline, and route the medium escalation.</final_answer>
+"""
+
+
+def build_support_tools() -> ToolRegistry:
+    tools = ToolRegistry()
+
+    @tools.register_tool("lookup_customer")
+    def lookup_customer(customer_id: str) -> dict:
+        return {
+            "customer_id": customer_id,
+            "plan": "enterprise",
+            "name": "Ada Ventures",
+        }
+
+    @tools.register_tool("recent_orders")
+    def recent_orders(customer_id: str) -> dict:
+        return {
+            "customer_id": customer_id,
+            "orders": [{"id": "ord-1002", "status": "delayed"}],
+        }
+
+    @tools.register_tool("support_policy_search")
+    def support_policy_search(query: str) -> dict:
+        return {
+            "query": query,
+            "policy": "Escalate delayed enterprise shipments above $1000.",
+        }
+
+    @tools.register_tool("create_escalation")
+    def create_escalation(ticket_id: str, severity: str, summary: str) -> dict:
+        return {
+            "ticket_id": ticket_id,
+            "severity": severity,
+            "summary": summary,
+            "status": "queued",
+        }
+
+    return tools
+
+
+@pytest.mark.asyncio
+async def test_support_operations_real_application_tracks_ticket_state_in_workspace(
+    tmp_path,
+):
+    result, history, telemetry_store, workspace_dir = await run_scripted_agent(
+        tmp_path=tmp_path,
+        agent_name="support_ops_real_app",
+        llm=SupportOperationsLlm(),
+        local_tools=build_support_tools(),
+        max_steps=6,
+    )
+
+    assert "Support plan ready" in result["answer"]
+    assert history.called_tools() >= {
+        "lookup_customer",
+        "recent_orders",
+        "support_policy_search",
+        "create_escalation",
+        "write_file",
+    }
+    ticket = workspace_dir / "files" / "tickets" / "tck-1042.md"
+    assert ticket.read_text(encoding="utf-8").startswith("# tck-1042")
+
+    traces = await telemetry_store.list_traces()
+    event_types = {event.event_type for event in traces[0].events}
+    assert {"tool_batch_start", "tool_result", "workspace_write"}.issubset(event_types)
+
+
+class WorkspaceCodeReviewLlm:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def llm_call(self, messages):
+        self.calls += 1
+        if self.calls == 1:
+            return """
+<tool_calls>
+  <tool_call>
+    <tool_name>ls</tool_name>
+    <parameters>{"path": ""}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>glob</tool_name>
+    <parameters>{"pattern": "**/*.py"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>grep</tool_name>
+    <parameters>{"pattern": "calculate_total", "include": "*.py"}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        if self.calls == 2:
+            return """
+<tool_call>
+  <tool_name>read_file</tool_name>
+  <parameters>{"path": "src/billing.py"}</parameters>
+</tool_call>
+"""
+        if self.calls == 3:
+            old = "def calculate_total(items):\\n    total = 0"
+            new = "def calculate_total(items):\\n    if any(item['price'] < 0 for item in items):\\n        raise ValueError('negative prices are not allowed')\\n    total = 0"
+            return f"""
+<tool_calls>
+  <tool_call>
+    <tool_name>edit_file</tool_name>
+    <parameters>{{"path": "src/billing.py", "old_str": "{old}", "new_str": "{new}"}}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>write_file</tool_name>
+    <parameters>{{"path": "reviews/billing-review.md", "content": "# Billing review\\n\\nAdded negative price validation.", "mode": "create"}}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        return """
+<final_answer>Workspace review complete. Billing validation was added and review notes were written.</final_answer>
+"""
+
+
+def seed_workspace(workspace_dir: Path) -> None:
+    files_dir = workspace_dir / "files"
+    (files_dir / "src").mkdir(parents=True)
+    (files_dir / "tests").mkdir(parents=True)
+    (files_dir / "src" / "billing.py").write_text(
+        "def calculate_total(items):\n"
+        "    total = 0\n"
+        "    for item in items:\n"
+        "        total += item['price']\n"
+        "    return total\n",
+        encoding="utf-8",
+    )
+    (files_dir / "tests" / "test_billing.py").write_text(
+        "from src.billing import calculate_total\n\n"
+        "def test_calculate_total():\n"
+        "    assert calculate_total([{'price': 2}]) == 2\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_workspace_code_review_real_application_uses_builtin_file_commands(
+    tmp_path,
+):
+    workspace_dir = tmp_path / "workspace_code_review_real_app"
+    seed_workspace(workspace_dir)
+
+    result, history, telemetry_store, _ = await run_scripted_agent(
+        tmp_path=tmp_path,
+        agent_name="workspace_code_review_real_app",
+        llm=WorkspaceCodeReviewLlm(),
+        local_tools=None,
+        max_steps=8,
+    )
+
+    assert "Workspace review complete" in result["answer"]
+    assert history.called_tools() >= {
+        "ls",
+        "glob",
+        "grep",
+        "read_file",
+        "edit_file",
+        "write_file",
+    }
+    billing_file = workspace_dir / "files" / "src" / "billing.py"
+    assert "negative prices are not allowed" in billing_file.read_text(encoding="utf-8")
+    review_file = workspace_dir / "files" / "reviews" / "billing-review.md"
+    assert review_file.read_text(encoding="utf-8").startswith("# Billing review")
+
+    traces = await telemetry_store.list_traces()
+    event_types = {event.event_type for event in traces[0].events}
+    assert {"workspace_read", "workspace_write"}.issubset(event_types)


### PR DESCRIPTION
## Summary
- add real application cookbook examples for due diligence, support operations, and workspace code review
- connect README/cookbook navigation to the new real application examples
- add deterministic real-application smoke tests covering parallel tools, workspace files, artifact offload/readback, and telemetry

## Verification
- uv run pytest tests/test_real_application_examples.py tests/test_real_application_smoke.py tests/test_docs_claims.py -q
- uv run ruff check README.md cookbook/real_applications/*.py tests/test_real_application_examples.py
- uv run python -m compileall -q cookbook/real_applications tests/test_real_application_examples.py
- uv run pytest -q

## Evaluator review
- architecture/examples evaluator found wording overclaims and workspace reseeding issue; fixed
- QA evaluator returned no issues
- DX evaluator found python command portability issue; fixed with uv run python