### PR TITLE
Add OmniServe real application example

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -25,6 +25,7 @@ def create_agent():
 |---------|-------------|------------|
 | [cli_agent.py](./cli_agent.py) | Agent file for CLI deployment | `omniserve run --agent cookbook/omniserve/cli_agent.py` |
 | [python_api.py](./python_api.py) | Full Python API with all config options | `python cookbook/omniserve/python_api.py` |
+| [real_application_agent.py](./real_application_agent.py) | Serve the support operations real application harness | `uv run omniserve run --agent cookbook/omniserve/real_application_agent.py` |
 
 ---
 
@@ -38,6 +39,9 @@ omniserve quickstart --provider openai --model gpt-4o-mini
 
 # Run with your agent file
 omniserve run --agent cookbook/omniserve/cli_agent.py --port 8000
+
+# Run a real application harness
+uv run omniserve run --agent cookbook/omniserve/real_application_agent.py --port 8000
 
 # With authentication and rate limiting
 omniserve run --agent cookbook/omniserve/cli_agent.py \

--- a/cookbook/omniserve/real_application_agent.py
+++ b/cookbook/omniserve/real_application_agent.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Serve a real application harness with OmniServe.
+
+Run:
+    uv run omniserve run --agent cookbook/omniserve/real_application_agent.py
+
+Then inspect:
+    curl http://localhost:8000/health
+    curl http://localhost:8000/tools
+    curl -X POST http://localhost:8000/run/sync \
+      -H "Content-Type: application/json" \
+      -d '{"query": "Handle ticket tck-1042 for customer cust-001."}'
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from cookbook.real_applications.support_operations_agent import build_agent  # noqa: E402
+
+
+def create_agent(workspace_dir: str | Path = "tmp/omniserve_real_app_support_ops"):
+    """Return the support operations real app as an OmniServe-loadable agent."""
+    return build_agent(workspace_dir=workspace_dir)

--- a/cookbook/real_applications/research_due_diligence_agent.py
+++ b/cookbook/real_applications/research_due_diligence_agent.py
@@ -11,7 +11,14 @@ from pathlib import Path
 
 from omnicoreagent import MemoryRouter, OmniCoreAgent, ToolRegistry
 
-from _bootstrap import model_config, require_llm_api_key, response_text
+try:
+    from cookbook.real_applications._bootstrap import (
+        model_config,
+        require_llm_api_key,
+        response_text,
+    )
+except ModuleNotFoundError:
+    from _bootstrap import model_config, require_llm_api_key, response_text
 
 
 def build_research_tools() -> ToolRegistry:

--- a/cookbook/real_applications/support_operations_agent.py
+++ b/cookbook/real_applications/support_operations_agent.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 from omnicoreagent import MemoryRouter, OmniCoreAgent, ToolRegistry
 
-from _bootstrap import model_config, require_llm_api_key, response_text
+try:
+    from cookbook.real_applications._bootstrap import (
+        model_config,
+        require_llm_api_key,
+        response_text,
+    )
+except ModuleNotFoundError:
+    from _bootstrap import model_config, require_llm_api_key, response_text
 
 
 def build_support_tools() -> ToolRegistry:

--- a/cookbook/real_applications/workspace_code_review_agent.py
+++ b/cookbook/real_applications/workspace_code_review_agent.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 from omnicoreagent import MemoryRouter, OmniCoreAgent
 
-from _bootstrap import model_config, require_llm_api_key, response_text
+try:
+    from cookbook.real_applications._bootstrap import (
+        model_config,
+        require_llm_api_key,
+        response_text,
+    )
+except ModuleNotFoundError:
+    from _bootstrap import model_config, require_llm_api_key, response_text
 
 
 def seed_workspace(workspace_dir: Path) -> None:

--- a/tests/test_real_application_production_boundaries.py
+++ b/tests/test_real_application_production_boundaries.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from fastapi.testclient import TestClient  # noqa: E402
+import pytest  # noqa: E402
+
+from omnicoreagent import OmniServe, OmniServeConfig  # noqa: E402
+from omnicoreagent.serve.cli import _load_agent_from_file  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def isolate_serving_env(monkeypatch):
+    """Keep local environment values from changing explicit server config."""
+    for key in list(os.environ):
+        if key.startswith(("OMNICOREAGENT_SERVE_", "OMNICOREAGENT_BACKGROUND_")):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+
+
+def test_real_application_examples_are_importable_agent_factories(tmp_path):
+    from cookbook.real_applications import (
+        research_due_diligence_agent,
+        support_operations_agent,
+        workspace_code_review_agent,
+    )
+
+    research = research_due_diligence_agent.build_agent(tmp_path / "research")
+    support = support_operations_agent.build_agent(tmp_path / "support")
+    code_review = workspace_code_review_agent.build_agent(tmp_path / "code-review")
+
+    assert research.name == "due_diligence_agent"
+    assert support.name == "support_operations_agent"
+    assert code_review.name == "workspace_code_review_agent"
+    assert support.agent_config["enable_workspace_files"] is True
+
+
+def test_omniserve_loads_real_application_agent_file():
+    agent = _load_agent_from_file("cookbook/omniserve/real_application_agent.py")
+
+    assert agent.name == "support_operations_agent"
+    assert agent.agent_config["enable_workspace_files"] is True
+    assert agent.agent_config["workspace_config"]["workspace_backend"] == "local"
+
+
+def test_omniserve_real_application_exposes_domain_and_workspace_tools(tmp_path):
+    from cookbook.omniserve.real_application_agent import create_agent
+
+    agent = create_agent(workspace_dir=tmp_path / "served-support-app")
+    server = OmniServe(agent, OmniServeConfig(background_enabled=False))
+
+    with TestClient(server.app) as client:
+        tools_response = client.get("/tools")
+
+    assert tools_response.status_code == 200
+    tool_names = {tool["name"] for tool in tools_response.json()["tools"]}
+    assert {
+        "lookup_customer",
+        "recent_orders",
+        "support_policy_search",
+        "create_escalation",
+    }.issubset(tool_names)

--- a/tests/test_real_application_production_boundaries.py
+++ b/tests/test_real_application_production_boundaries.py
@@ -21,7 +21,13 @@ def isolate_serving_env(monkeypatch):
     for key in list(os.environ):
         if key.startswith(("OMNICOREAGENT_SERVE_", "OMNICOREAGENT_BACKGROUND_")):
             monkeypatch.delenv(key, raising=False)
-    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+
+def attach_test_model_credentials(agent):
+    """Make runtime initialization explicit without depending on process env."""
+    agent.model_config = {**agent.model_config, "api_key": "test-key"}
+    return agent
 
 
 def test_real_application_examples_are_importable_agent_factories(tmp_path):
@@ -52,7 +58,9 @@ def test_omniserve_loads_real_application_agent_file():
 def test_omniserve_real_application_exposes_domain_and_workspace_tools(tmp_path):
     from cookbook.omniserve.real_application_agent import create_agent
 
-    agent = create_agent(workspace_dir=tmp_path / "served-support-app")
+    agent = attach_test_model_credentials(
+        create_agent(workspace_dir=tmp_path / "served-support-app")
+    )
     server = OmniServe(agent, OmniServeConfig(background_enabled=False))
 
     with TestClient(server.app) as client:


### PR DESCRIPTION
## Summary
- add an OmniServe agent file that serves the support operations real application harness
- make real application examples importable both as plain scripts and package modules
- document the real application OmniServe run path
- add production-boundary tests for agent factory imports, OmniServe agent loading, and served tool discovery

## Verification
- uv run pytest tests/test_real_application_production_boundaries.py tests/test_background_cookbook.py tests/test_docs_claims.py -q
- uv run pytest tests/test_real_application_production_boundaries.py tests/test_real_application_examples.py tests/test_real_application_smoke.py tests/test_omniserve_full.py tests/test_docs_claims.py -q
- uv run ruff check cookbook/real_applications/*.py cookbook/omniserve/real_application_agent.py tests/test_real_application_production_boundaries.py
- uv run python -m compileall -q cookbook/real_applications cookbook/omniserve tests/test_real_application_production_boundaries.py
- uv run pytest -q

## Evaluator review
- first evaluator batch timed out and was closed
- narrow docs evaluator: no findings
- narrow QA evaluator found test import-order risk; fixed and reran full suite