### PR TITLE
Harden OmniServe readiness and protected route limits

### DIFF
--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -138,6 +138,10 @@ limiting until you opt in.
 | GET | `/docs` | No | Swagger UI |
 | GET | `/redoc` | No | ReDoc UI |
 
+`/ready` becomes true after server startup finishes, the agent is initialized,
+and configured MCP servers are connected. Local-only agents with no MCP servers
+do not need an MCP client for readiness.
+
 ### Background Task Endpoints
 
 These routes are mounted when background execution is enabled. It is enabled by

--- a/docs/how-to-guides/omniserve.mdx
+++ b/docs/how-to-guides/omniserve.mdx
@@ -217,6 +217,11 @@ omniserve quickstart --provider anthropic --model claude-3-5-sonnet-20241022
 | `GET` | `/docs` | No | Swagger UI |
 | `GET` | `/redoc` | No | ReDoc UI |
 
+`/ready` returns `ready: true` only after the FastAPI lifespan has completed
+startup, the served agent is initialized, and any configured MCP servers are
+connected. Agents without MCP servers do not need an MCP client to pass
+readiness.
+
 ### Background Task Endpoints
 
 These routes are mounted when background execution is enabled. It is enabled by

--- a/engineering/architecture/omniserve.md
+++ b/engineering/architecture/omniserve.md
@@ -118,8 +118,10 @@ Lifespan errors should fail startup or shutdown clearly. They should not leave a
 half-started server that reports readiness while core dependencies failed.
 
 Readiness is intentionally cheap. `/ready` combines the startup-complete flag,
-agent initialization state, and MCP client presence. It never performs model
-calls, tool calls, background work, or network probes.
+agent initialization state, and configured MCP connection state. Agents without
+configured MCP servers do not require an MCP client to be ready. Agents with
+configured MCP servers must have connected MCP sessions. Readiness never
+performs model calls, tool calls, background work, or network probes.
 
 ## HTTP API Boundary
 
@@ -189,7 +191,8 @@ Middleware must be predictable and testable:
 
 - public auth bypass paths are explicit.
 - protected routes require bearer auth when auth is enabled.
-- rate limiting applies to protected routes when enabled.
+- rate limiting applies to protected routes when enabled, including protected
+  requests rejected by auth.
 - request timeout is configured by `request_timeout`.
 - CORS behavior follows `OmniServeConfig`.
 - request logging adds process-time headers when enabled.

--- a/engineering/specifications/omniserve.md
+++ b/engineering/specifications/omniserve.md
@@ -240,7 +240,8 @@ Rate limiting is in-process per FastAPI app instance.
 When enabled:
 
 - public auth-bypass paths are exempt.
-- protected routes are keyed by client IP.
+- protected routes are keyed by client IP, including requests that fail bearer
+  auth.
 - `X-Forwarded-For` is used when present.
 - `X-Real-IP` is used when present and `X-Forwarded-For` is absent.
 - otherwise the ASGI client host is used.
@@ -369,9 +370,10 @@ Startup failures must not report readiness as healthy.
 - `mcp_connected`
 
 `ready` is true only when lifespan startup completed, the agent is initialized,
-and an exposed MCP client is present. If startup has not completed, startup
-failed, the agent reports `_initialized=False`, or an exposed `mcp_client` is
-`None`, readiness is false.
+and configured MCP servers are connected. Agents without configured MCP servers
+do not require an MCP client to become ready. If startup has not completed,
+startup failed, the agent reports `_initialized=False`, or any configured MCP
+server is missing a connected session, readiness is false.
 
 Readiness must remain cheap. It should not execute model calls, tool calls, or
 background work.

--- a/src/omnicoreagent/serve/middleware/__init__.py
+++ b/src/omnicoreagent/serve/middleware/__init__.py
@@ -15,7 +15,7 @@ def setup_all_middleware(app: FastAPI, config: OmniServeConfig) -> None:
     """Set up middleware in execution order."""
     add_error_handling_middleware(app)
     add_timeout_middleware(app, config)
+    add_auth_middleware(app, config)
     add_rate_limit_middleware(app, config)
     add_request_logging_middleware(app, config)
-    add_auth_middleware(app, config)
     add_cors_middleware(app, config)

--- a/src/omnicoreagent/serve/models.py
+++ b/src/omnicoreagent/serve/models.py
@@ -132,7 +132,13 @@ class ReadinessResponse(BaseModel):
     ready: bool = Field(..., description="Whether the agent is ready")
     agent_name: str = Field(..., description="Name of the agent")
     initialized: bool = Field(..., description="Whether the agent is initialized")
-    mcp_connected: bool = Field(..., description="Whether MCP servers are connected")
+    mcp_connected: bool = Field(
+        ...,
+        description=(
+            "Whether MCP readiness is satisfied. True when no MCP servers are "
+            "configured, or when every configured MCP server has a connected session."
+        ),
+    )
 
 
 class ToolInfo(BaseModel):

--- a/src/omnicoreagent/serve/readiness.py
+++ b/src/omnicoreagent/serve/readiness.py
@@ -45,6 +45,56 @@ def _agent_initialized(agent: AgentType) -> bool:
 
 
 def _mcp_connected(agent: AgentType) -> bool:
-    if not hasattr(agent, "mcp_client"):
+    configured_servers = _configured_mcp_server_names(agent)
+    if not configured_servers:
         return True
-    return getattr(agent, "mcp_client") is not None
+
+    mcp_client = getattr(agent, "mcp_client", None)
+    if mcp_client is None:
+        return False
+
+    sessions = getattr(mcp_client, "sessions", None)
+    if not isinstance(sessions, dict):
+        return False
+
+    requested_to_actual = getattr(mcp_client, "added_servers_names", {}) or {}
+    for server_name in configured_servers:
+        actual_name = requested_to_actual.get(server_name, server_name)
+        session = sessions.get(actual_name)
+        if not _session_connected(session):
+            return False
+    return True
+
+
+def _configured_mcp_server_names(agent: AgentType) -> list[str]:
+    mcp_tools = getattr(agent, "mcp_tools", None)
+    if not mcp_tools:
+        return []
+    if isinstance(mcp_tools, dict):
+        if mcp_tools.get("name"):
+            return [str(mcp_tools["name"])]
+        return [str(name) for name in mcp_tools]
+
+    names: list[str] = []
+    for tool in mcp_tools:
+        if isinstance(tool, dict):
+            name = tool.get("name")
+        else:
+            name = getattr(tool, "name", None)
+        if name:
+            names.append(str(name))
+    if names:
+        return names
+
+    try:
+        return [str(index) for index in range(len(mcp_tools))]
+    except TypeError:
+        return [str(mcp_tools)]
+
+
+def _session_connected(session: Any) -> bool:
+    if session is None:
+        return False
+    if isinstance(session, dict):
+        return bool(session.get("connected", False))
+    return bool(getattr(session, "connected", False))

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import asyncio
 from importlib.metadata import version
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
 from fastapi.testclient import TestClient
 from click.testing import CliRunner
@@ -556,6 +557,36 @@ class TestMiddleware:
         )
         assert resp.status_code == 200
 
+    def test_auth_protects_telemetry_and_background_routes_with_api_prefix(self):
+        class LightweightAgent:
+            name = "BoundaryAgent"
+
+            def generate_session_id(self):
+                return "boundary-session"
+
+            def get_telemetry_events_after(self, **kwargs):
+                return []
+
+        config = OmniServeConfig(
+            api_prefix="/api",
+            auth_enabled=True,
+            auth_token="secret123",
+            background_start_worker=False,
+        )
+        server = OmniServe(agent=LightweightAgent(), config=config)
+        client = TestClient(server.app)
+
+        assert client.get("/api/ready").status_code == 200
+        assert client.get("/api/telemetry/events").status_code == 401
+        assert client.get("/api/background/status").status_code == 401
+
+        telemetry = client.get(
+            "/api/telemetry/events",
+            headers={"Authorization": "Bearer secret123"},
+        )
+        assert telemetry.status_code == 200
+        assert telemetry.json()["events"] == []
+
     def test_cors_middleware(self, mock_agent):
         config = OmniServeConfig(
             cors_enabled=True, cors_origins=["https://example.com"]
@@ -596,6 +627,60 @@ class TestMiddleware:
         assert allowed.headers["X-RateLimit-Remaining"] == "0"
         assert denied.status_code == 429
         assert denied.headers["Retry-After"]
+        assert denied.json()["error"] == "TooManyRequests"
+
+    def test_rate_limit_counts_unauthenticated_protected_requests(self, mock_agent):
+        config = OmniServeConfig(
+            auth_enabled=True,
+            auth_token="secret123",
+            rate_limit_enabled=True,
+            rate_limit_requests=2,
+            rate_limit_window=60,
+        )
+        server = OmniServe(agent=mock_agent, config=config)
+        client = TestClient(server.app)
+
+        first = client.post("/run/sync", json={"query": "first"})
+        second = client.post("/run/sync", json={"query": "second"})
+        third = client.post("/run/sync", json={"query": "third"})
+
+        assert first.status_code == 401
+        assert first.headers["X-RateLimit-Limit"] == "2"
+        assert first.headers["X-RateLimit-Remaining"] == "1"
+        assert second.status_code == 401
+        assert second.headers["X-RateLimit-Remaining"] == "0"
+        assert third.status_code == 429
+        assert third.json()["error"] == "TooManyRequests"
+
+    def test_rate_limit_applies_to_telemetry_and_exempts_readiness(self):
+        class LightweightAgent:
+            name = "RateLimitedTelemetryAgent"
+
+            def generate_session_id(self):
+                return "rate-limit-session"
+
+            def get_telemetry_events_after(self, **kwargs):
+                return []
+
+        config = OmniServeConfig(
+            rate_limit_enabled=True,
+            rate_limit_requests=1,
+            rate_limit_window=60,
+            background_enabled=False,
+        )
+        server = OmniServe(agent=LightweightAgent(), config=config)
+        client = TestClient(server.app)
+
+        readiness = client.get("/ready")
+        assert readiness.status_code == 200
+        assert "X-RateLimit-Limit" not in readiness.headers
+
+        allowed = client.get("/telemetry/events")
+        denied = client.get("/telemetry/events")
+
+        assert allowed.status_code == 200
+        assert allowed.headers["X-RateLimit-Limit"] == "1"
+        assert denied.status_code == 429
         assert denied.json()["error"] == "TooManyRequests"
 
 
@@ -713,6 +798,35 @@ class TestEndpoints:
             "mcp_connected": True,
         }
 
+    def test_readiness_does_not_require_mcp_when_no_servers_are_configured(self):
+        class LocalOnlyAgent:
+            name = "LocalOnlyAgent"
+            mcp_tools = []
+            mcp_client = None
+            _initialized = True
+
+            def generate_session_id(self):
+                return "local-only-session"
+
+            async def connect_mcp_servers(self):
+                return None
+
+        server = OmniServe(
+            agent=LocalOnlyAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ready": True,
+            "agent_name": "LocalOnlyAgent",
+            "initialized": True,
+            "mcp_connected": True,
+        }
+
     def test_readiness_reflects_uninitialized_agent(self):
         agent = MagicMock(spec=OmniCoreAgent)
         agent.name = "UninitializedAgent"
@@ -735,10 +849,140 @@ class TestEndpoints:
         agent = MagicMock(spec=OmniCoreAgent)
         agent.name = "MCPReadinessAgent"
         agent.generate_session_id.return_value = "mcp-readiness-session"
+        agent.mcp_tools = [{"name": "remote_tools", "transport_type": "stdio"}]
         agent.mcp_client = None
 
         server = OmniServe(
             agent=agent,
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["ready"] is False
+        assert resp.json()["mcp_connected"] is False
+
+    @pytest.mark.parametrize(
+        ("sessions", "expected_ready"),
+        [
+            ({"server_one": {"connected": True}, "server_two": {"connected": True}}, True),
+            (
+                {
+                    "server_one": {"connected": True},
+                    "server_two": {"connected": False},
+                },
+                False,
+            ),
+            ({"server_one": {"connected": True}}, False),
+            (
+                {
+                    "server_one": {"connected": True},
+                    "unconfigured_server": {"connected": True},
+                },
+                False,
+            ),
+        ],
+    )
+    def test_readiness_checks_each_configured_mcp_server_session(
+        self, sessions, expected_ready
+    ):
+        class MCPAgent:
+            name = "MCPAgent"
+            _initialized = True
+            mcp_tools = [
+                {"name": "server_one", "transport_type": "stdio"},
+                {"name": "server_two", "transport_type": "stdio"},
+            ]
+            mcp_client = SimpleNamespace(sessions=sessions)
+
+            def generate_session_id(self):
+                return "mcp-session-state"
+
+            async def connect_mcp_servers(self):
+                return None
+
+        server = OmniServe(
+            agent=MCPAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["ready"] is expected_ready
+        assert resp.json()["mcp_connected"] is expected_ready
+
+    def test_readiness_uses_mcp_requested_to_actual_server_mapping(self):
+        class MCPAgent:
+            name = "MappedMCPAgent"
+            _initialized = True
+            mcp_tools = [{"name": "filesystem", "transport_type": "stdio"}]
+            mcp_client = SimpleNamespace(
+                added_servers_names={"filesystem": "FileSystem MCP"},
+                sessions={"FileSystem MCP": {"connected": True}},
+            )
+
+            def generate_session_id(self):
+                return "mapped-mcp-session"
+
+            async def connect_mcp_servers(self):
+                return None
+
+        server = OmniServe(
+            agent=MCPAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["ready"] is True
+        assert resp.json()["mcp_connected"] is True
+
+    def test_readiness_supports_single_dict_mcp_config(self):
+        class MCPAgent:
+            name = "DictMCPAgent"
+            _initialized = True
+            mcp_tools = {"name": "filesystem", "transport_type": "stdio"}
+            mcp_client = SimpleNamespace(sessions={"filesystem": {"connected": True}})
+
+            def generate_session_id(self):
+                return "dict-mcp-session"
+
+            async def connect_mcp_servers(self):
+                return None
+
+        server = OmniServe(
+            agent=MCPAgent(),
+            config=OmniServeConfig(background_enabled=False),
+        )
+
+        with TestClient(server.app) as client:
+            resp = client.get("/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["ready"] is True
+        assert resp.json()["mcp_connected"] is True
+
+    def test_readiness_requires_sessions_for_configured_mcp_servers(self):
+        class MCPAgent:
+            name = "NoSessionMCPAgent"
+            _initialized = True
+            mcp_tools = [{"name": "filesystem", "transport_type": "stdio"}]
+            mcp_client = SimpleNamespace()
+
+            def generate_session_id(self):
+                return "no-session-mcp"
+
+            async def connect_mcp_servers(self):
+                return None
+
+        server = OmniServe(
+            agent=MCPAgent(),
             config=OmniServeConfig(background_enabled=False),
         )
 


### PR DESCRIPTION
## Summary
- tighten OmniServe readiness so local-only agents pass without MCP while configured MCP servers must have connected sessions
- validate MCP readiness across list, dict, requested-to-actual server mapping, missing-session, disconnected-session, and wrong-session cases
- reorder middleware so rate limiting counts unauthenticated protected requests before auth returns 401
- update public docs and internal architecture/spec wording for readiness and protected-route rate limiting

## Verification
- uv run ruff check src/omnicoreagent/serve tests/test_omniserve_full.py
- uv run pytest tests/test_omniserve_full.py tests/test_omniserve_background.py tests/test_docs_claims.py -q
- uv run pytest -q
- final suite: 856 passed, 10 skipped

## Review
- spawned reviewer, QA, and docs/spec agents twice
- first pass found MCP readiness false-positive issues and auth/rate-limit ordering gap
- fixed those issues and final pass reported no issues
