### PR TITLE
Improve docs onboarding and AI assistant experience

### DIFF
--- a/.mintlify/Assistant.md
+++ b/.mintlify/Assistant.md
@@ -1,0 +1,63 @@
+You are the documentation assistant for OmniCoreAgent.
+
+## Product Identity
+
+OmniCoreAgent is an open production agent harness for Python application
+builders. Use "agent harness" as the primary identity. Do not describe it only
+as a generic agent framework.
+
+The harness wraps one or more models with the runtime pieces needed for
+production agent applications: model loop, prompt contract, local tools, MCP
+tools, parallel tool batches, structured observations, memory, context
+management, workspace files, guardrails, telemetry, subagents, background tasks,
+and OmniServe REST/SSE serving.
+
+## Answering Rules
+
+- Answer from the official OmniCoreAgent docs.
+- Link relevant docs pages when they help the user continue.
+- If the docs do not contain enough information, say what is missing and point
+  to the closest relevant page.
+- Be concise, direct, and action-oriented.
+- Prefer runnable Python or shell examples when the user asks how to do
+  something.
+- Do not invent configuration fields, environment variables, routes, or
+  features.
+
+## Required Terminology
+
+- Use `LLM_API_KEY` as the public model API key environment variable.
+- Do not tell users to configure `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+  `GEMINI_API_KEY`, or `GROQ_API_KEY` for OmniCoreAgent examples.
+- "Memory" means conversation/session history.
+- "Workspace" means the file/state surface for notes, artifacts, offloads,
+  scratchpads, and subagent output.
+- "Task store" means background task, run, attempt, lease, retry, and schedule
+  state.
+- "Local tools" are application Python functions registered with
+  `ToolRegistry`.
+- "MCP tools" are tools loaded from external MCP servers.
+- "Telemetry" means runtime events, traces, streams, and optional exporters.
+- "OmniServe" means the REST/SSE serving boundary.
+
+## Common Guidance
+
+For a first agent, tell users to:
+
+1. install `omnicoreagent`
+2. set `LLM_API_KEY`
+3. create `OmniCoreAgent`
+4. call `await agent.run(...)`
+5. print `result["response"]`
+6. call `await agent.cleanup()`
+
+For production configuration questions, distinguish:
+
+- `MemoryRouter` from background task store
+- workspace storage from memory storage
+- telemetry events from trace exporters
+- local tools from MCP tools
+- OmniServe from the agent reasoning loop
+
+For deployment questions, point users to OmniServe, configuration, background
+agents, telemetry, and production cookbook pages.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
   <a href="#install-only-what-you-need">Install</a> -
   <a href="./cookbook">Cookbook</a> -
   <a href="#features">Features</a> -
-  <a href="https://docs-omnicoreagent.omnirexfloralabs.com/docs">Docs</a>
+  <a href="https://docs-omnicoreagent.omnirexfloralabs.com/docs">Docs</a> -
+  <a href="https://docs-omnicoreagent.omnirexfloralabs.com/docs/getting-started/use-docs-with-ai-tools">Ask AI</a>
 </p>
 
 ---
@@ -71,6 +72,13 @@ OmniCoreAgent keeps that boundary explicit:
 
 Start with the core harness. Turn on heavier production pieces only when the
 workload needs them.
+
+If you prefer guided docs, start with the
+[Quick Start](https://docs-omnicoreagent.omnirexfloralabs.com/docs/getting-started/quickstart).
+If you use AI coding tools, use the
+[AI tools guide](https://docs-omnicoreagent.omnirexfloralabs.com/docs/getting-started/use-docs-with-ai-tools)
+for Ask AI, `/llms.txt`, hosted docs MCP, Cursor, VS Code, ChatGPT, Claude, and
+Perplexity.
 
 ---
 
@@ -126,6 +134,8 @@ small.
 | Build a production-shaped app harness | [Real applications cookbook](./cookbook/real_applications) |
 | Build multi-step workflows | [Workflows cookbook](./cookbook/workflows) |
 | Serve an agent over HTTP/SSE | [OmniServe cookbook](./cookbook/omniserve) |
+| Use the docs inside AI tools | [AI tools guide](https://docs-omnicoreagent.omnirexfloralabs.com/docs/getting-started/use-docs-with-ai-tools) |
+| Debug setup or configuration | [Configuration guide](https://docs-omnicoreagent.omnirexfloralabs.com/docs/how-to-guides/configuration) |
 | Understand the runtime internals | [Implementation Map](#implementation-map) |
 
 ---

--- a/cookbook/CONTRIBUTING.mdx
+++ b/cookbook/CONTRIBUTING.mdx
@@ -1,3 +1,8 @@
+---
+title: Contributing to the Cookbook
+description: 'Recipe structure and quality checklist for contributing OmniCoreAgent cookbook examples'
+---
+
 # Contributing to the Cookbook
 
 Thank you for contributing to the OmniCoreAgent Cookbook! This guide explains how to add new recipes.

--- a/cookbook/README.mdx
+++ b/cookbook/README.mdx
@@ -1,6 +1,12 @@
-# 🍳 OmniCoreAgent Cookbook
+---
+title: Cookbook
+description: 'Runnable OmniCoreAgent examples for first agents, tools, memory, workspace files, background tasks, OmniServe, and real applications'
+---
 
-> **Copy, paste, run.** Build agents that actually work.
+# OmniCoreAgent Cookbook
+
+Copy, paste, run. These examples show how to build with OmniCoreAgent from the
+first local agent through production-shaped application harnesses.
 
 ## 🚀 Where to Start
 

--- a/cookbook/advanced_agent/README.mdx
+++ b/cookbook/advanced_agent/README.mdx
@@ -1,3 +1,8 @@
+---
+title: Advanced Agent Examples
+description: 'Larger OmniCoreAgent application examples for shopping, travel, customer support, and due diligence workflows'
+---
+
 # Advanced Agent Examples
 
 > Real-world applications that demonstrate the full power of OmniCoreAgent.

--- a/cookbook/advanced_agent/ai_due_diligence_agent/README.mdx
+++ b/cookbook/advanced_agent/ai_due_diligence_agent/README.mdx
@@ -1,3 +1,8 @@
+---
+title: AI Due Diligence Agent
+description: 'Multi-agent OmniCoreAgent due diligence workflow with local demo mode and optional Tavily MCP live research'
+---
+
 # AI Due Diligence Agent
 
 A multi-agent investment-analysis workflow built with OmniCoreAgent. It turns a company name into a due-diligence package using specialized agents for research, market analysis, financial modeling, risk review, memo writing, report generation, and infographic generation.

--- a/cookbook/background_agents/README.mdx
+++ b/cookbook/background_agents/README.mdx
@@ -1,3 +1,8 @@
+---
+title: Background Agents Cookbook
+description: 'Runnable examples for durable scheduled and manual background agent tasks, run state, events, retries, and workspace output'
+---
+
 # Background Agents: Durable Agent Tasks
 
 Background Agents run OmniCoreAgent work outside the foreground request path.

--- a/cookbook/getting_started/README.mdx
+++ b/cookbook/getting_started/README.mdx
@@ -1,3 +1,8 @@
+---
+title: Getting Started Cookbook
+description: 'Progressive runnable examples for your first OmniCoreAgent, local tools, MCP tools, memory, events, context management, guardrails, and OmniServe'
+---
+
 # Getting Started with OmniCoreAgent
 
 Welcome to the **OmniCoreAgent** learning path. This guide takes you from writing your first line of code to building production-ready, autonomous agents with persistent memory, context management, and guardrails.

--- a/cookbook/omniserve/README.mdx
+++ b/cookbook/omniserve/README.mdx
@@ -1,3 +1,8 @@
+---
+title: OmniServe Cookbook
+description: 'Runnable examples for serving OmniCoreAgent over REST and SSE with CLI and Python API patterns'
+---
+
 # OmniServe Cookbook
 
 Production-ready API server examples for OmniCoreAgent.

--- a/cookbook/production/README.mdx
+++ b/cookbook/production/README.mdx
@@ -1,3 +1,8 @@
+---
+title: Production Cookbook
+description: 'Production-oriented OmniCoreAgent examples for metrics, telemetry, guardrails, and operational configuration'
+---
+
 # Production
 
 > Deploy OmniCoreAgent with confidence. Runtime usage metrics and guardrails.

--- a/cookbook/real_applications/README.mdx
+++ b/cookbook/real_applications/README.mdx
@@ -1,16 +1,21 @@
+---
+title: Real Application Harness Examples
+description: 'Production-shaped OmniCoreAgent examples for research, support operations, personal operations, workspace code review, and background tasks'
+---
+
 # Real Application Harness Examples
 
 These examples show OmniCoreAgent as an application-facing agent harness, not a toy loop. Each app combines domain behavior with the built-in runtime pieces it needs: local tools, workspace files, tool offloading, guardrails, telemetry identifiers, and file commands.
 
 ## Examples
 
-| Example | What it demonstrates |
-|---------|----------------------|
-| [Research due diligence](./research_due_diligence_agent.py) | Parallel research tools, context management, large evidence offload, artifact readback, workspace report output, telemetry identifiers |
-| [Support operations](./support_operations_agent.py) | Customer/order tools, support knowledge retrieval, guardrails, workspace ticket notes, telemetry |
-| [Personal operations assistant](./personal_operations_assistant.py) | Calendar/task/preferences tools, selectable memory backend, private workspace brief, guardrails, telemetry identifiers |
-| [Workspace code review](./workspace_code_review_agent.py) | Built-in workspace command tools for file discovery, grep-style search, reading, editing, and writing review output |
-| [Support background task](../background_agents/real_application_background_task.py) | The support operations app shape running through durable task state, attempts, lifecycle events, and workspace output |
+| Example | Run command | What it demonstrates |
+|---------|-------------|----------------------|
+| [Research due diligence](./research_due_diligence_agent.py) | `uv run python cookbook/real_applications/research_due_diligence_agent.py` | Parallel research tools, context management, large evidence offload, artifact readback, workspace report output, telemetry identifiers |
+| [Support operations](./support_operations_agent.py) | `uv run python cookbook/real_applications/support_operations_agent.py` | Customer/order tools, support knowledge retrieval, guardrails, workspace ticket notes, telemetry |
+| [Personal operations assistant](./personal_operations_assistant.py) | `uv run python cookbook/real_applications/personal_operations_assistant.py` | Calendar/task/preferences tools, selectable memory backend, private workspace brief, guardrails, telemetry identifiers |
+| [Workspace code review](./workspace_code_review_agent.py) | `uv run python cookbook/real_applications/workspace_code_review_agent.py` | Built-in workspace command tools for file discovery, grep-style search, reading, editing, and writing review output |
+| [Support background task](../background_agents/real_application_background_task.py) | `uv run python cookbook/background_agents/real_application_background_task.py` | The support operations app shape running through durable task state, attempts, lifecycle events, and workspace output |
 
 ## Run an Example
 
@@ -18,6 +23,10 @@ These examples show OmniCoreAgent as an application-facing agent harness, not a 
 export LLM_API_KEY=your_key
 uv run python cookbook/real_applications/research_due_diligence_agent.py
 ```
+
+Expected output includes the agent response plus runtime identifiers such as
+`trace_id` and `run_id`. Workspace examples also print or create files under the
+configured workspace.
 
 The examples default to the provider/model from `cookbook/shared.py`. Override them with:
 

--- a/cookbook/workflows/README.mdx
+++ b/cookbook/workflows/README.mdx
@@ -1,3 +1,8 @@
+---
+title: Workflow Agents Cookbook
+description: 'Sequential, parallel, and router workflow examples for coordinating multiple OmniCoreAgent instances'
+---
+
 # Workflow Agents
 
 > Orchestrate multiple agents for complex tasks using Sequential, Parallel, and Router patterns.

--- a/docs.json
+++ b/docs.json
@@ -35,7 +35,8 @@
                         "pages": [
                             "docs/index",
                             "docs/getting-started/installation",
-                            "docs/getting-started/quickstart"
+                            "docs/getting-started/quickstart",
+                            "docs/getting-started/use-docs-with-ai-tools"
                         ]
                     },
                     {
@@ -72,6 +73,26 @@
                         "group": "Changelog",
                         "pages": [
                             "docs/changelog"
+                        ]
+                    }
+                ]
+            },
+            {
+                "dropdown": "Cookbook",
+                "icon": "book-open",
+                "description": "Runnable OmniCoreAgent examples by use case",
+                "groups": [
+                    {
+                        "group": "Examples",
+                        "pages": [
+                            "cookbook/README",
+                            "cookbook/getting_started/README",
+                            "cookbook/real_applications/README",
+                            "cookbook/omniserve/README",
+                            "cookbook/background_agents/README",
+                            "cookbook/workflows/README",
+                            "cookbook/production/README",
+                            "cookbook/advanced_agent/README"
                         ]
                     }
                 ]
@@ -137,5 +158,19 @@
         "telemetry": {
             "enabled": true
         }
+    },
+    "contextual": {
+        "options": [
+            "assistant",
+            "copy",
+            "view",
+            "chatgpt",
+            "claude",
+            "perplexity",
+            "mcp",
+            "cursor",
+            "vscode"
+        ],
+        "display": "header"
     }
 }

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,3 +1,8 @@
+---
+title: Documentation Development
+description: 'Local development notes for previewing and validating the OmniCoreAgent Mintlify documentation site'
+---
+
 # OmniCoreAgent Documentation
 
 ## 🚀 Quick Start

--- a/docs/assets/logo_light.svg
+++ b/docs/assets/logo_light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="OmniCoreAgent">
+  <rect width="64" height="64" rx="14" fill="#0D9373"/>
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#FFFFFF" stroke-width="5"/>
+  <circle cx="32" cy="32" r="8" fill="#FFFFFF"/>
+  <path d="M32 12v10M32 42v10M12 32h10M42 32h10" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/docs/core-concepts/local-tools.mdx
+++ b/docs/core-concepts/local-tools.mdx
@@ -6,28 +6,39 @@ icon: 'wrench'
 
 # Local Tools System
 
-Register any Python function as an AI tool using the `ToolRegistry`:
+Register any Python function as an AI tool using the `ToolRegistry`.
 
 ```python
-from omnicoreagent import ToolRegistry
+import asyncio
+from omnicoreagent import OmniCoreAgent, ToolRegistry
 
 tools = ToolRegistry()
 
 @tools.register_tool("get_weather")
-def get_weather(city: str) -> str:
+def get_weather(city: str) -> dict:
     """Get weather for a city."""
-    return f"Weather in {city}: Sunny, 25°C"
+    return {"city": city, "temperature": "25C", "condition": "Sunny"}
 
 @tools.register_tool("calculate_area")
-def calculate_area(length: float, width: float) -> str:
+def calculate_area(length: float, width: float) -> dict:
     """Calculate rectangle area."""
-    return f"Area: {length * width} square units"
+    return {"area": length * width, "unit": "square units"}
 
-agent = OmniCoreAgent(
-    name="tool_agent",
-    local_tools=tools,  # Your custom tools!
-    ...
-)
+async def main():
+    agent = OmniCoreAgent(
+        name="tool_agent",
+        system_instruction="Use local tools when they help answer the user.",
+        model_config={"provider": "openai", "model": "gpt-4o"},
+        local_tools=tools,
+    )
+
+    result = await agent.run(
+        "What is the weather in Lagos, and what is the area of a 12 by 8 room?"
+    )
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
 ```
 
 ---
@@ -119,8 +130,9 @@ def calculate_total(price: float, quantity: int) -> float:
 
 agent = OmniCoreAgent(
     name="local_tools_agent",
+    system_instruction="Use local tools when they help answer the user.",
+    model_config={"provider": "openai", "model": "gpt-4o"},
     local_tools=tools,
-    ...
 )
 ```
 

--- a/docs/core-concepts/memory.mdx
+++ b/docs/core-concepts/memory.mdx
@@ -13,7 +13,29 @@ MongoDB, or SQL database storage when the application needs persistence.
 
 ## Quick Start
 
-Install the backend extra before using a production store:
+The default `in_memory` backend is enough for local development and tests:
+
+```python
+import asyncio
+from omnicoreagent import OmniCoreAgent, MemoryRouter
+
+async def main():
+    agent = OmniCoreAgent(
+        name="memory_agent",
+        system_instruction="Remember useful details inside the active session.",
+        model_config={"provider": "openai", "model": "gpt-4o"},
+        memory_router=MemoryRouter("in_memory"),
+    )
+
+    await agent.run("My project is called Atlas.", session_id="user_123")
+    result = await agent.run("What is my project called?", session_id="user_123")
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
+```
+
+Install the backend extra before using a durable store:
 
 ```bash
 pip install "omnicoreagent[redis]"
@@ -27,6 +49,7 @@ from omnicoreagent import OmniCoreAgent, MemoryRouter
 # Start with Redis
 agent = OmniCoreAgent(
     name="my_agent",
+    system_instruction="Remember useful details inside the active session.",
     memory_router=MemoryRouter("redis"),
     model_config={"provider": "openai", "model": "gpt-4o"}
 )
@@ -46,7 +69,7 @@ await agent.switch_memory_store("redis")       # Back to Redis
 |---------|----------|---------------------|
 | `in_memory` | Fast development | — |
 | `redis` | Production persistence | `REDIS_URL` |
-| `database` | SQLAlchemy database storage | `DATABASE_URL` |
+| `sql` | SQLAlchemy database storage | `DATABASE_URL` |
 | `mongodb` | Document storage | `MONGODB_URI` |
 
 ---

--- a/docs/core-concepts/workspace-files.mdx
+++ b/docs/core-concepts/workspace-files.mdx
@@ -32,6 +32,45 @@ There is no separate workspace-files backend: choose the workspace backend once,
 Workspace files default to local disk. Choose S3 or R2 only when the whole workspace should live in cloud storage.
 
 ```bash
+export OMNICOREAGENT_WORKSPACE_BACKEND=local
+export OMNICOREAGENT_WORKSPACE_DIR=./workspace
+```
+
+```python
+import asyncio
+from omnicoreagent import OmniCoreAgent
+
+async def main():
+    agent = OmniCoreAgent(
+        name="workspace_agent",
+        system_instruction=(
+            "Use workspace files for notes, progress, and final artifacts."
+        ),
+        model_config={"provider": "openai", "model": "gpt-4o"},
+        agent_config={"enable_workspace_files": True},
+    )
+
+    result = await agent.run(
+        "Create a project note at notes/plan.md with three checklist items, "
+        "then read it back."
+    )
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
+```
+
+With the local backend, workspace command tools write under:
+
+```text
+./workspace/files/
+```
+
+For example, the prompt above creates `./workspace/files/notes/plan.md`.
+
+Cloud workspace storage uses the S3/R2 extra:
+
+```bash
 pip install "omnicoreagent[s3]"
 ```
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -7,7 +7,7 @@ icon: 'bolt'
 # Quick Start
 
 This guide creates the smallest useful OmniCoreAgent: one model, one harness
-runtime, and one task.
+runtime, one task, one local tool, and one stable session.
 
 The core install stays light. Redis, PostgreSQL, MongoDB, S3/R2, OmniServe, and
 background scheduling install as extras when the agent needs them.
@@ -74,6 +74,7 @@ background scheduling install as extras when the agent needs them.
 Local tools are normal Python functions registered through `ToolRegistry`.
 
 ```python
+import asyncio
 from omnicoreagent import OmniCoreAgent, ToolRegistry
 
 tools = ToolRegistry()
@@ -83,40 +84,111 @@ def get_weather(city: str) -> dict:
     """Get current weather for a city."""
     return {"city": city, "temp": "22C", "condition": "Sunny"}
 
-agent = OmniCoreAgent(
-    name="weather_agent",
-    system_instruction="Use tools when they help answer the user.",
-    model_config={"provider": "openai", "model": "gpt-4o"},
-    local_tools=tools,
-)
+async def main():
+    agent = OmniCoreAgent(
+        name="weather_agent",
+        system_instruction="Use tools when they help answer the user.",
+        model_config={"provider": "openai", "model": "gpt-4o"},
+        local_tools=tools,
+    )
 
-result = await agent.run("What's the weather in Tokyo?")
+    result = await agent.run("What's the weather in Tokyo?")
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
 ```
 
 ---
 
-## Add MCP Tools
+## Keep Continuity With Session IDs
+
+Agents keep continuity when you provide a stable `session_id`:
+
+```python
+await agent.run("My name is Abiola.", session_id="user_123")
+result = await agent.run("What is my name?", session_id="user_123")
+print(result["response"])
+```
+
+The default memory backend is in-memory and works for local development. Use
+Redis, MongoDB, or SQL database storage when conversation history must survive
+process restarts.
+
+---
+
+## Common First-Run Errors
+
+<AccordionGroup>
+  <Accordion title="LLM_API_KEY not found">
+    Export the model key before running your script:
+
+    ```bash
+    export LLM_API_KEY=your_api_key_here
+    ```
+
+    OmniCoreAgent examples use `LLM_API_KEY` as the single public model API-key
+    variable.
+  </Accordion>
+
+  <Accordion title="model_config requires provider and model">
+    Set both fields:
+
+    ```python
+    model_config={"provider": "openai", "model": "gpt-4o"}
+    ```
+
+    See [Models](/docs/how-to-guides/models) for supported provider names.
+  </Accordion>
+
+  <Accordion title="Missing optional backend package">
+    Install the extra for the backend you are using:
+
+    ```bash
+    pip install "omnicoreagent[redis]"
+    pip install "omnicoreagent[mongodb]"
+    pip install "omnicoreagent[serve]"
+    ```
+
+    The base quickstart does not require these extras.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Next: Add MCP Tools
 
 MCP servers are external tool providers. OmniCoreAgent connects to them and loads
 their tools into the same runtime view as local tools.
 
-```python
-agent = OmniCoreAgent(
-    name="fs_agent",
-    system_instruction="Inspect files when the task needs filesystem context.",
-    model_config={"provider": "openai", "model": "gpt-4o"},
-    mcp_tools=[
-        {
-            "name": "filesystem",
-            "transport_type": "stdio",
-            "command": "npx",
-            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-        }
-    ],
-)
+This optional example uses Node.js and `npx` because the filesystem MCP server is
+published as an npm package:
 
-await agent.connect_mcp_servers()
-result = await agent.run("List files in /tmp")
+```python
+import asyncio
+from omnicoreagent import OmniCoreAgent
+
+async def main():
+    agent = OmniCoreAgent(
+        name="fs_agent",
+        system_instruction="Inspect files when the task needs filesystem context.",
+        model_config={"provider": "openai", "model": "gpt-4o"},
+        mcp_tools=[
+            {
+                "name": "filesystem",
+                "transport_type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            }
+        ],
+    )
+
+    await agent.connect_mcp_servers()
+    result = await agent.run("List files in /tmp")
+    print(result["response"])
+    await agent.cleanup()
+
+asyncio.run(main())
 ```
 
 <Note>
@@ -127,7 +199,7 @@ harness tools.
 
 ---
 
-## Turn On Heavier Harness Features
+## Next: Turn On Heavier Harness Features
 
 For longer tasks, enable the heavier harness features explicitly: automatic
 context control before each model call, tool output offloading into the
@@ -158,31 +230,25 @@ workers write outputs that the lead agent reads back.
 
 ---
 
-## Persistence With Session IDs
-
-Agents keep continuity when you provide a stable `session_id`:
-
-```python
-await agent.run("My name is Abiola.", session_id="user_123")
-result = await agent.run("What is my name?", session_id="user_123")
-```
-
-The default memory backend is suitable for local development. Use Redis,
-MongoDB, or SQL database storage when the application needs persistence outside
-the current process.
-
----
-
 ## Next Steps
 
 <CardGroup cols={3}>
-  <Card title="Architecture" icon="sitemap" href="/docs/core-concepts/architecture">
-    Understand the runtime layers and request flow.
-  </Card>
   <Card title="Local Tools" icon="toolbox" href="/docs/core-concepts/local-tools">
     Register Python functions as tools.
   </Card>
+  <Card title="Workspace Files" icon="folder-tree" href="/docs/core-concepts/workspace-files">
+    Store notes, artifacts, scratchpads, and tool offloads.
+  </Card>
+  <Card title="OmniServe" icon="server" href="/docs/how-to-guides/omniserve">
+    Serve this agent through REST and SSE.
+  </Card>
   <Card title="Configuration" icon="gear" href="/docs/how-to-guides/configuration">
     Configure context, tool offload, memory, events, and workspace storage.
+  </Card>
+  <Card title="Use Docs With AI Tools" icon="sparkles" href="/docs/getting-started/use-docs-with-ai-tools">
+    Ask questions against the official docs from your editor or AI tool.
+  </Card>
+  <Card title="Architecture" icon="sitemap" href="/docs/core-concepts/architecture">
+    Understand the runtime layers and request flow.
   </Card>
 </CardGroup>

--- a/docs/getting-started/use-docs-with-ai-tools.mdx
+++ b/docs/getting-started/use-docs-with-ai-tools.mdx
@@ -1,0 +1,161 @@
+---
+title: Use Docs With AI Tools
+description: 'Use OmniCoreAgent docs with Ask AI, llms.txt, hosted MCP, Cursor, VS Code, ChatGPT, Claude, and Perplexity'
+icon: 'sparkles'
+---
+
+# Use Docs With AI Tools
+
+OmniCoreAgent docs are written for people and AI coding tools. Use this page
+when you want the docs inside your editor, chat session, or agent workflow.
+
+<Info>
+AI tools are a faster way to navigate the docs. They do not replace source-code
+verification for production changes.
+</Info>
+
+---
+
+## Ask AI In The Docs
+
+Use the Ask AI action in the docs header to ask questions against the official
+OmniCoreAgent documentation.
+
+Good prompts:
+
+```text
+Show me the smallest OmniCoreAgent with one local tool.
+```
+
+```text
+Explain memory vs workspace vs task store.
+```
+
+```text
+Build an OmniServe API with auth and rate limiting.
+```
+
+```text
+Which config enables context management and tool offload?
+```
+
+Ask AI should answer with the docs as source context. If a feature is not
+documented, verify in the source code or open an issue.
+
+---
+
+## Copy Or View A Page As Markdown
+
+Use the contextual menu on any docs page to copy the page as Markdown or view
+the raw Markdown source. This is useful when you want to paste one exact docs
+page into ChatGPT, Claude, Perplexity, Cursor, or another coding agent.
+
+Best use cases:
+
+- explain one API surface
+- convert one example to your app
+- compare memory, workspace, and task-store behavior
+- ask for a migration checklist from a specific docs page
+
+---
+
+## Use `/llms.txt`
+
+Mintlify publishes an AI-readable docs index at:
+
+```text
+https://docs-omnicoreagent.omnirexfloralabs.com/llms.txt
+```
+
+Use this when an AI tool asks for a documentation index or when you want to
+give a coding agent the full docs map before it starts changing code.
+
+Example prompt:
+
+```text
+Read the OmniCoreAgent llms.txt index, then show me the pages I need to build
+an agent with local tools, workspace files, and OmniServe.
+```
+
+---
+
+## Use The Hosted Docs MCP
+
+Mintlify exposes the docs as an MCP server at:
+
+```text
+https://docs-omnicoreagent.omnirexfloralabs.com/mcp
+```
+
+Use this with an MCP-capable editor or agent when you want documentation search
+available as a tool instead of pasting pages manually.
+
+Ask your tool to search the docs MCP for exact topics:
+
+```text
+Search the OmniCoreAgent docs MCP for task store configuration and summarize
+the Redis, MongoDB, and SQL options.
+```
+
+---
+
+## Use Cursor Or VS Code
+
+Use the contextual menu actions for Cursor or VS Code when you want the current
+docs page opened inside your editor context.
+
+Useful workflow:
+
+1. Open the docs page that matches your task.
+2. Send it to Cursor or VS Code from the contextual menu.
+3. Ask the editor agent to update your app using only that docs page and your
+   local source files.
+
+Example prompt:
+
+```text
+Using this OmniCoreAgent page, add a local tool registry to my existing agent
+without changing memory or workspace configuration.
+```
+
+---
+
+## Use ChatGPT, Claude, Or Perplexity
+
+The contextual menu can open the current docs page in ChatGPT, Claude, or
+Perplexity. Use this when you want explanation, comparison, or planning around
+one specific docs page.
+
+Good prompts:
+
+```text
+Turn this OmniServe docs page into a deployment checklist for my FastAPI app.
+```
+
+```text
+Explain the difference between MemoryRouter, workspace storage, and background
+task store using only this OmniCoreAgent page.
+```
+
+```text
+Create a minimal support-agent example from this local tools guide.
+```
+
+---
+
+## Where To Start
+
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="bolt" href="/docs/getting-started/quickstart">
+    Run the smallest useful OmniCoreAgent.
+  </Card>
+  <Card title="Configuration" icon="gear" href="/docs/how-to-guides/configuration">
+    Find environment variables and runtime config.
+  </Card>
+  <Card title="Agent Harness" icon="layer-group" href="/docs/core-concepts/agent-harness">
+    Understand what OmniCoreAgent adds around the model.
+  </Card>
+  <Card title="OmniServe" icon="server" href="/docs/how-to-guides/omniserve">
+    Serve an agent through REST and SSE.
+  </Card>
+</CardGroup>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,26 +15,72 @@ mode: 'wide'
   alt="OmniCoreAgent Dark"
 />
 
-## Open Python Agent Harness And Runtime For Production AI Agents
+## Open Python Agent Harness For Production AI Applications
 
 **OmniCoreAgent** is the harness around the model: the loop, tools, memory,
 context control, workspace files, MCP tools, subagents, background tasks, and
 REST/SSE serving boundary that make an agent usable beyond a demo.
 
-The goal is direct: give builders the production pieces they otherwise patch
-around an LLM after the first demo starts breaking.
+Start small with one agent and one model. Add tools, memory, workspace files,
+background tasks, telemetry, and OmniServe only when the application needs them.
 
 ```bash
 pip install omnicoreagent
 ```
 
-Add only the production extras you need:
+```bash
+export LLM_API_KEY=your_api_key_here
+```
+
+<CardGroup cols={2}>
+  <Card title="Run The Quickstart" icon="bolt" href="/docs/getting-started/quickstart">
+    Install OmniCoreAgent, create your first agent, add one tool, and learn the
+    next paths.
+  </Card>
+  <Card title="Use Docs With AI Tools" icon="sparkles" href="/docs/getting-started/use-docs-with-ai-tools">
+    Use Ask AI, Markdown export, `llms.txt`, hosted docs MCP, Cursor, VS Code,
+    ChatGPT, Claude, and Perplexity.
+  </Card>
+</CardGroup>
+
+Add only the production extras you need later:
 
 ```bash
 pip install "omnicoreagent[redis]"
 pip install "omnicoreagent[serve]"
 pip install "omnicoreagent[all]"
 ```
+
+---
+
+## Choose Your Path
+
+<CardGroup cols={2}>
+  <Card title="Build Your First Agent" icon="bolt" href="/docs/getting-started/quickstart">
+    One model, one agent, one task.
+  </Card>
+  <Card title="Add Python Tools" icon="toolbox" href="/docs/core-concepts/local-tools">
+    Register application-owned functions with `ToolRegistry`.
+  </Card>
+  <Card title="Connect MCP Tools" icon="plug" href="/docs/core-concepts/mcp">
+    Load tools from external MCP servers.
+  </Card>
+  <Card title="Keep Session Memory" icon="database" href="/docs/core-concepts/memory">
+    Store conversation history in memory, Redis, MongoDB, or SQL.
+  </Card>
+  <Card title="Use Workspace Files" icon="folder-tree" href="/docs/core-concepts/workspace-files">
+    Give agents a file surface for notes, artifacts, and offloads.
+  </Card>
+  <Card title="Serve An Agent API" icon="server" href="/docs/how-to-guides/omniserve">
+    Run the same agent behind REST and SSE endpoints.
+  </Card>
+  <Card title="Run Background Work" icon="clock" href="/docs/core-concepts/background-agents">
+    Schedule durable agent work with run history, retries, and workspace output.
+  </Card>
+  <Card title="Build A Real Application" icon="rocket" href="/cookbook/real_applications">
+    Start from production-shaped examples.
+  </Card>
+</CardGroup>
 
 ---
 
@@ -96,6 +142,13 @@ OmniCoreAgent is built around real agent runtime problems:
   </Card>
   <Card title="MCP Tools" icon="plug" href="/docs/core-concepts/mcp">
     Connect external MCP servers over stdio, SSE, or Streamable HTTP.
+  </Card>
+  <Card title="Configuration" icon="gear" href="/docs/how-to-guides/configuration">
+    Environment variables, memory, workspace, task stores, telemetry, and
+    OmniServe settings.
+  </Card>
+  <Card title="OmniServe" icon="server" href="/docs/how-to-guides/omniserve">
+    Production REST/SSE serving, auth, rate limits, events, and background APIs.
   </Card>
 </CardGroup>
 

--- a/engineering/architecture/docs-experience.md
+++ b/engineering/architecture/docs-experience.md
@@ -1,0 +1,416 @@
+# Documentation Experience Architecture
+
+This is an internal architecture record. It defines how the public README,
+Mintlify documentation, and cookbook should work together so new users can
+understand OmniCoreAgent quickly and experienced builders can find exact
+contracts without guessing.
+
+Public docs live under `docs/` and `cookbook/`. This record exists to keep the
+documentation system coherent before implementation changes begin.
+
+## Purpose
+
+OmniCoreAgent documentation must convert interest into working usage.
+
+The documentation should answer four user questions in order:
+
+1. What is OmniCoreAgent?
+2. How do I run my first agent?
+3. How do I build my real application shape?
+4. Where is the exact reference when I need to configure or debug something?
+
+The docs should support beginners, production app builders, and AI coding tools.
+The same content must be readable by humans and usable by Mintlify Assistant,
+`llms.txt`, hosted docs MCP, Cursor, Claude, ChatGPT, and similar tools.
+
+## Product Positioning
+
+OmniCoreAgent is an open production agent harness for application builders.
+
+The docs must not position OmniCoreAgent as:
+
+- a generic "agent framework"
+- a personal assistant product
+- a consumer chatbot platform
+- a marketing-only runtime
+- a bag of loosely connected helpers
+
+The docs should consistently use these terms:
+
+| Concept | Preferred Term |
+|---------|----------------|
+| Runtime around the model | agent harness |
+| Model credential | `LLM_API_KEY` |
+| Conversation storage | memory |
+| File/state surface | workspace |
+| Background run state | task store |
+| HTTP/SSE serving | OmniServe |
+| Runtime progress and traces | telemetry |
+| External MCP-provided functions | MCP tools |
+| Application Python functions | local tools |
+
+## Documentation Surfaces
+
+### README
+
+The README is the landing page for GitHub, PyPI, social links, and search
+traffic. It should make the value obvious before the reader scrolls.
+
+README order:
+
+1. one-line positioning
+2. short capability statement
+3. install
+4. smallest working example
+5. "what makes it different"
+6. build-by-use-case paths
+7. install extras
+8. features
+9. deeper architecture and contribution details
+
+The README can be strong and direct, but it must avoid long narrative blocks
+before the first runnable example.
+
+### Mintlify Docs
+
+Mintlify docs are the primary learning surface. They should be organized around
+two parallel paths:
+
+1. goal-oriented paths for users who know what they want to build
+2. concept/reference paths for users who need exact runtime behavior
+
+Top-level navigation must preserve fast access to configuration, serving,
+production operations, and troubleshooting. Those are not secondary details for
+application builders; they are where prototype agents usually become hard to
+ship.
+
+The docs should not force a beginner to understand every production feature
+before running the first agent.
+
+### Cookbook
+
+The cookbook is the proof surface. It should contain runnable examples, grouped
+by user intent:
+
+- first agent
+- local tools
+- MCP tools
+- memory
+- workspace files
+- tool offload
+- subagents
+- background tasks
+- OmniServe
+- real applications
+
+Cookbook pages should state:
+
+- what the example demonstrates
+- required environment variables
+- optional external services
+- how to run it
+- what output to expect
+
+### Internal Engineering Docs
+
+Engineering records stay under `engineering/`. They are not product docs. They
+exist for maintainers and coding agents. Public docs may summarize decisions
+from engineering records, but should not expose internal planning language as
+user-facing content.
+
+## AI-Native Documentation Layer
+
+Modern documentation is read by people and by AI tools. OmniCoreAgent docs must
+support both.
+
+Required AI-native surfaces:
+
+- Mintlify Assistant enabled in the dashboard.
+- `.mintlify/Assistant.md` for assistant behavior and terminology.
+- Mintlify contextual menu with `assistant`, `copy`, `view`, `chatgpt`,
+  `claude`, `perplexity`, `mcp`, `cursor`, and `vscode`.
+- A "Use Docs With AI Tools" page that explains Ask AI, `/llms.txt`, `/mcp`,
+  Cursor, Claude, VS Code, and copy-as-Markdown.
+- Consistent frontmatter titles and descriptions.
+- Language-labelled code blocks.
+- Specific nouns instead of ambiguous pronouns.
+- Hidden or agent-only content only when it helps AI answer correctly without
+  cluttering user-facing docs, and only when indexing/search/MCP behavior is
+  explicitly configured and validated.
+
+The assistant should answer from official docs only. If the docs do not contain
+the answer, the assistant should say what is missing and link the closest
+relevant pages.
+
+## Information Architecture
+
+Target public navigation:
+
+```text
+Get Started
+  Overview
+  Installation
+  Quickstart
+  Use Docs With AI Tools
+
+Choose Your Path
+  First Agent
+  Add Tools
+  Connect MCP Tools
+  Add Memory
+  Use Workspace Files
+  Serve An Agent API
+  Run Background Work
+  Build A Real Application
+
+Build Guides
+  Basic Usage
+  Local Tools
+  MCP Tools
+  Memory
+  Workspace Files
+  Context Engineering
+  Tool Offload
+  Subagents
+  Background Agents
+
+Concepts
+  Agent Harness
+  Architecture
+  Guardrails
+  Events and Telemetry
+  Skills
+  Workflows
+
+Configure
+  Configuration
+  Models
+  Memory Backends
+  Workspace Backends
+  Background Task Stores
+  Telemetry Exporters
+
+Serve
+  OmniServe
+  REST And SSE Endpoints
+  Auth And Rate Limits
+  Background HTTP API
+  Deployment Shape
+
+Production
+  Production Checklist
+  Troubleshooting
+  Guardrails In Production
+  Telemetry And Debugging
+  Background Task Recovery
+
+Reference
+  OmniCoreAgent
+  AgentConfig
+  MemoryRouter
+  Workspace
+  OmniServeConfig
+  BackgroundAgentManager
+  Telemetry APIs
+
+Cookbook
+  Getting Started
+  Real Applications
+  OmniServe
+  Background Agents
+  Workflows
+  Production
+
+Changelog
+```
+
+This can be implemented gradually. The first implementation phase should not
+create empty reference pages. It should add the navigation structure only when
+pages exist.
+
+## Beginner Journey
+
+A beginner should be able to complete this path without reading architecture:
+
+1. Install with `pip install omnicoreagent`.
+2. Set `LLM_API_KEY`.
+3. Run a minimal agent.
+4. Add one local tool.
+5. Add a stable `session_id`.
+6. Write/read a workspace file.
+7. Know where to go next based on use case.
+
+Every step must be copy-paste runnable or clearly marked as conceptual.
+
+The beginner quickstart should not require OmniServe. The local-agent to served
+API transition gets its own short guide: "Serve An Agent API". That guide starts
+from the quickstart agent and shows the smallest OmniServe path.
+
+## Production Builder Journey
+
+A production app builder should quickly find:
+
+- memory backend choice
+- workspace backend choice
+- task store choice
+- OmniServe auth/rate-limit/prefix settings
+- telemetry trace retrieval and export
+- guardrail behavior
+- background task lifecycle
+- deployment-shaped examples
+- production checklist
+- troubleshooting and recovery steps
+
+The docs should explain the difference between similar concepts:
+
+- memory vs workspace
+- workspace storage vs memory backend
+- task store vs memory router
+- telemetry events vs trace exports
+- local tools vs MCP tools
+- background agent manager vs OmniServe
+
+## Goal-Oriented Entry Points
+
+The docs landing page and README must include a "Choose Your Path" section.
+This section maps user intent to pages and examples instead of asking users to
+infer which feature they need.
+
+Required paths:
+
+| User Goal | Destination |
+|-----------|-------------|
+| Run the first agent | Quickstart |
+| Add application tools | Local tools guide |
+| Connect external tools | MCP tools guide |
+| Keep session continuity | Memory guide |
+| Store files and artifacts | Workspace files guide |
+| Avoid context overflow | Context engineering guide |
+| Serve an agent over HTTP/SSE | OmniServe guide |
+| Run durable long-running work | Background agents guide |
+| Build a production-shaped app | Real applications cookbook |
+| Debug or operate production runs | Production/troubleshooting docs |
+
+## Troubleshooting Path
+
+Troubleshooting is part of the docs architecture, not an afterthought. The docs
+must give direct fixes for common first-run and production failures:
+
+- missing `LLM_API_KEY`
+- unsupported provider/model name
+- optional extra not installed
+- async cleanup/lifecycle mistakes
+- MCP server connection failures
+- port already in use
+- OmniServe auth failures
+- rate-limit behavior
+- workspace backend misconfiguration
+- Redis/MongoDB/SQL task-store connection failures
+- background task stuck, cancelled, retried, timed out, or missing workspace output
+- telemetry trace not found
+
+## Voice And Style
+
+The docs should sound confident and direct. They should not weaken clear claims
+with unnecessary hedging. They should also not overclaim features that are not
+implemented.
+
+Writing rules:
+
+- lead with the answer
+- use short paragraphs
+- use concrete examples
+- say exactly which config key or env var matters
+- prefer tables for option comparison
+- avoid story-heavy sections in quickstart paths
+- keep official docs cleaner than social posts
+- use one term per concept
+
+## Implementation Phases
+
+### Phase 1: AI-Native Discovery And First-Run Path
+
+Goal: make docs easier to enter and easier for AI tools to use.
+
+Scope:
+
+- add `.mintlify/Assistant.md`
+- add Mintlify contextual menu configuration
+- add `docs/getting-started/use-docs-with-ai-tools.mdx`
+- tighten docs landing page and quickstart
+- tighten README top section
+- add frontmatter to cookbook index pages where missing
+
+### Phase 2: Build-By-Use-Case Guides
+
+Goal: help users map intent to examples.
+
+Scope:
+
+- choose-your-path page or landing section
+- support agent guide
+- research agent guide
+- background worker guide
+- served API guide
+- MCP tools guide
+- workspace-first guide
+- production checklist
+- troubleshooting guide
+
+### Phase 3: Reference Section
+
+Goal: give app builders exact contracts.
+
+Scope:
+
+- OmniCoreAgent reference
+- AgentConfig reference
+- ModelConfig reference
+- MemoryRouter reference
+- Workspace reference
+- OmniServeConfig reference
+- BackgroundAgentManager reference
+- Telemetry API reference
+
+### Phase 4: Cookbook Quality Pass
+
+Goal: make every cookbook page runnable, searchable, and explicit about
+requirements.
+
+Scope:
+
+- standard frontmatter
+- prerequisites
+- run commands
+- expected output
+- required services
+- links back to docs concepts
+- every individual recipe documents whether it is local-only or requires
+  external services
+
+## Non-Goals
+
+This docs redesign does not:
+
+- redesign the visual brand
+- add new runtime features
+- publish internal engineering docs as official product docs
+- create API reference pages without verifying source code contracts
+- claim unsupported provider-specific environment variables
+- replace examples with marketing copy
+
+## Success Criteria
+
+The docs pass when:
+
+- a new user can run the quickstart in under ten minutes
+- the README communicates the harness value before deep details
+- the docs navigation exposes beginner, builder, concept, and reference paths
+- Ask AI and contextual AI actions are configured
+- `/llms.txt` and `/mcp` are explained for AI-tool users
+- hidden or agent-only content is indexed/searchable when used
+- no docs page contradicts the code about env vars, defaults, or feature status
+- every code block has a language tag
+- cookbook pages tell users what runs locally and what needs services
+- troubleshooting gives direct fixes for common setup and production failures
+- docs validation passes locally

--- a/engineering/specifications/docs-experience.md
+++ b/engineering/specifications/docs-experience.md
@@ -1,0 +1,337 @@
+# Documentation Experience Specification
+
+This is an internal specification. It defines the documentation behavior that
+the README, Mintlify docs, and cookbook must satisfy.
+
+Public documentation lives in `README.md`, `docs/`, and `cookbook/`.
+
+## Source Of Truth
+
+Documentation must describe implemented behavior only. If a page documents
+configuration, defaults, exports, or public behavior, the claim must be grounded
+in code, tests, or an accepted engineering specification.
+
+Priority order when resolving conflicts:
+
+1. shipped source code
+2. tests
+3. engineering specifications
+4. public docs
+5. README
+
+Public docs and README must be updated when source code changes public behavior.
+
+## Terminology Contract
+
+Use these terms consistently:
+
+| Term | Meaning |
+|------|---------|
+| agent harness | runtime layer around one or more models |
+| model_config | provider/model selection and model options |
+| `LLM_API_KEY` | single public model API key env var |
+| local tools | Python functions registered by the application |
+| MCP tools | tools loaded from MCP servers |
+| memory | conversation/session history |
+| workspace | file/state surface for notes, artifacts, offloads, subagent output |
+| task store | background task/run/attempt/lease storage |
+| telemetry | typed events, traces, streams, and exporters |
+| OmniServe | REST/SSE serving boundary |
+
+Forbidden public-doc substitutions:
+
+- do not call OmniCoreAgent only an "agent framework" in primary positioning
+- do not document `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or
+  `GROQ_API_KEY` as OmniCoreAgent public env vars
+- do not use `DeepAgent` as a current public API path
+- do not call background task-store state "memory"
+- do not call workspace storage a memory backend
+
+## README Contract
+
+`README.md` must contain, in this order:
+
+1. logo/name/badges
+2. one-sentence positioning
+3. short capability line
+4. navigation links
+5. "What It Is"
+6. "Quick Start"
+7. "Choose Your Path"
+8. "What You Can Build"
+9. differentiators
+10. install extras
+11. features
+12. implementation map or architecture pointer
+13. cookbook/docs links
+14. development/contribution/license/author
+
+The first runnable example must appear before any long architecture narrative.
+
+README quickstart must:
+
+- install with `pip install omnicoreagent`
+- set `LLM_API_KEY`
+- construct `OmniCoreAgent`
+- call `agent.run(...)`
+- print `result["response"]`
+- call `await agent.cleanup()`
+
+## Mintlify Configuration Contract
+
+`docs.json` must:
+
+- keep project name as `OmniCoreAgent`
+- keep the primary docs CTA pointing to quickstart
+- include a GitHub navbar link
+- include a docs contextual menu when supported by Mintlify
+- include `assistant`, `copy`, `view`, `chatgpt`, `claude`, `perplexity`,
+  `mcp`, `cursor`, and `vscode` contextual actions when supported
+- include the "Use Docs With AI Tools" page in the Get Started group
+- include goal-oriented navigation for "Choose Your Path" when those pages exist
+- keep configuration, serving, production, and troubleshooting discoverable from
+  navigation when those pages exist
+- configure `seo.indexing: "all"` when hidden or agent-only pages are used as
+  assistant/MCP/`llms.txt` context
+- avoid navigation entries for pages that do not exist
+
+If Mintlify changes the config schema, docs config must be validated before
+merge.
+
+## Assistant Contract
+
+`.mintlify/Assistant.md` must exist.
+
+The assistant instructions must tell Mintlify Assistant to:
+
+- answer from official OmniCoreAgent docs
+- use "agent harness" as the primary identity
+- tell users to use `LLM_API_KEY`
+- distinguish memory, workspace, and task store
+- distinguish local tools and MCP tools
+- avoid claiming unimplemented features
+- link relevant docs pages when answering
+- say when the docs do not contain enough information
+- keep answers concise and action-oriented
+
+The assistant instructions must not include secrets or local-only paths.
+
+Assistant availability is a deployment concern. The first implementation must
+configure `.mintlify/Assistant.md`; release verification must also check the
+deployed docs site after merge to confirm Ask AI is available when the Mintlify
+plan/dashboard supports it. If Ask AI is unavailable because of dashboard or
+plan state, the PR should still improve AI-tool docs through contextual actions,
+`/llms.txt`, `/mcp`, and Markdown export, but the release note must call out
+that dashboard enablement is still required.
+
+## AI Tools Page Contract
+
+`docs/getting-started/use-docs-with-ai-tools.mdx` must exist.
+
+It must explain:
+
+- Mintlify Ask AI
+- copy page as Markdown
+- view page as Markdown
+- `/llms.txt`
+- hosted docs MCP at `/mcp`
+- using the docs from Cursor
+- using the docs from VS Code
+- using the docs from ChatGPT, Claude, and Perplexity
+
+The page must include examples of good prompts:
+
+- "Show me the smallest OmniCoreAgent with one local tool."
+- "Explain memory vs workspace vs task store."
+- "Build an OmniServe API with auth and rate limiting."
+- "Which config enables context management and tool offload?"
+
+The page must not imply AI answers replace source verification for production
+changes.
+
+## Quickstart Contract
+
+`docs/getting-started/quickstart.mdx` must be beginner-first.
+
+It must contain:
+
+- install
+- set `LLM_API_KEY`
+- first agent
+- run command
+- expected result shape
+- add one local tool
+- add a stable session id
+- point to workspace and OmniServe next steps
+- a common-errors section for missing `LLM_API_KEY`, missing optional extras,
+  and provider/model failures
+
+It must not require:
+
+- Redis
+- MongoDB
+- PostgreSQL
+- S3/R2
+- MCP
+- OmniServe
+- background tasks
+
+Those belong in later sections.
+
+The transition from local agent to API must live in a separate "Serve An Agent
+API" path or the OmniServe guide. Quickstart may link to it but must not make it
+part of the first successful run.
+
+## Docs Landing Page Contract
+
+`docs/index.mdx` must:
+
+- identify OmniCoreAgent as an open production agent harness
+- give a minimal install command
+- link to quickstart
+- link to "Use Docs With AI Tools"
+- include a "Choose Your Path" section that maps user goals to docs/cookbook
+  destinations
+- link to production and troubleshooting paths when those pages exist
+- avoid overwhelming users with every feature before the first run path
+
+## Cookbook Contract
+
+Cookbook index pages must have frontmatter unless Mintlify explicitly does not
+render them.
+
+Each cookbook category page should include:
+
+- title
+- description
+- what examples prove
+- prerequisites
+- run command
+- expected output or output location
+- table of examples
+- links back to docs concept pages
+
+Cookbook examples that require external services must say so.
+
+Cookbook examples that run with local defaults must say so.
+
+Each individual cookbook recipe should be copy-paste runnable or explicitly
+marked as conceptual. Each recipe should state required env vars, optional
+services, and expected output when practical.
+
+## Configuration Accuracy Contract
+
+Public docs must document these environment facts:
+
+- `LLM_API_KEY` is the single public hosted-model API key variable used by
+  OmniCoreAgent examples.
+- Memory defaults to in-memory.
+- Workspace defaults to local storage.
+- OmniServe has defaults and does not require env vars to start.
+- Background task store defaults to in-memory.
+- Redis/MongoDB/SQL task store is separate from MemoryRouter.
+- S3/R2 workspace storage is separate from memory.
+
+Docs must not add provider-specific model API key env vars unless source code
+adds them as public OmniCoreAgent configuration.
+
+## Code Block Contract
+
+All fenced code blocks in public docs must have a language tag unless they are
+plain terminal output or intentionally generic text.
+
+Allowed common tags:
+
+- `bash`
+- `python`
+- `json`
+- `text`
+- `yaml`
+- `dockerfile`
+
+## Frontmatter And Metadata Contract
+
+Every touched public `.mdx` page must include frontmatter with:
+
+- `title`
+- `description`
+
+Use `icon` where the page appears in primary navigation.
+
+Descriptions should be concrete enough to help Mintlify search, `llms.txt`, and
+AI retrieval. Avoid vague descriptions such as "Learn more".
+
+## Goal Path Contract
+
+The docs must include a goal-oriented entry point on the landing page and
+README. The implementation may add separate pages gradually, but the mapping
+must exist.
+
+Required goal mappings:
+
+| Goal | Required Destination |
+|------|----------------------|
+| Run first agent | quickstart |
+| Add Python tools | local tools guide or cookbook |
+| Connect MCP tools | MCP guide or cookbook |
+| Keep memory | memory guide |
+| Use files/artifacts | workspace files guide |
+| Serve as API | OmniServe guide |
+| Run background work | background agents guide or cookbook |
+| Build real app | real applications cookbook |
+| Debug production issue | troubleshooting or production guide |
+
+## Troubleshooting Contract
+
+Beginner and production docs must expose troubleshooting paths. At minimum,
+docs must include direct fixes for:
+
+- missing `LLM_API_KEY`
+- unsupported provider/model value
+- missing optional extra
+- MCP server connection failure
+- OmniServe port already in use
+- OmniServe auth failure
+- workspace backend credentials missing
+- Redis/MongoDB/SQL connection failure
+- background run timeout/cancel/retry states
+- telemetry trace not found
+
+## Validation Contract
+
+Before merging docs changes:
+
+- run a local search for forbidden provider-specific env var claims
+- run a local search for stale `DeepAgent` references
+- run a local search for "framework" in primary positioning pages
+- validate `docs.json` is parseable JSON
+- verify every touched public `.mdx` page has `title` and `description`
+  frontmatter
+- run docs/cookbook tests when examples or claims change
+- run a markdown/frontmatter sanity check for new docs pages
+- validate AI contextual menu schema against current Mintlify docs
+- check `/llms.txt` and `/mcp` documentation links after deployment
+
+If Mintlify CLI is available locally, run:
+
+- `mint validate`
+- `mint broken-links --check-anchors`
+
+If Mintlify CLI is unavailable, record that explicitly in the PR and run the
+fallback checks above. A deployed docs smoke check must run after merge.
+
+## First Implementation Acceptance Criteria
+
+The first docs-experience implementation is complete when:
+
+- `.mintlify/Assistant.md` exists
+- `docs.json` includes AI contextual actions and the AI tools page
+- `docs/getting-started/use-docs-with-ai-tools.mdx` exists
+- `docs/index.mdx` has a clearer beginner and AI-tool entry
+- `docs/getting-started/quickstart.mdx` is beginner-first and runnable
+- `README.md` top section is tighter and keeps claims grounded
+- cookbook index pages touched by the change have frontmatter
+- all new claims avoid unsupported provider-specific env vars
+- the first-run docs include common setup errors
+- the landing page and README include goal-oriented path selection
+- validation commands pass


### PR DESCRIPTION
## Summary
- add internal docs architecture/spec for the documentation experience and AI-native docs layer
- add Mintlify Assistant instructions, contextual AI menu support, AI tools guide, and docs favicon asset
- tighten README, docs landing, quickstart, local tools, memory, workspace, and cookbook index pages for beginner and app-builder paths

## Validation
- mintlify validate
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/test_docs_claims.py -q
- docs.json JSON parse
- MDX frontmatter check
- stale provider-key/DeepAgent search