### PR TITLE
Add real application background task example

### DIFF
--- a/cookbook/README.mdx
+++ b/cookbook/README.mdx
@@ -81,6 +81,7 @@ cookbook/
 | [Research Due Diligence](./real_applications/research_due_diligence_agent.py) | Research agent with parallel tools, workspace reports, artifact readback, telemetry |
 | [Support Operations](./real_applications/support_operations_agent.py) | Support agent with customer/order tools, guardrails, escalation, workspace notes |
 | [Workspace Code Review](./real_applications/workspace_code_review_agent.py) | Code review agent using built-in workspace file commands instead of unrestricted shell |
+| [Support Background Task](./background_agents/real_application_background_task.py) | Real support operations app running through durable background task state, events, attempts, and workspace output |
 | [E-commerce Shopper](./advanced_agent/e_commerce_personal_shopper_agent.py) | Personal shopping assistant with cart, preferences, recommendations |
 | [Flight Booking](./advanced_agent/flightBooking_agent.py) | Travel agent with search, booking, and itinerary management |
 | [Customer Support](./advanced_agent/real_time_customer_support_agent.py) | Support agent with ticket handling and escalation |

--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -172,6 +172,34 @@ OMNICOREAGENT_COOKBOOK_WORKSPACE_DIR=/tmp/omnicoreagent-background-demo \
   python3 cookbook/background_agents/scheduled_task_example.py
 ```
 
+## Real Application Background Task
+
+The real application example runs the support operations app shape through the
+background manager. It uses the same support domain tools as
+`cookbook/real_applications/support_operations_agent.py`, registers a manual
+task, waits for the run to finish, then prints the run id, status, attempts,
+lifecycle events, and workspace files.
+
+It is deterministic and does not require `LLM_API_KEY`, so it is safe to run in
+CI or locally when you only want to inspect the background execution boundary:
+
+```bash
+uv run python cookbook/background_agents/real_application_background_task.py
+```
+
+By default, the workspace root is under your system temp directory at
+`omnicoreagent_real_app_background_workspace`. The script prints both
+`workspace_root` and the run-local `workspace` path. Pass `workspace_dir` when
+calling `run_real_application_background_example(...)` from Python if you want a
+specific local root.
+
+The run workspace contains:
+
+- `output.md` with the durable support note
+- `tickets/tck-1042.md` with the ticket-specific record
+- `run.json` with the latest run snapshot
+- `events.jsonl` with ordered lifecycle events
+
 ## Runtime Controls
 
 ```python

--- a/cookbook/background_agents/real_application_background_task.py
+++ b/cookbook/background_agents/real_application_background_task.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Run a real application harness through BackgroundAgentManager.
+
+This example uses the support operations domain tools from the real application
+cookbook and executes them as a durable background task. It does not require an
+LLM API key; the agent is deterministic so the background boundary is easy to
+run, test, and inspect.
+
+Run:
+    uv run python cookbook/background_agents/real_application_background_task.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import tempfile
+from typing import Any
+
+try:
+    from cookbook.background_agents._bootstrap import ROOT_DIR  # noqa: F401
+except ModuleNotFoundError:
+    from _bootstrap import ROOT_DIR  # noqa: F401
+from cookbook.real_applications.support_operations_agent import build_support_tools
+from omnicoreagent import BackgroundAgentManager
+from omnicoreagent.core.workspace.manager import Workspace
+
+
+class SupportOperationsBackgroundAgent:
+    """Deterministic support operations agent for background execution."""
+
+    name = "support_operations_background_agent"
+    system_instruction = "Resolve support operations tasks in the background."
+    model_config = {"provider": "openai", "model": "gpt-5.4-mini"}
+    agent_config: dict[str, Any] = {"enable_workspace_files": True}
+    mcp_tools: list[dict[str, Any]] = []
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.tools = build_support_tools()
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(
+        self,
+        query: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, str]:
+        self.calls.append({"query": query, "session_id": session_id, "run_id": run_id})
+        workspace_path = workspace_path_from_query(query)
+
+        customer = await self.tools.execute_tool(
+            "lookup_customer",
+            {"customer_id": "cust-001"},
+        )
+        orders = await self.tools.execute_tool(
+            "recent_orders",
+            {"customer_id": "cust-001"},
+        )
+        policy = await self.tools.execute_tool(
+            "support_policy_search",
+            {"query": "enterprise delayed shipment escalation"},
+        )
+        escalation = await self.tools.execute_tool(
+            "create_escalation",
+            {
+                "ticket_id": "tck-1042",
+                "severity": "medium",
+                "summary": "Delayed enterprise shipment needs timeline and goodwill review.",
+            },
+        )
+
+        note = render_ticket_note(
+            customer=customer,
+            orders=orders,
+            policy=policy,
+            escalation=escalation,
+            session_id=session_id,
+            run_id=run_id,
+        )
+        self.workspace.files.write_text(f"{workspace_path}/output.md", note)
+        self.workspace.files.write_text(
+            f"{workspace_path}/tickets/tck-1042.md",
+            note,
+        )
+
+        return {
+            "response": (
+                "support background task complete; "
+                "ticket=tck-1042; "
+                f"workspace=/workspace/{workspace_path}"
+            )
+        }
+
+
+def workspace_path_from_query(query: str) -> str:
+    for line in query.splitlines():
+        if line.startswith("workspace_path: /workspace/"):
+            return line.removeprefix("workspace_path: /workspace/")
+    raise ValueError("background run query did not include workspace_path guidance")
+
+
+def render_ticket_note(
+    *,
+    customer: dict[str, Any],
+    orders: dict[str, Any],
+    policy: dict[str, Any],
+    escalation: dict[str, Any],
+    session_id: str | None,
+    run_id: str | None,
+) -> str:
+    delayed_orders = [
+        order for order in orders["orders"] if order.get("status") == "delayed"
+    ]
+    delayed_summary = ", ".join(order["id"] for order in delayed_orders)
+    return "\n".join(
+        [
+            "# Support background task: tck-1042",
+            "",
+            f"- run_id: {run_id}",
+            f"- session_id: {session_id}",
+            f"- customer: {customer['name']} ({customer['customer_id']})",
+            f"- plan: {customer['plan']}",
+            f"- delayed_orders: {delayed_summary}",
+            f"- policy: {policy['policy']}",
+            f"- escalation_status: {escalation['status']}",
+            "",
+            "## Customer plan",
+            "",
+            "1. Confirm the latest shipment timeline.",
+            "2. Send the customer-visible update.",
+            "3. Review goodwill credit if the delay impact is material.",
+            "",
+        ]
+    )
+
+
+async def run_real_application_background_example(
+    workspace_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    workspace_root = Path(
+        workspace_dir
+        or Path(tempfile.gettempdir()) / "omnicoreagent_real_app_background_workspace"
+    )
+    workspace = Workspace.from_config(workspace_dir=workspace_root).ensure()
+    agent = SupportOperationsBackgroundAgent(workspace)
+    manager = BackgroundAgentManager(workspace=workspace, worker_id="real_app_worker")
+
+    try:
+        await manager.register_agent("support_ops", agent)
+        await manager.register_task(
+            task_id="support_ticket_tck_1042",
+            agent_id="support_ops",
+            query=(
+                "Handle ticket tck-1042 for customer cust-001. "
+                "Create a durable support note and escalation summary."
+            ),
+            schedule={"type": "manual"},
+            timeout_seconds=10,
+            retry_policy={"max_retries": 1, "initial_delay_seconds": 0},
+        )
+
+        run = await manager.run_now("support_ticket_tck_1042", wait=True)
+        events = await manager.get_run_events(run.run_id)
+        attempts = await manager.list_attempts(run.run_id)
+        task_status = await manager.get_task_status("support_ticket_tck_1042")
+        manager_status = await manager.get_manager_status()
+        workspace_state = await manager.get_run_workspace(run.run_id)
+
+        result = {
+            "run_id": run.run_id,
+            "status": run.status.value,
+            "session_id": run.session_id,
+            "workspace_root": str(workspace_root),
+            "workspace_path": run.workspace_path,
+            "result_preview": run.result_preview,
+            "events": [event["event"] for event in events],
+            "attempts": [attempt.model_dump(mode="json") for attempt in attempts],
+            "task_status": task_status,
+            "manager_status": manager_status,
+            "workspace_files": [item["name"] for item in workspace_state["files"]],
+            "agent_calls": agent.calls,
+        }
+    finally:
+        await manager.shutdown()
+    result["shutdown_status"] = await manager.get_manager_status()
+    return result
+
+
+async def main() -> None:
+    result = await run_real_application_background_example()
+    print(f"run_id={result['run_id']}")
+    print(f"status={result['status']}")
+    print(f"session_id={result['session_id']}")
+    print(f"workspace_root={result['workspace_root']}")
+    print(f"workspace={result['workspace_path']}")
+    print(f"attempts={len(result['attempts'])}")
+    print(f"runs={result['task_status']['runs']}")
+    print(f"completed={result['task_status']['status_counts']['completed']}")
+    print(f"manager_worker={result['manager_status']['worker_id']}")
+    print(f"files={','.join(result['workspace_files'])}")
+    print(f"events={','.join(result['events'])}")
+    print(result["result_preview"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/real_applications/README.mdx
+++ b/cookbook/real_applications/README.mdx
@@ -9,6 +9,7 @@ These examples show OmniCoreAgent as an application-facing agent harness, not a 
 | [Research due diligence](./research_due_diligence_agent.py) | Parallel research tools, context management, large evidence offload, artifact readback, workspace report output, telemetry identifiers |
 | [Support operations](./support_operations_agent.py) | Customer/order tools, support knowledge retrieval, guardrails, workspace ticket notes, telemetry |
 | [Workspace code review](./workspace_code_review_agent.py) | Built-in workspace command tools for file discovery, grep-style search, reading, editing, and writing review output |
+| [Support background task](../background_agents/real_application_background_task.py) | The support operations app shape running through durable task state, attempts, lifecycle events, and workspace output |
 
 ## Run an Example
 
@@ -30,6 +31,7 @@ Application builders need to see where OmniCoreAgent owns the base harness and w
 
 - App code provides domain tools, instructions, data sources, and business rules.
 - OmniCoreAgent provides the model loop, tool execution, workspace files, structured observations, offloading, telemetry, memory, and guardrails.
-- The same application pattern can be served later through OmniServe or run through background tasks when the app needs those boundaries.
+- The same application pattern can be served through OmniServe with `cookbook/omniserve/real_application_agent.py`.
+- The same application pattern can run as a background task with `cookbook/background_agents/real_application_background_task.py`.
 
 Use these examples as starting points for your own application harness.

--- a/tests/test_background_cookbook.py
+++ b/tests/test_background_cookbook.py
@@ -10,20 +10,44 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 EXAMPLE_PATH = ROOT / "cookbook" / "background_agents" / "scheduled_task_example.py"
+REAL_APP_EXAMPLE_PATH = (
+    ROOT / "cookbook" / "background_agents" / "real_application_background_task.py"
+)
 
 
-def load_scheduled_example_module():
-    script_dir = str(EXAMPLE_PATH.parent)
+def load_example_module(path: Path, module_name: str):
+    script_dir = str(path.parent)
     if script_dir not in sys.path:
         sys.path.insert(0, script_dir)
-    spec = importlib.util.spec_from_file_location(
-        "scheduled_task_example", EXAMPLE_PATH
-    )
+    spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def load_scheduled_example_module():
+    return load_example_module(EXAMPLE_PATH, "scheduled_task_example")
+
+
+def load_real_app_background_module():
+    return load_example_module(
+        REAL_APP_EXAMPLE_PATH,
+        "real_application_background_task",
+    )
+
+
+def test_real_application_background_cookbook_imports_as_package():
+    from cookbook.background_agents import real_application_background_task
+
+    assert hasattr(
+        real_application_background_task,
+        "run_real_application_background_example",
+    )
 
 
 @pytest.mark.asyncio
@@ -63,7 +87,7 @@ def test_background_scheduled_cookbook_script_runs_as_plain_script(tmp_path):
         env=env,
         text=True,
         capture_output=True,
-        timeout=10,
+        timeout=30,
         check=False,
     )
 
@@ -75,6 +99,64 @@ def test_background_scheduled_cookbook_script_runs_as_plain_script(tmp_path):
     assert "manager_active_runs=0" in result.stdout
     assert "background_task_scheduled" in result.stdout
     assert "background_run_completed" in result.stdout
+    assert "output.md" in result.stdout
+    assert "run.json" in result.stdout
+    assert "events.jsonl" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_real_application_background_cookbook_example_runs_end_to_end(tmp_path):
+    module = load_real_app_background_module()
+
+    result = await module.run_real_application_background_example(tmp_path)
+
+    assert result["status"] == "completed"
+    assert result["task_status"]["runs"] == 1
+    assert result["task_status"]["active_runs"] == 0
+    assert result["task_status"]["status_counts"]["completed"] == 1
+    assert result["manager_status"]["worker_id"] == "real_app_worker"
+    assert result["manager_status"]["runs"] == 1
+    assert result["workspace_root"] == str(tmp_path)
+    assert result["shutdown_status"]["running"] is False
+    assert result["shutdown_status"]["initialized"] is False
+    assert len(result["attempts"]) == 1
+    assert result["attempts"][0]["status"] == "completed"
+    assert "background_run_queued" in result["events"]
+    assert "background_run_completed" in result["events"]
+    assert {"tickets", "output.md", "run.json", "events.jsonl"}.issubset(
+        set(result["workspace_files"])
+    )
+    assert (
+        result["agent_calls"][0]["session_id"]
+        == "background:support_ops:support_ticket_tck_1042"
+    )
+    assert result["agent_calls"][0]["run_id"] == result["run_id"]
+    assert "/workspace/background/" in result["agent_calls"][0]["query"]
+    assert "support background task complete" in result["result_preview"]
+
+
+def test_real_application_background_cookbook_script_runs_as_plain_script(tmp_path):
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(REAL_APP_EXAMPLE_PATH)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "status=completed" in result.stdout
+    assert "completed=1" in result.stdout
+    assert "manager_worker=real_app_worker" in result.stdout
+    assert f"workspace_root={tmp_path}" in result.stdout
+    assert "background_run_queued" in result.stdout
+    assert "background_run_completed" in result.stdout
+    assert "tickets" in result.stdout
     assert "output.md" in result.stdout
     assert "run.json" in result.stdout
     assert "events.jsonl" in result.stdout


### PR DESCRIPTION
## Summary
- add a deterministic support operations background task example using the real application domain tools
- prove background task state, attempts, lifecycle events, and workspace output
- document the background real-app path and link it from the real applications cookbook
- add package-import and plain-script regression coverage

## Verification
- uv run pytest tests/test_background_cookbook.py tests/test_docs_claims.py -q
- uv run pytest tests/test_background_cookbook.py tests/test_real_application_examples.py tests/test_real_application_production_boundaries.py tests/test_real_application_smoke.py tests/test_omniserve_background.py tests/test_docs_claims.py -q
- uv run pytest tests/test_workspace.py tests/test_workspace_files_backend.py -q
- uv run pytest tests/test_background_cookbook.py tests/test_workspace.py tests/test_workspace_files_backend.py tests/test_docs_claims.py -q
- uv run ruff check cookbook/background_agents/real_application_background_task.py tests/test_background_cookbook.py
- uv run python -m compileall -q cookbook/background_agents/real_application_background_task.py tests/test_background_cookbook.py
- uv run pytest -q

## Live workspace checks
- R2 live workspace smoke passed using src/.env credentials
- R2 live background workspace run passed using src/.env credentials
- S3 live workspace smoke passed using src/.env credentials
- S3 live background workspace run passed using src/.env credentials

## Evaluator review
- architecture evaluator: no findings
- docs evaluator found workspace-root discoverability and real-app README discoverability issues; fixed
- QA/final narrow evaluators timed out and were closed; full suite and focused checks are green