### PR TITLE
Strengthen real app serving QA

### DIFF
--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -566,7 +566,13 @@ class OmniCoreAgent:
         if not self._initialized:
             await self.initialize()
 
-        return harness_tools.available_tools(self.mcp_client, self.local_tools)
+        runtime_local_tools = self.local_tools
+        if self.agent and hasattr(self.agent, "tool_runtime_registry"):
+            runtime_local_tools = await self.agent.tool_runtime_registry.prepare_tools(
+                local_tools=self.local_tools
+            )
+
+        return harness_tools.available_tools(self.mcp_client, runtime_local_tools)
 
     async def get_session_history(self, session_id: str) -> List[Dict[str, Any]]:
         """Get session history for a specific session ID"""

--- a/src/omnicoreagent/core/tools/tool_executor.py
+++ b/src/omnicoreagent/core/tools/tool_executor.py
@@ -5,6 +5,9 @@ from typing import Any
 
 from omnicoreagent.core.tools.base_tool_handler import BaseToolHandler
 
+RESULT_ENVELOPE_STATUSES = {"success", "error"}
+RESULT_ENVELOPE_KEYS = {"status", "data", "message", "error"}
+
 
 class ToolExecutor:
     """Execute one validated tool call and normalize its result."""
@@ -55,9 +58,7 @@ class ToolExecutor:
         self, tool_name: str, tool_args: dict[str, Any], result: Any
     ) -> dict[str, Any]:
         if isinstance(result, dict):
-            is_result_envelope = any(
-                key in result for key in ("status", "data", "message")
-            )
+            is_result_envelope = self._is_result_envelope(result)
             if not is_result_envelope:
                 status = "success"
                 data = result
@@ -66,6 +67,10 @@ class ToolExecutor:
                 status = result.get("status", "success")
                 data = result.get("data")
                 message = result.get("message")
+
+                if "error" in result and "status" not in result:
+                    status = "error"
+                    message = message or result.get("error")
 
                 if status == "error" and not message:
                     message = (
@@ -97,3 +102,25 @@ class ToolExecutor:
             "data": data,
             "message": message,
         }
+
+    @staticmethod
+    def _is_result_envelope(result: dict[str, Any]) -> bool:
+        status = result.get("status")
+        keys = set(result)
+
+        if status in RESULT_ENVELOPE_STATUSES:
+            return keys.issubset(RESULT_ENVELOPE_KEYS)
+
+        if "status" in result:
+            return False
+
+        if "data" in result:
+            return True
+
+        if "error" in result:
+            return keys.issubset({"error", "message"})
+
+        if "message" in result and "status" not in result:
+            return keys.issubset(RESULT_ENVELOPE_KEYS)
+
+        return False

--- a/tests/test_real_application_production_boundaries.py
+++ b/tests/test_real_application_production_boundaries.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from pathlib import Path
+from typing import Any
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
@@ -11,23 +13,107 @@ if str(ROOT_DIR) not in sys.path:
 from fastapi.testclient import TestClient  # noqa: E402
 import pytest  # noqa: E402
 
-from omnicoreagent import OmniServe, OmniServeConfig  # noqa: E402
+from omnicoreagent import BackgroundAgentManager, OmniServe, OmniServeConfig  # noqa: E402
+from omnicoreagent.core.workspace.manager import Workspace  # noqa: E402
 from omnicoreagent.serve.cli import _load_agent_from_file  # noqa: E402
+
+
+LLM_ENV_KEYS = (
+    "LLM_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENROUTER_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_API_BASE",
+    "AZURE_API_VERSION",
+    "OLLAMA_API_BASE",
+    "CENCORI_API_KEY",
+)
 
 
 @pytest.fixture(autouse=True)
 def isolate_serving_env(monkeypatch):
     """Keep local environment values from changing explicit server config."""
+    saved_env = {key: os.environ.get(key) for key in LLM_ENV_KEYS}
     for key in list(os.environ):
         if key.startswith(("OMNICOREAGENT_SERVE_", "OMNICOREAGENT_BACKGROUND_")):
             monkeypatch.delenv(key, raising=False)
-    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    for key in LLM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+    for key, value in saved_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 def attach_test_model_credentials(agent):
     """Make runtime initialization explicit without depending on process env."""
     agent.model_config = {**agent.model_config, "api_key": "test-key"}
     return agent
+
+
+class ScriptedSupportOperationsLlm:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def llm_call(self, messages: list[Any]):
+        self.calls += 1
+        if self.calls == 1:
+            return """
+<tool_calls>
+  <tool_call>
+    <tool_name>lookup_customer</tool_name>
+    <parameters>{"customer_id": "cust-001"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>recent_orders</tool_name>
+    <parameters>{"customer_id": "cust-001"}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>support_policy_search</tool_name>
+    <parameters>{"query": "enterprise delayed shipment escalation"}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        if self.calls == 2:
+            conversation = _messages_text(messages)
+            assert "Ada Ventures" in conversation
+            assert "ord-1002" in conversation
+            assert "Enterprise delayed shipments" in conversation
+            return """
+<tool_calls>
+  <tool_call>
+    <tool_name>create_escalation</tool_name>
+    <parameters>{"ticket_id": "tck-1042", "severity": "medium", "summary": "Delayed enterprise shipment needs timeline and goodwill review."}</parameters>
+  </tool_call>
+  <tool_call>
+    <tool_name>write_file</tool_name>
+    <parameters>{"path": "tickets/tck-1042.md", "content": "# tck-1042\\n\\nEscalated delayed shipment for Ada Ventures.", "mode": "create"}</parameters>
+  </tool_call>
+</tool_calls>
+"""
+        conversation = _messages_text(messages)
+        assert "queued_for_specialist" in conversation
+        assert "tickets/tck-1042.md" in conversation
+        return """
+<final_answer>Support plan ready: explain the delay, share timeline, and route the medium escalation.</final_answer>
+"""
+
+
+def _messages_text(messages: list[Any]) -> str:
+    parts: list[str] = []
+    for message in messages:
+        if isinstance(message, dict):
+            parts.append(str(message.get("content", "")))
+        else:
+            parts.append(str(getattr(message, "content", message)))
+    return "\n".join(parts)
 
 
 def test_real_application_examples_are_importable_agent_factories(tmp_path):
@@ -92,4 +178,189 @@ def test_omniserve_real_application_exposes_domain_and_workspace_tools(tmp_path)
         "recent_orders",
         "support_policy_search",
         "create_escalation",
+        "ls",
+        "read_file",
+        "write_file",
+        "grep",
     }.issubset(tool_names)
+
+
+def test_omniserve_real_application_sync_run_writes_workspace_and_trace(tmp_path):
+    from cookbook.omniserve.real_application_agent import create_agent
+
+    workspace_dir = tmp_path / "served-support-app"
+    agent = attach_test_model_credentials(create_agent(workspace_dir=workspace_dir))
+    server = OmniServe(agent, OmniServeConfig(background_enabled=False))
+
+    with TestClient(server.app) as client:
+        agent.llm_connection = ScriptedSupportOperationsLlm()
+        response = client.post(
+            "/run/sync",
+            json={
+                "query": (
+                    "Handle ticket tck-1042 for customer cust-001. Use the support "
+                    "tools and save notes at tickets/tck-1042.md."
+                ),
+                "session_id": "served-support-session",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["response"].startswith("Support plan ready")
+        assert payload["session_id"] == "served-support-session"
+        assert payload["trace_id"]
+        assert payload["run_id"]
+
+        events_response = client.get(
+            f"/events/served-support-session/list?run_id={payload['run_id']}"
+        )
+        assert events_response.status_code == 200
+        events_payload = events_response.json()
+        assert events_payload["count"] > 0
+        event_names = [event["event_type"] for event in events_payload["events"]]
+        assert event_names[0] == "serve_request_start"
+        assert "serve_request_end" in event_names
+        assert "tool_batch_start" in event_names
+        assert "observation_pipeline_end" in event_names
+        assert "workspace_write" in event_names
+        assert "final_answer" in event_names
+
+        tool_results = [
+            event["output"]
+            for event in events_payload["events"]
+            if event["event_type"] == "tool_result"
+        ]
+        tool_names = {result["tool_name"] for result in tool_results}
+        assert {
+            "lookup_customer",
+            "recent_orders",
+            "support_policy_search",
+            "create_escalation",
+        }.issubset(tool_names)
+        assert any(result.get("data", {}).get("name") == "Ada Ventures" for result in tool_results)
+        assert any("ord-1002" in str(result.get("data")) for result in tool_results)
+        assert any(
+            result.get("data", {}).get("status") == "queued_for_specialist"
+            for result in tool_results
+            if result["tool_name"] == "create_escalation"
+        )
+
+        trace_response = client.get(
+            f"/events/served-support-session/trace?run_id={payload['run_id']}"
+        )
+        assert trace_response.status_code == 200
+        trace_payload = trace_response.json()
+        assert trace_payload["summary"]["trace_id"] == payload["trace_id"]
+        assert trace_payload["summary"]["run_id"] == payload["run_id"]
+        assert trace_payload["summary"]["status"] == "completed"
+        assert trace_payload["summary"]["event_count"] >= 20
+        assert [step["event_type"] for step in trace_payload["steps"]][-1] == "final_answer"
+
+    ticket = workspace_dir / "files" / "tickets" / "tck-1042.md"
+    assert ticket.read_text(encoding="utf-8").startswith("# tck-1042")
+
+
+def test_omniserve_background_api_runs_real_application_background_agent(tmp_path):
+    from cookbook.background_agents.real_application_background_task import (
+        SupportOperationsBackgroundAgent,
+    )
+
+    workspace = Workspace.from_config(
+        {
+            "workspace_backend": "local",
+            "workspace_dir": str(tmp_path / "background-workspace"),
+        }
+    ).ensure()
+    agent = SupportOperationsBackgroundAgent(workspace)
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        workspace=workspace,
+        worker_id="served_real_app_worker",
+    )
+    server = OmniServe(
+        agent,
+        OmniServeConfig(
+            background_agent_id="support_ops",
+            background_start_worker=True,
+            request_timeout=2,
+        ),
+        background_manager=manager,
+    )
+
+    with TestClient(server.app) as client:
+        created = client.post(
+            "/background/tasks",
+            json={
+                "task_id": "support_ticket_tck_1042",
+                "query": (
+                    "Handle ticket tck-1042 for customer cust-001. Create a durable "
+                    "support note and escalation summary."
+                ),
+                "schedule": {"type": "manual"},
+                "timeout_seconds": 10,
+                "retry_policy": {"max_retries": 0},
+            },
+        )
+        assert created.status_code == 200
+
+        queued_response = client.post(
+            "/background/tasks/support_ticket_tck_1042/run",
+            json={"wait": False},
+        )
+        assert queued_response.status_code == 200
+        queued_run = queued_response.json()
+        assert queued_run["status"] in {"queued", "running", "completed"}
+
+        run = _wait_for_background_run(
+            client,
+            queued_run["run_id"],
+            timeout_seconds=3,
+        )
+        assert run["status"] == "completed"
+
+        events_response = client.get(f"/background/runs/{run['run_id']}/events")
+        assert events_response.status_code == 200
+        event_names = [event["event"] for event in events_response.json()["events"]]
+        assert "background_run_completed" in event_names
+
+        workspace_response = client.get(f"/background/runs/{run['run_id']}/workspace")
+        assert workspace_response.status_code == 200
+        workspace_files = {item["name"] for item in workspace_response.json()["files"]}
+        assert {"events.jsonl", "output.md", "run.json", "tickets"}.issubset(
+            workspace_files
+        )
+
+    output = workspace.files.read_text(f"{run['workspace_path']}/output.md")
+    assert "Support background task: tck-1042" in output
+    assert "Ada Ventures" in output
+    assert "ord-1002" in output
+    assert "Enterprise delayed shipments" in output
+    assert "queued_for_specialist" in output
+
+    ticket = workspace.files.read_text(f"{run['workspace_path']}/tickets/tck-1042.md")
+    assert ticket == output
+
+
+def _wait_for_background_run(
+    client: TestClient,
+    run_id: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_run: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        response = client.get(f"/background/runs/{run_id}")
+        assert response.status_code == 200
+        last_run = response.json()
+        if last_run["status"] in {
+            "completed",
+            "failed",
+            "cancelled",
+            "timeout",
+            "retry_exhausted",
+        }:
+            return last_run
+        time.sleep(0.05)
+    raise AssertionError(f"background run did not finish: {last_run}")

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -26,3 +26,90 @@ def test_normalize_structured_tool_result_envelope_still_supported():
 
     assert result["status"] == "success"
     assert result["data"] == [{"name": "Wireless Headphones"}]
+
+
+def test_normalize_dict_with_domain_status_is_data_not_envelope():
+    executor = ToolExecutor(tool_handler=None)
+
+    result = executor._normalize_result(
+        "create_escalation",
+        {"ticket_id": "tck-1042"},
+        {
+            "ticket_id": "tck-1042",
+            "status": "queued_for_specialist",
+            "summary": "Delayed shipment needs review.",
+        },
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["status"] == "queued_for_specialist"
+    assert result["data"]["ticket_id"] == "tck-1042"
+
+
+def test_normalize_dict_with_domain_status_and_message_is_data_not_envelope():
+    executor = ToolExecutor(tool_handler=None)
+
+    result = executor._normalize_result(
+        "check_order",
+        {"order_id": "ord-1002"},
+        {
+            "order_id": "ord-1002",
+            "status": "delayed",
+            "message": "Carrier missed the pickup window.",
+        },
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["status"] == "delayed"
+    assert result["data"]["message"] == "Carrier missed the pickup window."
+
+
+def test_normalize_dict_with_domain_error_field_is_data_not_envelope():
+    executor = ToolExecutor(tool_handler=None)
+
+    result = executor._normalize_result(
+        "validate_profile",
+        {"customer_id": "cust-001"},
+        {
+            "customer_id": "cust-001",
+            "field": "email",
+            "error": "minor validation warning",
+        },
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["error"] == "minor validation warning"
+    assert result["data"]["field"] == "email"
+
+
+def test_normalize_dict_with_domain_status_and_data_is_data_not_envelope():
+    executor = ToolExecutor(tool_handler=None)
+
+    result = executor._normalize_result(
+        "create_escalation",
+        {"ticket_id": "tck-1042"},
+        {
+            "status": "queued_for_specialist",
+            "data": {"ticket_id": "tck-1042"},
+        },
+    )
+
+    assert result["status"] == "success"
+    assert result["data"] == {
+        "status": "queued_for_specialist",
+        "data": {"ticket_id": "tck-1042"},
+    }
+
+
+def test_normalize_pure_error_dict_is_error_envelope():
+    executor = ToolExecutor(tool_handler=None)
+
+    result = executor._normalize_result(
+        "search_inventory",
+        {"sku": "missing"},
+        {"error": "Inventory service unavailable"},
+    )
+
+    assert result["status"] == "error"
+    assert result["data"] is None
+    assert result["message"] == "Inventory service unavailable"


### PR DESCRIPTION
## Summary
- expose prepared runtime tools through OmniServe tool discovery so built-in workspace tools are visible with domain tools
- preserve domain tool payloads that use fields like status, data, message, or error without confusing them with framework result envelopes
- add production-boundary coverage for real cookbook app sync serving, telemetry list/trace correlation, queued background execution, and workspace outputs

## Verification
- uv run ruff check src/omnicoreagent/core/tools/tool_executor.py src/omnicoreagent/core/runtime/omnicore_agent.py tests/test_tool_executor.py tests/test_real_application_production_boundaries.py
- uv run pytest tests/test_tool_executor.py tests/test_real_application_production_boundaries.py tests/test_tool_observation.py tests/test_tool_batch_runner.py -q
- uv run pytest tests/test_real_application_production_boundaries.py tests/test_omniserve_background.py tests/test_omniserve_full.py tests/test_real_application_examples.py tests/test_real_application_smoke.py -q
- uv run pytest -q