### PR TITLE
Add OmniServe telemetry inspection API

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -128,6 +128,12 @@ limiting until you opt in.
 | GET | `/events/{session_id}` | Yes* | Replay and follow telemetry events over SSE |
 | GET | `/events/{session_id}/list` | Yes* | Return stored telemetry events as JSON |
 | GET | `/events/{session_id}/trace` | Yes* | Return the latest telemetry trace summary |
+| GET | `/telemetry/events` | Yes* | Return stored telemetry events by trace, run, session, task, or event type; default `limit=200` |
+| GET | `/telemetry/events/stream` | Yes* | Replay and follow telemetry over SSE for a session |
+| GET | `/telemetry/traces` | Yes* | List traces by trace, run, session, task, agent, workflow, model, or status; default `limit=100` |
+| GET | `/telemetry/traces/{trace_id}` | Yes* | Return one exact trace |
+| GET | `/telemetry/runs/{run_id}/trace` | Yes* | Return the latest trace for one run |
+| GET | `/telemetry/sessions/{session_id}/trace` | Yes* | Return the latest trace for one session |
 | GET | `/sessions/{session_id}/history` | Yes* | Return conversation history |
 | GET | `/docs` | No | Swagger UI |
 | GET | `/redoc` | No | ReDoc UI |

--- a/docs/core-concepts/events.mdx
+++ b/docs/core-concepts/events.mdx
@@ -88,12 +88,23 @@ OmniServe uses the same telemetry stream:
 
 - `POST /run` streams telemetry for the run it starts and finishes with
   `complete`.
-- `GET /events/{session_id}` replays stored telemetry for a session and follows
-  new telemetry. Add `?run_id=...` to isolate one run inside that session.
-- `GET /events/{session_id}/list` returns stored telemetry events as JSON. Add
-  `?run_id=...` for the same run-scoped filtering.
-- `GET /events/{session_id}/trace` returns a compact telemetry summary for the
-  latest session trace. Add `?run_id=...` to retrieve the trace for that run.
+- `GET /telemetry/events` returns stored telemetry events as JSON. Filter by
+  `trace_id`, `run_id`, `session_id`, `task_id`, or `event_type`. The default
+  event limit is `200`.
+- `GET /telemetry/events/stream?session_id=...` replays stored telemetry for a
+  session and follows new telemetry. Add `run_id` to isolate one run.
+- `GET /telemetry/traces/{trace_id}` returns one exact trace.
+- `GET /telemetry/runs/{run_id}/trace` returns the latest trace correlated to
+  one run.
+- `GET /telemetry/sessions/{session_id}/trace` returns the latest trace for a
+  session.
+
+The older `/events/{session_id}`, `/events/{session_id}/list`, and
+`/events/{session_id}/trace` routes remain as compact session-oriented aliases.
+Use `?run_id=...` on those aliases to isolate one run inside a shared session.
+
+Trace detail routes return `404` when the requested exact trace, run trace, or
+session trace does not exist. The trace list route defaults to `limit=100`.
 
 Every telemetry event includes its `trace_id`. Runtime-created events also carry
 correlation metadata such as `run_id`, `session_id`, and `agent_id` when that

--- a/docs/how-to-guides/observability.mdx
+++ b/docs/how-to-guides/observability.mdx
@@ -59,21 +59,25 @@ for event in events:
     print(event.event_type, event.model_dump())
 ```
 
-When serving through OmniServe, `POST /run` streams the live run over SSE and
-`GET /events/{session_id}` replays stored telemetry events for that session
-before following new live telemetry events. Add `?run_id=...` to
-`/events/{session_id}`, `/events/{session_id}/list`, or
-`/events/{session_id}/trace` when a UI needs to isolate one run inside a shared
-session.
+When serving through OmniServe, `POST /run` streams the live run over SSE.
+For application UIs and APIs, use the `/telemetry` routes to replay, inspect,
+and stream stored telemetry. Filter by `run_id` when a UI needs to isolate one
+execution inside a shared session.
+The compact `/events/{session_id}` aliases are still available and accept
+`?run_id=...` for the same run-scoped isolation.
 
 ```bash
 curl -N -X POST http://localhost:8000/run \
   -H "Content-Type: application/json" \
   -d '{"query": "Research this topic", "session_id": "research_1"}'
 
-curl -N http://localhost:8000/events/research_1
-curl http://localhost:8000/events/research_1/list?run_id=RUN_ID
-curl http://localhost:8000/events/research_1/trace?run_id=RUN_ID
+curl "http://localhost:8000/telemetry/events?session_id=research_1&run_id=RUN_ID"
+curl "http://localhost:8000/telemetry/events?run_id=RUN_ID&event_type=tool_result&limit=100"
+curl "http://localhost:8000/telemetry/traces?session_id=research_1&limit=20"
+curl "http://localhost:8000/telemetry/traces/TRACE_ID"
+curl "http://localhost:8000/telemetry/runs/RUN_ID/trace"
+curl "http://localhost:8000/telemetry/sessions/research_1/trace"
+curl -N "http://localhost:8000/telemetry/events/stream?session_id=research_1&run_id=RUN_ID"
 ```
 
 ---

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -208,6 +208,12 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/events/{session_id}` | Yes* | Replay stored telemetry events, then follow live telemetry events over SSE; add `?run_id=...` to isolate one run |
 | `GET` | `/events/{session_id}/list` | Yes* | Return stored telemetry events as JSON; add `?run_id=...` to isolate one run |
 | `GET` | `/events/{session_id}/trace` | Yes* | Compact telemetry trace summary for the latest session trace, or `?run_id=...` for one run |
+| `GET` | `/telemetry/events` | Yes* | Return stored telemetry events filtered by `trace_id`, `run_id`, `session_id`, `task_id`, or `event_type` |
+| `GET` | `/telemetry/events/stream` | Yes* | Replay and follow telemetry events over SSE for `session_id`; add `run_id` to isolate one run |
+| `GET` | `/telemetry/traces` | Yes* | List traces filtered by trace, run, session, task, agent, workflow, model, or status |
+| `GET` | `/telemetry/traces/{trace_id}` | Yes* | Return one exact trace |
+| `GET` | `/telemetry/runs/{run_id}/trace` | Yes* | Return the latest trace correlated to one run |
+| `GET` | `/telemetry/sessions/{session_id}/trace` | Yes* | Return the latest trace for one session |
 | `GET` | `/docs` | No | Swagger UI |
 | `GET` | `/redoc` | No | ReDoc UI |
 
@@ -268,14 +274,30 @@ curl -N "http://localhost:8000/events/user123?run_id=RUN_ID"
 curl "http://localhost:8000/events/user123/list?run_id=RUN_ID"
 curl "http://localhost:8000/events/user123/trace?run_id=RUN_ID"
 
+# Production telemetry API
+curl "http://localhost:8000/telemetry/events?session_id=user123&run_id=RUN_ID"
+curl "http://localhost:8000/telemetry/events?run_id=RUN_ID&event_type=tool_result&limit=100"
+curl "http://localhost:8000/telemetry/traces?session_id=user123&limit=20"
+curl "http://localhost:8000/telemetry/traces/TRACE_ID"
+curl "http://localhost:8000/telemetry/runs/RUN_ID/trace"
+curl "http://localhost:8000/telemetry/sessions/user123/trace"
+curl -N "http://localhost:8000/telemetry/events/stream?session_id=user123&run_id=RUN_ID"
+
 # List tools
 curl http://localhost:8000/tools \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
 For telemetry traces, `trace_id` is the exact lookup handle returned by the
-agent runtime. OmniServe's `run_id` query parameter is a session-scoped
-correlation filter for event replay and trace summaries.
+agent runtime. `run_id` is the serving/runtime correlation handle returned from
+`/run/sync` and SSE completion payloads. Use `trace_id` when you need one exact
+trace. Use `run_id` when your UI or application needs all telemetry for one
+execution inside a shared session.
+
+`/telemetry/events` defaults to `limit=200`; `/telemetry/traces` defaults to
+`limit=100`. Both accept lower limits per request. Exact trace, run trace, and
+session trace detail endpoints return `404` when no matching trace exists or an
+accessor returns a trace that does not match the requested selector.
 
 ### Background Task Example
 

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -190,6 +190,30 @@ class TraceResponse(BaseModel):
     steps: list[dict[str, Any]] = Field(..., description="Ordered telemetry events")
 
 
+class TelemetryEventsResponse(BaseModel):
+    """Response model for filtered telemetry events."""
+
+    filters: dict[str, Any] = Field(default_factory=dict)
+    events: list[dict[str, Any]] = Field(..., description="Telemetry events list")
+    count: int = Field(..., description="Number of telemetry events")
+
+
+class TelemetryTraceDetailResponse(BaseModel):
+    """Response model for one telemetry trace."""
+
+    filters: dict[str, Any] = Field(default_factory=dict)
+    summary: dict[str, Any] = Field(..., description="Telemetry trace summary")
+    trace: dict[str, Any] = Field(..., description="Full telemetry trace")
+
+
+class TelemetryTraceListResponse(BaseModel):
+    """Response model for filtered telemetry traces."""
+
+    filters: dict[str, Any] = Field(default_factory=dict)
+    traces: list[dict[str, Any]] = Field(..., description="Telemetry traces")
+    count: int = Field(..., description="Number of telemetry traces")
+
+
 class BackgroundStatusResponse(BaseModel):
     """Simple status response for background control endpoints."""
 

--- a/src/omnicoreagent/serve/routes/__init__.py
+++ b/src/omnicoreagent/serve/routes/__init__.py
@@ -7,6 +7,7 @@ from .health import create_health_router
 from .metrics import create_metrics_router
 from .runs import create_runs_router
 from .sessions import create_sessions_router
+from .telemetry import create_telemetry_router
 from .tools import create_tools_router
 
 
@@ -16,6 +17,7 @@ def create_agent_router(config: OmniServeConfig) -> APIRouter:
     router.include_router(create_health_router())
     router.include_router(create_runs_router())
     router.include_router(create_sessions_router())
+    router.include_router(create_telemetry_router())
     router.include_router(create_tools_router())
     router.include_router(create_metrics_router())
     if config.background_enabled:

--- a/src/omnicoreagent/serve/routes/telemetry.py
+++ b/src/omnicoreagent/serve/routes/telemetry.py
@@ -1,0 +1,422 @@
+"""Telemetry inspection routes for OmniServe."""
+
+from __future__ import annotations
+
+from inspect import isawaitable, signature
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+
+from omnicoreagent.core.telemetry import TraceStatus
+
+from ..models import (
+    TelemetryEventsResponse,
+    TelemetryTraceDetailResponse,
+    TelemetryTraceListResponse,
+)
+from ..serialization import normalize_events
+from ..sse import stream_session_events
+from ..state import get_agent
+
+
+def _clean_filters(**filters: Any) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in filters.items()
+        if value is not None and value != () and value != []
+    }
+
+
+def _supported_kwargs(method: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    try:
+        parameters = signature(method).parameters
+    except (TypeError, ValueError):
+        return kwargs
+
+    if any(parameter.kind.name == "VAR_KEYWORD" for parameter in parameters.values()):
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in parameters}
+
+
+async def _maybe_await(value: Any) -> Any:
+    if isawaitable(value):
+        return await value
+    return value
+
+
+async def _call(method: Any, **kwargs: Any) -> Any:
+    return await _maybe_await(method(**_supported_kwargs(method, kwargs)))
+
+
+def _event_value(event: dict[str, Any], key: str) -> Any:
+    value = event.get(key)
+    if value is not None:
+        return value
+    metadata = event.get("metadata") or {}
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    return None
+
+
+def _event_matches_filters(
+    event: dict[str, Any],
+    *,
+    trace_id: str | None,
+    run_id: str | None,
+    session_id: str | None,
+    task_id: str | None,
+    event_types: tuple[str, ...] | None,
+) -> bool:
+    checks = {
+        "trace_id": trace_id,
+        "run_id": run_id,
+        "session_id": session_id,
+        "task_id": task_id,
+    }
+    for key, expected in checks.items():
+        if expected is not None and _event_value(event, key) != expected:
+            return False
+    if event_types and event.get("event_type") not in event_types:
+        return False
+    return True
+
+
+def _trace_summary(trace: dict[str, Any] | None) -> dict[str, Any]:
+    trace = trace or {}
+    events = trace.get("events", [])
+    spans = trace.get("spans", [])
+    return {
+        "trace_id": trace.get("trace_id"),
+        "run_id": trace.get("run_id"),
+        "session_id": trace.get("session_id"),
+        "status": trace.get("status"),
+        "event_count": len(events),
+        "span_count": len(spans),
+    }
+
+
+def _validate_status(status: str | None) -> str | None:
+    if status is None:
+        return None
+    try:
+        return TraceStatus(status).value
+    except ValueError:
+        allowed = ", ".join(item.value for item in TraceStatus)
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid trace status '{status}'. Expected one of: {allowed}",
+        ) from None
+
+
+def _require_trace(
+    trace: dict[str, Any] | None,
+    detail: str,
+    *,
+    trace_id: str | None = None,
+    run_id: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    if trace is None:
+        raise HTTPException(status_code=404, detail=detail)
+    if trace_id is not None and trace.get("trace_id") != trace_id:
+        raise HTTPException(status_code=404, detail=detail)
+    if run_id is not None and trace.get("run_id") != run_id:
+        raise HTTPException(status_code=404, detail=detail)
+    if session_id is not None and trace.get("session_id") != session_id:
+        raise HTTPException(status_code=404, detail=detail)
+    return trace
+
+
+async def _get_events(
+    agent: Any,
+    *,
+    cursor: str | None,
+    trace_id: str | None,
+    run_id: str | None,
+    session_id: str | None,
+    task_id: str | None,
+    event_types: tuple[str, ...] | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    events_after = getattr(agent, "get_telemetry_events_after", None)
+    if not callable(events_after):
+        return []
+
+    raw_events = await _call(
+        events_after,
+        cursor=cursor,
+        trace_id=trace_id,
+        run_id=run_id,
+        session_id=session_id,
+        task_id=task_id,
+        event_types=event_types,
+    )
+    events = normalize_events(raw_events or [])
+    filtered = [
+        event
+        for event in events
+        if _event_matches_filters(
+            event,
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            task_id=task_id,
+            event_types=event_types,
+        )
+    ]
+    return filtered[:limit]
+
+
+async def _get_trace(
+    agent: Any,
+    *,
+    trace_id: str | None = None,
+    run_id: str | None = None,
+    session_id: str | None = None,
+    normalize: bool = False,
+) -> dict[str, Any] | None:
+    if session_id is not None and trace_id is None and run_id is None:
+        get_latest_trace = getattr(agent, "get_latest_trace", None)
+        if callable(get_latest_trace):
+            return await _call(get_latest_trace, session_id=session_id, normalize=normalize)
+
+    get_trace = getattr(agent, "get_trace", None)
+    if not callable(get_trace):
+        return None
+
+    trace = await _call(
+        get_trace,
+        **_clean_filters(trace_id=trace_id, run_id=run_id, session_id=session_id),
+        normalize=normalize,
+    )
+    return trace or None
+
+
+async def _list_traces(
+    agent: Any,
+    *,
+    trace_id: str | None = None,
+    run_id: str | None = None,
+    session_id: str | None = None,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+    workflow_id: str | None = None,
+    model: str | None = None,
+    status: str | None = None,
+    normalize: bool = False,
+) -> list[dict[str, Any]]:
+    list_traces = getattr(agent, "list_telemetry_traces", None)
+    if not callable(list_traces):
+        trace = await _get_trace(
+            agent,
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            normalize=normalize,
+        )
+        return [trace] if trace else []
+
+    traces = await _call(
+        list_traces,
+        trace_id=trace_id,
+        run_id=run_id,
+        session_id=session_id,
+        task_id=task_id,
+        agent_id=agent_id,
+        workflow_id=workflow_id,
+        model=model,
+        status=status,
+        normalize=normalize,
+    )
+    return list(traces or [])
+
+
+def create_telemetry_router() -> APIRouter:
+    """Create telemetry inspection endpoints."""
+    router = APIRouter(prefix="/telemetry", tags=["Telemetry"])
+
+    @router.get(
+        "/events",
+        response_model=TelemetryEventsResponse,
+        summary="List telemetry events",
+        description="Return stored telemetry events filtered by trace, run, session, task, or event type.",
+    )
+    async def list_events(
+        request: Request,
+        trace_id: str | None = Query(default=None),
+        run_id: str | None = Query(default=None),
+        session_id: str | None = Query(default=None),
+        task_id: str | None = Query(default=None),
+        event_type: list[str] | None = Query(default=None),
+        cursor: str | None = Query(default=None),
+        limit: int = Query(default=200, ge=1, le=1000),
+    ) -> TelemetryEventsResponse:
+        event_types = tuple(event_type or ()) or None
+        agent = get_agent(request)
+        events = await _get_events(
+            agent,
+            cursor=cursor,
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            task_id=task_id,
+            event_types=event_types,
+            limit=limit,
+        )
+        return TelemetryEventsResponse(
+            filters=_clean_filters(
+                cursor=cursor,
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+                task_id=task_id,
+                event_type=list(event_types) if event_types else None,
+                limit=limit,
+            ),
+            events=events,
+            count=len(events),
+        )
+
+    @router.get(
+        "/events/stream",
+        summary="Stream telemetry events",
+        description="Replay and follow telemetry events for one session. Add run_id to isolate one run.",
+    )
+    async def stream_events(
+        request: Request,
+        session_id: str = Query(...),
+        run_id: str | None = Query(default=None),
+    ):
+        agent = get_agent(request)
+        return StreamingResponse(
+            stream_session_events(agent, session_id, run_id=run_id),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @router.get(
+        "/traces",
+        response_model=TelemetryTraceListResponse,
+        summary="List telemetry traces",
+        description="Return telemetry traces filtered by trace, run, session, task, agent, workflow, model, or status.",
+    )
+    async def list_traces(
+        request: Request,
+        trace_id: str | None = Query(default=None),
+        run_id: str | None = Query(default=None),
+        session_id: str | None = Query(default=None),
+        task_id: str | None = Query(default=None),
+        agent_id: str | None = Query(default=None),
+        workflow_id: str | None = Query(default=None),
+        model: str | None = Query(default=None),
+        status: str | None = Query(default=None),
+        normalize: bool = Query(default=False),
+        limit: int = Query(default=100, ge=1, le=1000),
+    ) -> TelemetryTraceListResponse:
+        agent = get_agent(request)
+        status = _validate_status(status)
+        traces = await _list_traces(
+            agent,
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            task_id=task_id,
+            agent_id=agent_id,
+            workflow_id=workflow_id,
+            model=model,
+            status=status,
+            normalize=normalize,
+        )
+        traces = traces[:limit]
+        return TelemetryTraceListResponse(
+            filters=_clean_filters(
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+                task_id=task_id,
+                agent_id=agent_id,
+                workflow_id=workflow_id,
+                model=model,
+                status=status,
+                normalize=normalize,
+                limit=limit,
+            ),
+            traces=traces,
+            count=len(traces),
+        )
+
+    @router.get(
+        "/traces/{trace_id}",
+        response_model=TelemetryTraceDetailResponse,
+        summary="Get exact telemetry trace",
+        description="Return one telemetry trace by exact trace_id.",
+    )
+    async def get_exact_trace(
+        request: Request,
+        trace_id: str,
+        normalize: bool = Query(default=False),
+    ) -> TelemetryTraceDetailResponse:
+        agent = get_agent(request)
+        trace = _require_trace(
+            await _get_trace(agent, trace_id=trace_id, normalize=normalize),
+            f"Trace not found: {trace_id}",
+            trace_id=trace_id,
+        )
+        return TelemetryTraceDetailResponse(
+            filters=_clean_filters(trace_id=trace_id, normalize=normalize),
+            summary=_trace_summary(trace),
+            trace=trace,
+        )
+
+    @router.get(
+        "/runs/{run_id}/trace",
+        response_model=TelemetryTraceDetailResponse,
+        summary="Get run telemetry trace",
+        description="Return the latest telemetry trace correlated to one run_id.",
+    )
+    async def get_run_trace(
+        request: Request,
+        run_id: str,
+        normalize: bool = Query(default=False),
+    ) -> TelemetryTraceDetailResponse:
+        agent = get_agent(request)
+        trace = _require_trace(
+            await _get_trace(agent, run_id=run_id, normalize=normalize),
+            f"Trace not found for run: {run_id}",
+            run_id=run_id,
+        )
+        return TelemetryTraceDetailResponse(
+            filters=_clean_filters(run_id=run_id, normalize=normalize),
+            summary=_trace_summary(trace),
+            trace=trace,
+        )
+
+    @router.get(
+        "/sessions/{session_id}/trace",
+        response_model=TelemetryTraceDetailResponse,
+        summary="Get latest session telemetry trace",
+        description="Return the latest telemetry trace for one session_id.",
+    )
+    async def get_session_trace(
+        request: Request,
+        session_id: str,
+        normalize: bool = Query(default=False),
+    ) -> TelemetryTraceDetailResponse:
+        agent = get_agent(request)
+        trace = _require_trace(
+            await _get_trace(agent, session_id=session_id, normalize=normalize),
+            f"Trace not found for session: {session_id}",
+            session_id=session_id,
+        )
+        return TelemetryTraceDetailResponse(
+            filters=_clean_filters(session_id=session_id, normalize=normalize),
+            summary=_trace_summary(trace),
+            trace=trace,
+        )
+
+    return router

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -616,20 +616,33 @@ class TestEndpoints:
             return_value={
                 "trace_id": "trace_endpoint",
                 "run_id": "run_endpoint",
+                "session_id": "test-endpoint-session",
                 "status": "completed",
                 "events": [{"event_type": "user_message"}],
                 "spans": [{"kind": "agent.run"}],
             }
         )
         agent.get_trace = AsyncMock(
-            return_value={
-                "trace_id": "trace_endpoint_by_run",
-                "run_id": "run_endpoint",
+            side_effect=lambda **kwargs: {
+                "trace_id": kwargs.get("trace_id") or "trace_endpoint_by_run",
+                "run_id": kwargs.get("run_id") or "run_endpoint",
                 "session_id": "test-endpoint-session",
                 "status": "completed",
                 "events": [{"event_type": "final_answer"}],
                 "spans": [{"kind": "agent.run"}],
             }
+        )
+        agent.list_telemetry_traces = AsyncMock(
+            return_value=[
+                {
+                    "trace_id": "trace_endpoint",
+                    "run_id": "run_endpoint",
+                    "session_id": "test-endpoint-session",
+                    "status": "completed",
+                    "events": [{"event_type": "user_message"}],
+                    "spans": [{"kind": "agent.run"}],
+                }
+            ]
         )
         store = InMemoryTelemetryStore()
         agent.telemetry_store = store
@@ -869,6 +882,7 @@ class TestEndpoints:
 
     def test_trace_endpoint_rejects_run_id_from_another_session(self, server_client):
         agent = server_client.app.state.agent
+        agent.get_trace.side_effect = None
         agent.get_trace.return_value = {
             "trace_id": "trace_other",
             "run_id": "run_other",
@@ -896,6 +910,7 @@ class TestEndpoints:
         self, server_client
     ):
         agent = server_client.app.state.agent
+        agent.get_trace.side_effect = None
         agent.get_trace.return_value = None
 
         resp = server_client.get(
@@ -938,6 +953,215 @@ class TestEndpoints:
             run_id="run_endpoint",
         )
 
+    def test_telemetry_events_endpoint_filters_by_session_and_run(self, server_client):
+        resp = server_client.get(
+            "/telemetry/events?session_id=test-endpoint-session&run_id=run_endpoint"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filters"] == {
+            "limit": 200,
+            "run_id": "run_endpoint",
+            "session_id": "test-endpoint-session",
+        }
+        assert data["count"] == 1
+        assert data["events"][0]["event_type"] == "user_message"
+        agent = server_client.app.state.agent
+        agent.get_telemetry_events_after.assert_awaited_with(
+            cursor=None,
+            trace_id=None,
+            run_id="run_endpoint",
+            session_id="test-endpoint-session",
+            task_id=None,
+            event_types=None,
+        )
+
+    def test_telemetry_traces_endpoint_lists_filtered_traces(self, server_client):
+        resp = server_client.get(
+            "/telemetry/traces?session_id=test-endpoint-session&run_id=run_endpoint"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filters"]["session_id"] == "test-endpoint-session"
+        assert data["filters"]["run_id"] == "run_endpoint"
+        assert data["filters"]["limit"] == 100
+        assert data["count"] == 1
+        assert data["traces"][0]["trace_id"] == "trace_endpoint"
+        agent = server_client.app.state.agent
+        agent.list_telemetry_traces.assert_awaited_with(
+            trace_id=None,
+            run_id="run_endpoint",
+            session_id="test-endpoint-session",
+            task_id=None,
+            agent_id=None,
+            workflow_id=None,
+            model=None,
+            status=None,
+            normalize=False,
+        )
+
+    def test_telemetry_trace_endpoint_uses_exact_trace_id(self, server_client):
+        resp = server_client.get("/telemetry/traces/trace_endpoint")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filters"] == {"trace_id": "trace_endpoint", "normalize": False}
+        assert data["summary"]["trace_id"] == "trace_endpoint"
+        assert data["trace"]["events"][0]["event_type"] == "final_answer"
+        agent = server_client.app.state.agent
+        agent.get_trace.assert_awaited_with(trace_id="trace_endpoint", normalize=False)
+
+    def test_telemetry_run_trace_endpoint_uses_run_id(self, server_client):
+        resp = server_client.get("/telemetry/runs/run_endpoint/trace")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filters"] == {"run_id": "run_endpoint", "normalize": False}
+        assert data["summary"]["run_id"] == "run_endpoint"
+        agent = server_client.app.state.agent
+        agent.get_trace.assert_awaited_with(run_id="run_endpoint", normalize=False)
+
+    def test_telemetry_session_trace_endpoint_uses_latest_session_trace(
+        self, server_client
+    ):
+        resp = server_client.get("/telemetry/sessions/test-endpoint-session/trace")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filters"] == {
+            "session_id": "test-endpoint-session",
+            "normalize": False,
+        }
+        assert data["summary"]["trace_id"] == "trace_endpoint"
+        agent = server_client.app.state.agent
+        agent.get_latest_trace.assert_awaited_with(
+            session_id="test-endpoint-session",
+            normalize=False,
+        )
+
+    def test_telemetry_trace_detail_endpoints_return_404_when_missing(self):
+        class MissingTraceAgent:
+            name = "MissingTraceAgent"
+
+            def generate_session_id(self):
+                return "missing-trace-session"
+
+            async def get_trace(self, **kwargs):
+                return None
+
+            async def get_latest_trace(self, **kwargs):
+                return None
+
+        server = OmniServe(
+            agent=MissingTraceAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+        client = TestClient(server.app, raise_server_exceptions=False)
+
+        assert client.get("/telemetry/traces/missing").status_code == 404
+        assert client.get("/telemetry/runs/missing/trace").status_code == 404
+        assert client.get("/telemetry/sessions/missing/trace").status_code == 404
+
+    def test_telemetry_trace_detail_endpoints_reject_mismatched_accessor_result(self):
+        class MismatchedTraceAgent:
+            name = "MismatchedTraceAgent"
+
+            def generate_session_id(self):
+                return "requested-session"
+
+            async def get_trace(self, **kwargs):
+                return {
+                    "trace_id": "wrong-trace",
+                    "run_id": "wrong-run",
+                    "session_id": "wrong-session",
+                    "status": "completed",
+                    "events": [],
+                    "spans": [],
+                }
+
+            async def get_latest_trace(self, **kwargs):
+                return {
+                    "trace_id": "wrong-trace",
+                    "run_id": "wrong-run",
+                    "session_id": "wrong-session",
+                    "status": "completed",
+                    "events": [],
+                    "spans": [],
+                }
+
+        server = OmniServe(
+            agent=MismatchedTraceAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+        client = TestClient(server.app, raise_server_exceptions=False)
+
+        assert client.get("/telemetry/traces/requested-trace").status_code == 404
+        assert client.get("/telemetry/runs/requested-run/trace").status_code == 404
+        assert client.get("/telemetry/sessions/requested-session/trace").status_code == 404
+
+    def test_telemetry_traces_endpoint_rejects_invalid_status(self, server_client):
+        resp = server_client.get("/telemetry/traces?status=bogus")
+
+        assert resp.status_code == 422
+        assert "Invalid trace status" in resp.json()["detail"]
+
+    def test_telemetry_events_endpoint_honors_limit(self, server_client):
+        resp = server_client.get(
+            "/telemetry/events?session_id=test-endpoint-session&limit=1"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filters"]["limit"] == 1
+        assert data["count"] == 1
+
+    def test_telemetry_events_stream_endpoint_is_registered_and_run_filtered(self):
+        class StreamTelemetryAgent:
+            name = "StreamTelemetryAgent"
+
+            def generate_session_id(self):
+                return "stream-session"
+
+            def get_telemetry_stream_cursor(self, *, session_id, run_id):
+                assert session_id == "stream-session"
+                assert run_id == "run-stream"
+                return None
+
+            def get_telemetry_events_after(self, *, cursor, session_id, run_id):
+                assert cursor is None
+                assert session_id == "stream-session"
+                assert run_id == "run-stream"
+                return [
+                    {
+                        "event_type": "final_answer",
+                        "metadata": {"session_id": session_id, "run_id": "run-stream"},
+                    },
+                    {
+                        "event_type": "final_answer",
+                        "metadata": {"session_id": session_id, "run_id": "run-drop"},
+                    },
+                ]
+
+            async def stream_telemetry_after(self, *, cursor, session_id, run_id):
+                if False:
+                    yield {}
+
+        server = OmniServe(
+            agent=StreamTelemetryAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+        client = TestClient(server.app, raise_server_exceptions=False)
+
+        resp = client.get(
+            "/telemetry/events/stream?session_id=stream-session&run_id=run-stream"
+        )
+
+        assert resp.status_code == 200
+        assert "run-stream" in resp.text
+        assert "run-drop" not in resp.text
+
     def test_events_list_endpoint_defensively_filters_run_id(self):
         class UnfilteredTelemetryAgent:
             name = "UnfilteredTelemetryAgent"
@@ -967,6 +1191,49 @@ class TestEndpoints:
         client = TestClient(server.app, raise_server_exceptions=False)
 
         resp = client.get("/events/unfiltered-session/list?run_id=run-keep")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["events"][0]["metadata"]["run_id"] == "run-keep"
+
+    def test_telemetry_events_endpoint_defensively_filters_run_id(self):
+        class UnfilteredTelemetryAgent:
+            name = "TelemetryUnfilteredAgent"
+
+            def generate_session_id(self):
+                return "telemetry-unfiltered-session"
+
+            def get_telemetry_events_after(self, *, cursor, session_id, run_id):
+                assert cursor is None
+                assert session_id == "telemetry-unfiltered-session"
+                assert run_id == "run-keep"
+                return [
+                    {
+                        "event_type": "tool_result",
+                        "metadata": {
+                            "session_id": session_id,
+                            "run_id": "run-keep",
+                        },
+                    },
+                    {
+                        "event_type": "tool_result",
+                        "metadata": {
+                            "session_id": session_id,
+                            "run_id": "run-drop",
+                        },
+                    },
+                ]
+
+        server = OmniServe(
+            agent=UnfilteredTelemetryAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+        client = TestClient(server.app, raise_server_exceptions=False)
+
+        resp = client.get(
+            "/telemetry/events?session_id=telemetry-unfiltered-session&run_id=run-keep"
+        )
 
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/test_real_application_production_boundaries.py
+++ b/tests/test_real_application_production_boundaries.py
@@ -257,6 +257,45 @@ def test_omniserve_real_application_sync_run_writes_workspace_and_trace(tmp_path
         assert trace_payload["summary"]["event_count"] >= 20
         assert [step["event_type"] for step in trace_payload["steps"]][-1] == "final_answer"
 
+        telemetry_events_response = client.get(
+            "/telemetry/events",
+            params={
+                "session_id": "served-support-session",
+                "run_id": payload["run_id"],
+                "event_type": "tool_result",
+            },
+        )
+        assert telemetry_events_response.status_code == 200
+        telemetry_events = telemetry_events_response.json()
+        assert telemetry_events["count"] >= 4
+        assert {
+            event["output"]["tool_name"]
+            for event in telemetry_events["events"]
+        }.issuperset(
+            {
+                "lookup_customer",
+                "recent_orders",
+                "support_policy_search",
+                "create_escalation",
+            }
+        )
+
+        exact_trace_response = client.get(f"/telemetry/traces/{payload['trace_id']}")
+        assert exact_trace_response.status_code == 200
+        exact_trace = exact_trace_response.json()
+        assert exact_trace["summary"]["trace_id"] == payload["trace_id"]
+        assert exact_trace["trace"]["run_id"] == payload["run_id"]
+
+        run_trace_response = client.get(f"/telemetry/runs/{payload['run_id']}/trace")
+        assert run_trace_response.status_code == 200
+        assert run_trace_response.json()["summary"]["trace_id"] == payload["trace_id"]
+
+        session_trace_response = client.get(
+            "/telemetry/sessions/served-support-session/trace"
+        )
+        assert session_trace_response.status_code == 200
+        assert session_trace_response.json()["summary"]["run_id"] == payload["run_id"]
+
     ticket = workspace_dir / "files" / "tickets" / "tck-1042.md"
     assert ticket.read_text(encoding="utf-8").startswith("# tck-1042")
 


### PR DESCRIPTION
## Summary
- add production-facing /telemetry endpoints for filtered events, exact trace lookup, run trace lookup, latest session trace, trace listing, and SSE stream replay/follow
- enforce selector integrity for trace detail routes, return 404 for missing/mismatched traces, validate trace status filters, and bound list responses with limits
- update OmniServe/observability docs and cookbook tables to describe the new telemetry API while keeping the older /events session aliases documented

## Verification
- uv run ruff check src/omnicoreagent/serve/routes/telemetry.py src/omnicoreagent/serve/routes/__init__.py src/omnicoreagent/serve/models.py tests/test_omniserve_full.py tests/test_real_application_production_boundaries.py
- uv run pytest tests/test_omniserve_full.py tests/test_real_application_production_boundaries.py tests/test_docs_claims.py -q
- uv run pytest tests/test_omniserve_sse.py tests/test_runtime_telemetry_wiring.py tests/test_telemetry_foundation.py tests/test_telemetry_exporters.py tests/test_telemetry_otlp_integration.py tests/test_telemetry_cookbook.py -q
- uv run pytest -q