### PR TITLE
Strengthen production harness QA coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ wheels/
 servers_config.json
 *.log
 *.log.*
+tmp/
 *.db
 # Generated docs site
 site/

--- a/cookbook/getting_started/agent_with_memory.py
+++ b/cookbook/getting_started/agent_with_memory.py
@@ -99,11 +99,11 @@ async def demo_sql_database():
     # Examples:
     #   DATABASE_URL=postgresql://user:pass@localhost:5432/db
     #   DATABASE_URL=sqlite:///./memory.db
-    memory_router = MemoryRouter("database")
+    memory_router = MemoryRouter("sql")
 
     agent = OmniCoreAgent(
         name="db_agent",
-        system_instruction="You are a helpful assistant with database memory.",
+        system_instruction="You are a helpful assistant with SQL memory.",
         model_config=model_config(max_tokens=800),
         memory_router=memory_router,
     )

--- a/cookbook/getting_started/agent_with_memory_switching.py
+++ b/cookbook/getting_started/agent_with_memory_switching.py
@@ -71,7 +71,7 @@ async def main():
     # Note: Requires DATABASE_URL in .env before runtime switching
     print("\n4. Switching to Database...")
     try:
-        await agent.switch_memory_store("database")
+        await agent.switch_memory_store("sql")
         current_type = await agent.get_memory_store_type()
         print(f"   Now using: {current_type}")
     except Exception as e:

--- a/cookbook/real_applications/README.mdx
+++ b/cookbook/real_applications/README.mdx
@@ -8,6 +8,7 @@ These examples show OmniCoreAgent as an application-facing agent harness, not a 
 |---------|----------------------|
 | [Research due diligence](./research_due_diligence_agent.py) | Parallel research tools, context management, large evidence offload, artifact readback, workspace report output, telemetry identifiers |
 | [Support operations](./support_operations_agent.py) | Customer/order tools, support knowledge retrieval, guardrails, workspace ticket notes, telemetry |
+| [Personal operations assistant](./personal_operations_assistant.py) | Calendar/task/preferences tools, selectable memory backend, private workspace brief, guardrails, telemetry identifiers |
 | [Workspace code review](./workspace_code_review_agent.py) | Built-in workspace command tools for file discovery, grep-style search, reading, editing, and writing review output |
 | [Support background task](../background_agents/real_application_background_task.py) | The support operations app shape running through durable task state, attempts, lifecycle events, and workspace output |
 
@@ -23,6 +24,14 @@ The examples default to the provider/model from `cookbook/shared.py`. Override t
 ```bash
 export OMNICOREAGENT_PROVIDER=openai
 export OMNICOREAGENT_MODEL=gpt-5.4-mini
+```
+
+The personal assistant example defaults to in-memory history. To prove durable
+local memory without any external service, run it with SQLite:
+
+```bash
+export OMNICOREAGENT_COOKBOOK_MEMORY_BACKEND=sql
+uv run python cookbook/real_applications/personal_operations_assistant.py
 ```
 
 ## Why these examples exist

--- a/cookbook/real_applications/personal_operations_assistant.py
+++ b/cookbook/real_applications/personal_operations_assistant.py
@@ -1,0 +1,146 @@
+"""Personal operations assistant built on OmniCoreAgent."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from omnicoreagent import MemoryRouter, OmniCoreAgent, ToolRegistry
+
+try:
+    from cookbook.real_applications._bootstrap import (
+        model_config,
+        require_llm_api_key,
+        response_text,
+    )
+except ModuleNotFoundError:
+    from _bootstrap import model_config, require_llm_api_key, response_text
+
+
+def build_personal_tools() -> ToolRegistry:
+    tools = ToolRegistry()
+
+    @tools.register_tool("calendar_agenda")
+    def calendar_agenda(date: str) -> dict:
+        return {
+            "date": date,
+            "events": [
+                {
+                    "time": "09:30",
+                    "title": "Product review",
+                    "location": "Zoom",
+                },
+                {
+                    "time": "14:00",
+                    "title": "Customer renewal prep",
+                    "location": "HQ",
+                },
+            ],
+        }
+
+    @tools.register_tool("task_list")
+    def task_list(owner: str) -> dict:
+        return {
+            "owner": owner,
+            "tasks": [
+                {
+                    "id": "task-17",
+                    "title": "Send renewal notes",
+                    "priority": "high",
+                },
+                {
+                    "id": "task-22",
+                    "title": "Review product launch risks",
+                    "priority": "medium",
+                },
+            ],
+        }
+
+    @tools.register_tool("preference_profile")
+    def preference_profile(user_id: str) -> dict:
+        return {
+            "user_id": user_id,
+            "working_hours": "09:00-17:30",
+            "communication_style": "brief, direct, action-oriented",
+            "focus_blocks": ["10:00-12:00"],
+        }
+
+    @tools.register_tool("draft_email")
+    def draft_email(recipient: str, subject: str, notes: str) -> dict:
+        return {
+            "recipient": recipient,
+            "subject": subject,
+            "draft": (
+                f"Subject: {subject}\n\n"
+                f"Hi {recipient},\n\n{notes}\n\nBest,\nAssistant"
+            ),
+            "status": "drafted",
+        }
+
+    return tools
+
+
+def build_memory_router(
+    *,
+    memory_backend: str = "in_memory",
+    workspace_dir: Path | str = "tmp/real_apps/personal_assistant",
+) -> MemoryRouter:
+    if memory_backend == "sql" and not os.getenv("DATABASE_URL"):
+        db_path = Path(workspace_dir) / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    return MemoryRouter(memory_backend)
+
+
+def build_agent(
+    workspace_dir: Path | str = "tmp/real_apps/personal_assistant",
+    *,
+    memory_backend: str = "in_memory",
+) -> OmniCoreAgent:
+    return OmniCoreAgent(
+        name="personal_operations_assistant",
+        system_instruction="""You are a personal operations assistant.
+Use calendar, task, preference, and email tools together when possible. Keep
+private working notes in workspace files and write a daily brief before the
+final answer. The final answer should summarize the user-facing plan and name
+the workspace brief that was saved.""",
+        model_config=model_config(max_tokens=1100),
+        local_tools=build_personal_tools(),
+        memory_router=build_memory_router(
+            memory_backend=memory_backend,
+            workspace_dir=workspace_dir,
+        ),
+        agent_config={
+            "max_steps": 10,
+            "tool_call_timeout": 20,
+            "enable_workspace_files": True,
+            "guardrail_config": {"strict_mode": True},
+            "workspace_config": {
+                "workspace_backend": "local",
+                "workspace_dir": str(workspace_dir),
+            },
+        },
+    )
+
+
+async def main() -> None:
+    require_llm_api_key()
+
+    memory_backend = os.getenv("OMNICOREAGENT_COOKBOOK_MEMORY_BACKEND", "in_memory")
+    agent = build_agent(memory_backend=memory_backend)
+    result = await agent.run(
+        "Prepare my day for 2026-05-19. Check my calendar, tasks, and preferences, "
+        "draft a short email update for Jordan about renewal prep, and save the "
+        "brief to briefs/2026-05-19.md.",
+        session_id="real_app_personal_operations",
+    )
+
+    print(response_text(result))
+    print(f"trace_id={result['trace_id']}")
+    print(f"run_id={result['run_id']}")
+    await agent.cleanup()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -27,6 +27,8 @@ OMNICOREAGENT_SERVE_API_PREFIX=
 OMNICOREAGENT_SERVE_CORS_ENABLED=true
 # Comma-separated list of origins, or * for all
 OMNICOREAGENT_SERVE_CORS_ORIGINS=*
+OMNICOREAGENT_SERVE_CORS_METHODS=*
+OMNICOREAGENT_SERVE_CORS_HEADERS=*
 OMNICOREAGENT_SERVE_CORS_CREDENTIALS=true
 
 # =============================================================================
@@ -53,3 +55,24 @@ OMNICOREAGENT_SERVE_LOG_LEVEL=INFO
 # Timeouts
 # =============================================================================
 OMNICOREAGENT_SERVE_REQUEST_TIMEOUT=300
+
+# =============================================================================
+# Workspace Files
+# =============================================================================
+OMNICOREAGENT_WORKSPACE_BACKEND=local
+OMNICOREAGENT_WORKSPACE_DIR=/app/workspace
+OMNICOREAGENT_WORKSPACE_PREFIX=workspace
+
+# =============================================================================
+# Background Agents
+# =============================================================================
+OMNICOREAGENT_BACKGROUND_ENABLED=true
+OMNICOREAGENT_BACKGROUND_AGENT_ID=default
+OMNICOREAGENT_BACKGROUND_TASK_STORE=in_memory
+OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=
+OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=
+OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=omnicoreagent
+OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX=
+OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX=
+OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT=
+OMNICOREAGENT_BACKGROUND_START_WORKER=true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       # =======================================================================
       - OMNICOREAGENT_SERVE_CORS_ENABLED=${OMNICOREAGENT_SERVE_CORS_ENABLED:-true}
       - OMNICOREAGENT_SERVE_CORS_ORIGINS=${OMNICOREAGENT_SERVE_CORS_ORIGINS:-*}
+      - OMNICOREAGENT_SERVE_CORS_METHODS=${OMNICOREAGENT_SERVE_CORS_METHODS:-*}
+      - OMNICOREAGENT_SERVE_CORS_HEADERS=${OMNICOREAGENT_SERVE_CORS_HEADERS:-*}
       - OMNICOREAGENT_SERVE_CORS_CREDENTIALS=${OMNICOREAGENT_SERVE_CORS_CREDENTIALS:-true}
       
       # =======================================================================
@@ -69,8 +71,31 @@ services:
       # =======================================================================
       # Timeouts
       # =======================================================================
+      - OMNICOREAGENT_SERVE_REQUEST_TIMEOUT=${OMNICOREAGENT_SERVE_REQUEST_TIMEOUT:-300}
+
       # =======================================================================
-      # Cloud Storage (Optional - Uncomment to use)
+      # Workspace Files
+      # =======================================================================
+      - OMNICOREAGENT_WORKSPACE_BACKEND=${OMNICOREAGENT_WORKSPACE_BACKEND:-local}
+      - OMNICOREAGENT_WORKSPACE_DIR=${OMNICOREAGENT_WORKSPACE_DIR:-/app/workspace}
+      - OMNICOREAGENT_WORKSPACE_PREFIX=${OMNICOREAGENT_WORKSPACE_PREFIX:-workspace}
+
+      # =======================================================================
+      # Background Agents
+      # =======================================================================
+      - OMNICOREAGENT_BACKGROUND_ENABLED=${OMNICOREAGENT_BACKGROUND_ENABLED:-true}
+      - OMNICOREAGENT_BACKGROUND_AGENT_ID=${OMNICOREAGENT_BACKGROUND_AGENT_ID:-default}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE=${OMNICOREAGENT_BACKGROUND_TASK_STORE:-in_memory}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE_URL=${OMNICOREAGENT_BACKGROUND_TASK_STORE_URL:-}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE_URI=${OMNICOREAGENT_BACKGROUND_TASK_STORE_URI:-}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE=${OMNICOREAGENT_BACKGROUND_TASK_STORE_DATABASE:-omnicoreagent}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX=${OMNICOREAGENT_BACKGROUND_TASK_STORE_PREFIX:-}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX=${OMNICOREAGENT_BACKGROUND_TASK_STORE_COLLECTION_PREFIX:-}
+      - OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT=${OMNICOREAGENT_BACKGROUND_TASK_STORE_CONNECT_TIMEOUT:-}
+      - OMNICOREAGENT_BACKGROUND_START_WORKER=${OMNICOREAGENT_BACKGROUND_START_WORKER:-true}
+
+      # =======================================================================
+      # Cloud Storage (Optional)
       # =======================================================================
       # AWS S3
       # - AWS_S3_BUCKET=${AWS_S3_BUCKET:-}
@@ -84,11 +109,6 @@ services:
       # - R2_ACCOUNT_ID=${R2_ACCOUNT_ID:-}
       # - R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID:-}
       # - R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY:-}
-
-      # =======================================================================
-      # Timeouts
-      # =======================================================================
-      - OMNICOREAGENT_SERVE_REQUEST_TIMEOUT=${OMNICOREAGENT_SERVE_REQUEST_TIMEOUT:-300}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -6,184 +6,41 @@ icon: 'clock-rotate-left'
 
 # Changelog
 
-All notable changes to OmniCoreAgent are documented here.
+OmniCoreAgent is being rebuilt around the production agent harness direction:
+runtime, tools, MCP, memory, workspace, guardrails, background tasks, telemetry,
+and OmniServe as one application-facing base layer.
 
----
+Detailed version history is published with GitHub releases:
 
-## [0.1.18] - 2025-06-19
+<Card
+  title="GitHub Releases"
+  href="https://github.com/omnirexflora-labs/omnicoreagent/releases"
+>
+  Review tagged releases, release notes, and package versions.
+</Card>
 
-### Changed
-- **BREAKING CHANGE**: Removed local ChromaDB support for performance optimization
-  - Local ChromaDB fallback system has been completely removed
-  - Users must now explicitly configure a vector database provider
-  - No more automatic fallback to local storage
-  - This eliminates the 81+ second startup delay from ChromaDB Rust bindings
-- **Performance Improvement**: Vector database modules now load only when explicitly needed
-  - Lazy loading prevents unnecessary imports during package initialization
-  - Faster startup when vector DB is disabled
-  - Better resource management
+## Current Package Direction
 
-### Added
-- **Required Configuration**: Users must set `OMNI_MEMORY_PROVIDER` to one of:
-  - `qdrant-remote` (recommended default)
-  - `chroma-remote`
-  - `chroma-cloud`
-- **Clear Error Messages**: Better feedback when vector DB configuration is missing
+- Agent harness positioning instead of generic framework positioning.
+- Single `LLM_API_KEY` public API-key variable for hosted model providers.
+- Optional extras for heavier production integrations.
+- Workspace files on local disk, S3, or Cloudflare R2.
+- Memory backends: `in_memory`, `sql`, `redis`, and `mongodb`.
+- Background task stores: `in_memory`, `sql`, `redis`, and `mongodb`.
+- Telemetry stores: in-memory and JSONL, with OTLP-compatible exporters for
+  OpenTelemetry, LangSmith, and Opik.
+- OmniServe configuration through `OMNICOREAGENT_SERVE_*`.
+- Background serving configuration through `OMNICOREAGENT_BACKGROUND_*`.
 
-### Removed
-- Local ChromaDB persistence and warmup system
-- Automatic fallback mechanisms
-- Module-level vector DB initialization
-- ChromaDB local client type
+## Configuration Source Of Truth
 
-### Migration Guide
-- **Before**: `ENABLE_VECTOR_DB=true` would automatically use local ChromaDB
-- **After**: Must set both `ENABLE_VECTOR_DB=true` AND `OMNI_MEMORY_PROVIDER=qdrant-remote` (or other provider)
-- **Impact**: Faster startup, but requires explicit configuration
+Use the configuration guide for current environment variables and runtime
+settings:
 
----
-
-## [0.1.17] - 2025-05-28
-
-### Added
-- OAuth Authentication Support:
-  - OAuth 2.0 authentication flow for MCP servers
-  - Support for multiple authentication methods (OAuth 2.0, Bearer token, Custom headers)
-  - Flexible authentication configuration in server settings
-  - Secure credential management
-- Enhanced Server Configuration:
-  - Updated server configuration format to support OAuth
-  - Improved server connection security
-
-### Changed
-- Updated server configuration examples to include OAuth support
-- Enhanced documentation for authentication methods
-
-### Fixed
-- Improved authentication error handling
-- Updated configuration validation for authentication methods
-
----
-
-## [0.1.16] - 2025-05-16
-
-### Added
-- **Streamable HTTP Transport**: New transport protocol with efficient data streaming, configurable timeouts, and header support
-- **Dynamic Server Management**:
-  - `/add_servers:<config.json>` — Add one or more servers
-  - `/remove_server:<server_name>` — Remove servers
-  - Real-time server capability updates after changes
-- Enhanced server configuration with streamable HTTP examples
-
-### Changed
-- Updated README with new server management commands
-- Improved documentation for transport protocols
-
-### Fixed
-- Improved server connection handling
-- Enhanced error messages for server management commands
-
----
-
-## [0.1.15] - 2025-05-05
-
-### Added
-- **Token & Usage Management**:
-  - `/api_stats` command for token/request tracking
-  - Configurable limits for total requests and token usage
-  - Configurable tool call timeout and max steps
-- **Developer Integration Enhancements**:
-  - FastAPI example for building custom API servers
-  - Minimal code snippets for custom MCP client integration
-- **FastAPI API Documentation**: `/chat/agent_chat` endpoint docs
-- **Environment Variables Reference**: Full table in README
-
-### Changed
-- Updated server configuration examples
-- Improved README structure
-
-### Fixed
-- Corrected typos in documentation
-- Improved code example consistency
-
----
-
-## [0.1.14] - 2025-04-18
-
-### Added
-- **DeepSeek model integration** with full tool execution support
-- **Orchestrator Agent Mode**:
-  - Advanced planning for complex multi-step tasks
-  - Strategic delegation across multiple MCP servers
-  - Parallel task execution capabilities
-  - Dynamic resource allocation
-  - Real-time progress monitoring
-- **Chat History File Storage**: Save/load conversations, persistent history
-
-### Changed
-- Enhanced Mode System with three distinct modes (Chat, Autonomous, Orchestrator)
-- Updated AI model integration documentation
-
-### Fixed
-- Improved mode switching reliability
-- Enhanced chat history persistence
-
----
-
-## [0.1.13] - 2025-04-14
-
-### Added
-- **Gemini model integration** with full tool execution support
-- **Redis-powered memory persistence**:
-  - Conversation history tracking
-  - State management across sessions
-  - Multi-server memory synchronization
-- **Agentic Mode capabilities**:
-  - Autonomous task execution
-  - Advanced reasoning and decision-making
-  - Complex task decomposition
-- **Advanced prompt features**: Dynamic discovery, JSON/key-value formats, nested arguments
-- Comprehensive troubleshooting guide
-- Detailed architecture documentation
-- Advanced server configuration examples
-
-### Changed
-- Enhanced installation process with UV package manager
-- Improved development quick start guide
-- Updated server configuration format for multiple LLM providers
-
-### Fixed
-- Standardized command formatting
-- Improved code block consistency
-
----
-
-## [0.1.1] - 2025-03-27
-
-### Added
-- Comprehensive Security & Privacy section
-- Detailed Model Support section (OpenAI, OpenRouter, Groq)
-- Structured Testing section with coverage reporting
-- Support for additional LLM providers (OpenRouter, Groq)
-
-### Changed
-- Improved AI-Powered Intelligence section with multi-provider support
-- Enhanced Server Configuration Examples
-- Updated Python version requirement from 3.12+ to 3.10+
-- Changed from provider-specific API-key names to `LLM_API_KEY` for broader provider support
-
-### Fixed
-- Various typos and formatting issues
-- Fixed typo in "client" command (was "cient")
-
-### Removed
-- Redundant security information
-- Specific OpenAI model references in favor of provider-agnostic examples
-
----
-
-## [0.1.0] - 2025-03-21
-- Initial release
-- Basic MCP server integration
-- OpenAI model support
-- Core CLI functionality
+<Card
+  title="Configuration"
+  href="/docs/how-to-guides/configuration"
+>
+  Current model, memory, workspace, background, telemetry, and OmniServe
+  settings.
+</Card>

--- a/docs/core-concepts/memory.mdx
+++ b/docs/core-concepts/memory.mdx
@@ -33,7 +33,7 @@ agent = OmniCoreAgent(
 
 # Switch at runtime — no restart needed!
 await agent.switch_memory_store("mongodb")     # Switch to MongoDB
-await agent.switch_memory_store("database")    # Switch to SQL database storage
+await agent.switch_memory_store("sql")         # Switch to SQL database storage
 await agent.switch_memory_store("in_memory")   # Switch to in-memory
 await agent.switch_memory_store("redis")       # Back to Redis
 ```

--- a/docs/core-concepts/overview.mdx
+++ b/docs/core-concepts/overview.mdx
@@ -210,7 +210,7 @@ Switch configured memory backends without rebuilding the agent object:
 
 ```python
 await agent.switch_memory_store("mongodb")
-await agent.switch_memory_store("database")
+await agent.switch_memory_store("sql")
 await agent.switch_memory_store("redis")
 
 await agent.get_memory_store_type()

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -79,7 +79,7 @@ The base install stays focused on the core agent harness. Add heavier production
 
 | Extra | Installs |
 |-------|----------|
-| `redis` | Redis memory and Redis Stream events |
+| `redis` | Redis memory and Redis-backed background task state |
 | `postgres` | SQLAlchemy and PostgreSQL driver |
 | `mongodb` | MongoDB async and sync drivers |
 | `s3` | AWS S3 and Cloudflare R2 workspace storage |

--- a/docs/how-to-guides/basic-usage.mdx
+++ b/docs/how-to-guides/basic-usage.mdx
@@ -78,7 +78,7 @@ agent = OmniCoreAgent(
     name="persistent_agent",
     system_instruction="You are a helpful assistant.",
     model_config={"provider": "openai", "model": "gpt-4o"},
-    memory_router=MemoryRouter("redis")  # or "database", "mongodb", "in_memory"
+    memory_router=MemoryRouter("redis")  # or "sql", "mongodb", "in_memory"
 )
 ```
 

--- a/src/omnicoreagent/core/guardrails/engine.py
+++ b/src/omnicoreagent/core/guardrails/engine.py
@@ -200,8 +200,17 @@ class DetectionEngine:
             "µ": "u",
             "°": "o",
         }
-        for leet, normal in leet_map.items():
-            normalized = normalized.replace(leet, normal)
+        def normalize_leet_token(match: re.Match[str]) -> str:
+            token = match.group(0)
+            has_alpha = any(char.isalpha() for char in token)
+            has_digit = any(char.isdigit() for char in token)
+            if not (has_alpha and has_digit):
+                return token
+            for leet, normal in leet_map.items():
+                token = token.replace(leet, normal)
+            return token
+
+        normalized = re.sub(r"[\w@$!|€©®£¥¢µ°]+", normalize_leet_token, normalized)
 
         normalized = re.sub(
             r"([a-z])[\.\-_,;:\/\\]+([a-z])", r"\1 \2", normalized, flags=re.IGNORECASE

--- a/src/omnicoreagent/core/memory_store/memory_router.py
+++ b/src/omnicoreagent/core/memory_store/memory_router.py
@@ -35,10 +35,10 @@ class MemoryRouter:
     def initialize_memory_store(self):
         if self.memory_store_type == "in_memory":
             self.memory_store = InMemoryStore()
-        elif self.memory_store_type == "database":
+        elif self.memory_store_type == "sql":
             db_url = os.environ.get("DATABASE_URL")
             if db_url is None:
-                logger.info("Database not configured, using in_memory")
+                logger.info("SQL memory not configured, using in_memory")
                 self.memory_store = InMemoryStore()
             else:
                 DatabaseMessageStore = load_optional(
@@ -85,7 +85,10 @@ class MemoryRouter:
                     uri=uri, db_name=db_name, collection=collection
                 )
         else:
-            raise ValueError(f"Invalid memory store type: {self.memory_store_type}")
+            raise ValueError(
+                "Invalid memory store type: "
+                f"{self.memory_store_type}. Use one of: in_memory, sql, redis, mongodb"
+            )
 
     def switch_memory_store(self, memory_store_type: str):
         if memory_store_type != self.memory_store_type:

--- a/tests/test_guardrails_package.py
+++ b/tests/test_guardrails_package.py
@@ -83,3 +83,14 @@ def test_non_string_input_is_coerced_deterministically():
 
     assert result.is_safe is True
     assert result.input_length == len(str({"status": "ok", "count": 1}))
+
+
+def test_guardrail_does_not_treat_iso_dates_as_obfuscated_text():
+    guard = PromptInjectionGuard(DetectionConfig(strict_mode=True))
+
+    result = guard.check(
+        "Prepare my day for 2026-05-19 and save the brief to briefs/2026-05-19.md."
+    )
+
+    assert result.threat_level in {ThreatLevel.SAFE, ThreatLevel.LOW_RISK}
+    assert not any("obfuscation_techniques" in flag for flag in result.flags)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -425,19 +425,30 @@ class TestRedisMemoryStore:
     @pytest_asyncio.fixture
     async def memory(self, mock_redis_client):
         """Create a RedisMemoryStore with mocked client."""
+        import omnicoreagent.core.memory_store.redis_memory as redis_memory_module
+
+        original_manager = redis_memory_module._redis_manager
+        redis_memory_module._redis_manager = None
         with patch(
             "omnicoreagent.core.memory_store.redis_memory.RedisConnectionManager"
         ) as MockManager:
-            mock_manager_instance = MagicMock()
-            mock_manager_instance.get_client = AsyncMock(return_value=mock_redis_client)
-            mock_manager_instance.release_client = MagicMock()
-            MockManager.return_value = mock_manager_instance
+            try:
+                mock_manager_instance = MagicMock()
+                mock_manager_instance.get_client = AsyncMock(
+                    return_value=mock_redis_client
+                )
+                mock_manager_instance.release_client = MagicMock()
+                MockManager.return_value = mock_manager_instance
 
-            from omnicoreagent.core.memory_store.redis_memory import RedisMemoryStore
+                from omnicoreagent.core.memory_store.redis_memory import (
+                    RedisMemoryStore,
+                )
 
-            store = RedisMemoryStore(redis_url="redis://localhost:6379")
-            store._connection_manager = mock_manager_instance
-            yield store
+                store = RedisMemoryStore(redis_url="redis://localhost:6379")
+                store._connection_manager = mock_manager_instance
+                yield store
+            finally:
+                redis_memory_module._redis_manager = original_manager
 
     async def test_set_memory_config(self, memory):
         """Test memory configuration."""
@@ -721,7 +732,10 @@ async def redis_memory_store_from_env_or_skip():
     finally:
         await client.aclose()
 
-    from omnicoreagent.core.memory_store.redis_memory import RedisMemoryStore
+    import omnicoreagent.core.memory_store.redis_memory as redis_memory_module
+
+    redis_memory_module._redis_manager = None
+    RedisMemoryStore = redis_memory_module.RedisMemoryStore
 
     return RedisMemoryStore(redis_url=url)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -15,11 +15,15 @@ Each store is tested for:
 - Summarization integration with background persistence
 """
 
-import pytest
-import pytest_asyncio
 import asyncio
+import os
+import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+import pytest_asyncio
+
+from omnicoreagent.core.memory_store.memory_router import MemoryRouter
 from omnicoreagent.core.memory_store.in_memory import InMemoryStore
 from omnicoreagent.core.memory_store.sql_db_memory import DatabaseMessageStore
 
@@ -588,3 +592,184 @@ class TestBackgroundPersistence:
         assert len(messages_after) >= 2  # At least the recent messages
         # If summary was persisted, it would be first; otherwise we get recent messages
         # Skip type assertion due to timing variance in background thread
+
+
+async def assert_memory_store_contract(memory):
+    session_id = f"contract-{uuid.uuid4().hex}"
+    other_session_id = f"contract-other-{uuid.uuid4().hex}"
+
+    await memory.store_message(
+        "user",
+        "first",
+        {"agent_name": "primary"},
+        session_id,
+    )
+    await memory.store_message(
+        "assistant",
+        "second",
+        {"agent_name": "primary"},
+        session_id,
+    )
+    await memory.store_message(
+        "user",
+        "other agent",
+        {"agent_name": "secondary"},
+        session_id,
+    )
+    await memory.store_message(
+        "user",
+        "other session",
+        {"agent_name": "primary"},
+        other_session_id,
+    )
+
+    primary = await memory.get_messages(session_id, "primary")
+    assert [message["content"] for message in primary] == ["first", "second"]
+    assert {message["role"] for message in primary} == {"user", "assistant"}
+    assert all(message.get("id") for message in primary)
+    assert all(message.get("timestamp") for message in primary)
+
+    all_session = await memory.get_messages(session_id)
+    assert {message["content"] for message in all_session} == {
+        "first",
+        "second",
+        "other agent",
+    }
+
+    await memory.clear_memory(session_id, "secondary")
+    assert [message["content"] for message in await memory.get_messages(session_id)] == [
+        "first",
+        "second",
+    ]
+
+    message_ids = [message["id"] for message in await memory.get_messages(session_id)]
+    await memory.mark_messages_summarized(
+        message_ids,
+        summary_id="summary-contract",
+        retention_policy="keep",
+    )
+    assert await memory.get_messages(session_id) == []
+
+    await memory.clear_memory(session_id)
+    await memory.clear_memory(other_session_id)
+
+
+@pytest.mark.asyncio
+async def test_memory_router_uses_sql_backend_name(monkeypatch, tmp_path):
+    from omnicoreagent.core.memory_store.sql_db_memory import get_sql_manager
+
+    get_sql_manager().close_all()
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'router-memory.db'}")
+
+    router = MemoryRouter("sql")
+
+    assert router.get_memory_store_info()["type"] == "sql"
+    assert router.get_memory_store_info()["store_class"] == "DatabaseMessageStore"
+    await router.store_message(
+        "user",
+        "remember this",
+        {"agent_name": "router-agent"},
+        "router-session",
+    )
+
+    messages = await router.get_messages("router-session", "router-agent")
+    assert messages[0]["content"] == "remember this"
+    assert messages[0]["metadata"]["agent_name"] == "router-agent"
+
+    get_sql_manager().close_all()
+
+
+def test_memory_router_rejects_old_database_backend_name():
+    with pytest.raises(ValueError, match="in_memory, sql, redis, mongodb"):
+        MemoryRouter("database")
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_contract():
+    await assert_memory_store_contract(InMemoryStore())
+
+
+@pytest.mark.asyncio
+async def test_sql_memory_store_contract(tmp_path):
+    from omnicoreagent.core.memory_store.sql_db_memory import get_sql_manager
+
+    get_sql_manager().close_all()
+    memory = DatabaseMessageStore(db_url=f"sqlite:///{tmp_path / 'contract.db'}")
+    await assert_memory_store_contract(memory)
+    get_sql_manager().close_all()
+
+
+async def redis_memory_store_from_env_or_skip():
+    url = os.getenv("OMNICOREAGENT_TEST_REDIS_URL") or os.getenv("REDIS_URL")
+    if not url:
+        pytest.skip(
+            "Redis memory contract requires OMNICOREAGENT_TEST_REDIS_URL or REDIS_URL"
+        )
+
+    import redis.asyncio as redis
+
+    client = redis.from_url(
+        url,
+        decode_responses=True,
+        socket_connect_timeout=0.2,
+        socket_timeout=0.2,
+    )
+    try:
+        await client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis memory backend unavailable: {exc}")
+    finally:
+        await client.aclose()
+
+    from omnicoreagent.core.memory_store.redis_memory import RedisMemoryStore
+
+    return RedisMemoryStore(redis_url=url)
+
+
+async def mongodb_memory_store_from_env_or_skip():
+    uri = os.getenv("OMNICOREAGENT_TEST_MONGODB_URI") or os.getenv("MONGODB_URI")
+    database = (
+        os.getenv("OMNICOREAGENT_TEST_MONGODB_DATABASE")
+        or os.getenv("MONGODB_DB_NAME")
+        or "omnicoreagent_memory_test"
+    )
+    if not uri:
+        pytest.skip(
+            "MongoDB memory contract requires OMNICOREAGENT_TEST_MONGODB_URI or MONGODB_URI"
+        )
+
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from omnicoreagent.core.memory_store.mongodb import MongoDb
+
+    client = AsyncIOMotorClient(
+        uri,
+        serverSelectionTimeoutMS=200,
+        connectTimeoutMS=200,
+        socketTimeoutMS=200,
+    )
+    try:
+        await client.admin.command("ping")
+    except Exception as exc:
+        pytest.skip(f"MongoDB memory backend unavailable: {exc}")
+    finally:
+        client.close()
+
+    collection = f"messages_{uuid.uuid4().hex}"
+    return MongoDb(uri=uri, db_name=database, collection=collection)
+
+
+@pytest.mark.asyncio
+async def test_redis_memory_store_live_contract():
+    memory = await redis_memory_store_from_env_or_skip()
+    await assert_memory_store_contract(memory)
+
+
+@pytest.mark.asyncio
+async def test_mongodb_memory_store_live_contract():
+    memory = await mongodb_memory_store_from_env_or_skip()
+    try:
+        await assert_memory_store_contract(memory)
+    finally:
+        if memory.client is not None:
+            await memory.collection.drop()
+            memory.client.close()

--- a/tests/test_real_application_production_boundaries.py
+++ b/tests/test_real_application_production_boundaries.py
@@ -32,19 +32,38 @@ def attach_test_model_credentials(agent):
 
 def test_real_application_examples_are_importable_agent_factories(tmp_path):
     from cookbook.real_applications import (
+        personal_operations_assistant,
         research_due_diligence_agent,
         support_operations_agent,
         workspace_code_review_agent,
     )
 
+    personal = personal_operations_assistant.build_agent(tmp_path / "personal")
     research = research_due_diligence_agent.build_agent(tmp_path / "research")
     support = support_operations_agent.build_agent(tmp_path / "support")
     code_review = workspace_code_review_agent.build_agent(tmp_path / "code-review")
 
+    assert personal.name == "personal_operations_assistant"
     assert research.name == "due_diligence_agent"
     assert support.name == "support_operations_agent"
     assert code_review.name == "workspace_code_review_agent"
+    assert personal.agent_config["enable_workspace_files"] is True
     assert support.agent_config["enable_workspace_files"] is True
+
+
+def test_personal_assistant_can_use_sql_memory_by_default_path(monkeypatch, tmp_path):
+    from cookbook.real_applications import personal_operations_assistant
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    agent = personal_operations_assistant.build_agent(
+        tmp_path / "personal-sql",
+        memory_backend="sql",
+    )
+
+    assert agent.name == "personal_operations_assistant"
+    assert agent.memory_router.get_memory_store_info()["type"] == "sql"
+    assert (tmp_path / "personal-sql").is_dir()
 
 
 def test_omniserve_loads_real_application_agent_file():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,6 +15,7 @@ from omnicoreagent.core.workspace import (
 from omnicoreagent.core.workspace.config import WorkspaceConfig
 from omnicoreagent.core.workspace.manager import Workspace
 from omnicoreagent.core.workspace.storage import LocalWorkspaceStorage
+from omnicoreagent.core.workspace.storage import R2WorkspaceStorage
 from omnicoreagent.core.workspace.storage import S3WorkspaceStorage
 from omnicoreagent.core.workspace.storage import create_workspace_storage
 
@@ -75,6 +76,26 @@ def test_workspace_config_from_env_normalizes_values(monkeypatch, tmp_path):
     )
 
 
+def test_workspace_config_from_env_normalizes_r2_values(monkeypatch):
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_BACKEND", " R2 ")
+    monkeypatch.setenv("OMNICOREAGENT_WORKSPACE_PREFIX", "/agent-workspace/")
+    monkeypatch.setenv("R2_BUCKET_NAME", "bucket")
+    monkeypatch.setenv("R2_ACCOUNT_ID", "account")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "access")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "secret")
+
+    config = WorkspaceConfig.from_env()
+
+    assert config.workspace_backend == "r2"
+    assert config.namespace_prefix("files") == "agent-workspace/files"
+    assert config.cache_key(namespace="files") == (
+        "r2",
+        "bucket",
+        "account",
+        "agent-workspace/files",
+    )
+
+
 def test_workspace_config_uses_workspace_backend_name_only():
     try:
         WorkspaceConfig(backend="s3")
@@ -128,6 +149,55 @@ def test_workspace_storage_accepts_explicit_s3_config(monkeypatch):
         "aws_secret_access_key": None,
         "endpoint_url": "https://example.test",
     }
+
+
+def test_workspace_storage_accepts_explicit_r2_config(monkeypatch):
+    captured = {}
+
+    class FakeStorage:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "omnicoreagent.core.workspace.storage.R2WorkspaceStorage",
+        FakeStorage,
+    )
+
+    storage = create_workspace_storage(
+        namespace="files",
+        config=WorkspaceConfig(
+            workspace_backend="r2",
+            prefix="agent",
+            r2_bucket_name="bucket",
+            r2_account_id="account",
+            r2_access_key_id="access",
+            r2_secret_access_key="secret",
+        ),
+    )
+
+    assert isinstance(storage, FakeStorage)
+    assert captured == {
+        "bucket_name": "bucket",
+        "account_id": "account",
+        "access_key_id": "access",
+        "secret_access_key": "secret",
+        "prefix": "agent/files",
+    }
+
+
+def test_workspace_storage_requires_r2_configuration():
+    try:
+        create_workspace_storage(
+            namespace="files",
+            config=WorkspaceConfig(workspace_backend="r2", r2_bucket_name="bucket"),
+        )
+    except ValueError as exc:
+        message = str(exc)
+        assert "R2_ACCOUNT_ID" in message
+        assert "R2_ACCESS_KEY_ID" in message
+        assert "R2_SECRET_ACCESS_KEY" in message
+    else:
+        raise AssertionError("R2 workspace storage should require all R2 credentials")
 
 
 def test_create_workspace_storage_accepts_explicit_workspace_backend(monkeypatch):
@@ -292,6 +362,26 @@ def test_s3_workspace_storage_reads_writes_and_lists_files():
     assert storage.read_text("result.txt") == "hello"
     assert storage.location("result.txt") == "s3://bucket/workspace/artifacts/result.txt"
     assert [item.name for item in storage.list_files()] == ["result.txt"]
+
+
+def test_r2_workspace_storage_uses_s3_compatible_storage_without_sse():
+    client = FakeS3Client()
+    storage = R2WorkspaceStorage(
+        bucket_name="bucket",
+        account_id="account",
+        access_key_id="access",
+        secret_access_key="secret",
+        prefix="workspace/files",
+        client=client,
+    )
+
+    storage.write_text("result.txt", "hello")
+
+    assert storage.exists("result.txt")
+    assert storage.read_text("result.txt") == "hello"
+    assert storage.location("result.txt") == "s3://bucket/workspace/files/result.txt"
+    assert client.objects[("bucket", "workspace/files/result.txt")]["Body"] == b"hello"
+    assert storage.enable_encryption is False
 
 
 def test_s3_workspace_storage_rejects_path_traversal():

--- a/tests/test_workspace_files_backend.py
+++ b/tests/test_workspace_files_backend.py
@@ -10,7 +10,11 @@ from omnicoreagent.core.workspace.factory import (
 from omnicoreagent.core.workspace.tools import WorkspaceFilesTool
 from omnicoreagent.core.workspace.files import WorkspaceFilesBackend
 from omnicoreagent.core.workspace.config import WorkspaceConfig
-from omnicoreagent.core.workspace.storage import LocalWorkspaceStorage, S3WorkspaceStorage
+from omnicoreagent.core.workspace.storage import (
+    LocalWorkspaceStorage,
+    R2WorkspaceStorage,
+    S3WorkspaceStorage,
+)
 
 
 class FakeS3Body:
@@ -211,6 +215,26 @@ def test_workspace_files_uses_s3_compatible_workspace_storage():
 
     assert "deleted" in memory.delete("renamed.txt").lower()
     assert ("bucket", "workspace/files/renamed.txt") not in client.objects
+
+
+def test_workspace_files_uses_r2_workspace_storage_without_sse():
+    client = FakeS3Client()
+    storage = R2WorkspaceStorage(
+        bucket_name="bucket",
+        account_id="account",
+        access_key_id="access",
+        secret_access_key="secret",
+        prefix="workspace/files",
+        client=client,
+    )
+    memory = WorkspaceFilesBackend(storage)
+
+    assert "created" in memory.write("notes/today.md", "hello", mode="create").lower()
+    assert ("bucket", "workspace/files/notes/today.md") in client.objects
+    assert "notes/" in memory.view("")
+    assert "hello" in memory.read("notes/today.md")
+    assert "notes/today.md:1:hello" in memory.grep("hello")
+    assert storage.enable_encryption is False
 
 
 def test_workspace_files_s3_glob_and_grep_follow_pagination():


### PR DESCRIPTION
## Summary
- add a real personal operations assistant example with tools, workspace files, guardrails, telemetry IDs, and selectable memory backend
- standardize the public SQL memory backend name to `sql` and remove stale `database` docs/examples
- add memory backend contract coverage for in-memory, SQL, Redis, and MongoDB
- add R2 workspace fake-client coverage alongside S3-compatible storage coverage
- fix guardrail false positives on ISO-like dates so normal app tasks do not get blocked
- align Docker/env/install/changelog docs with current harness configuration

## Verification
- uv run ruff check src/omnicoreagent/core/guardrails/engine.py src/omnicoreagent/core/memory_store/memory_router.py tests/test_guardrails_package.py tests/test_memory.py tests/test_workspace.py tests/test_workspace_files_backend.py tests/test_real_application_production_boundaries.py cookbook/real_applications/personal_operations_assistant.py
- uv run python -m compileall -q cookbook/real_applications/personal_operations_assistant.py tests/test_memory.py tests/test_workspace.py tests/test_workspace_files_backend.py tests/test_real_application_production_boundaries.py
- uv run pytest tests/test_guardrails_package.py tests/test_guardrail_default_mode.py tests/test_real_application_production_boundaries.py -q
- uv run pytest tests/test_memory.py tests/test_workspace.py tests/test_workspace_files_backend.py tests/test_guardrails_package.py tests/test_real_application_production_boundaries.py tests/test_docs_claims.py -q -rs
- uv run pytest tests/test_docs_claims.py -q
- uv run pytest -q

## Live backend and app checks
- Redis memory contract passed against redis://localhost:6379/0
- MongoDB memory/background contracts passed against a temporary local mongo:4.4 container on port 27018
- Background durable manager/store contracts passed with Redis and MongoDB envs
- Personal operations assistant ran live with default in-memory backend
- Personal operations assistant ran live with `OMNICOREAGENT_COOKBOOK_MEMORY_BACKEND=sql`
- Support operations real app ran live and wrote the ticket workspace note
- Workspace code review real app ran live and edited/wrote workspace files

## Notes
- Full suite result: 827 passed, 10 skipped
- The configured Atlas MongoDB URI in src/.env was not reachable from this machine due DNS resolution timeout, so local Docker MongoDB was used for live Mongo proof.
- Evaluator subagents were started twice for final review but timed out and were closed; local verification above completed successfully.