### PR TITLE
Add governance enforcement for tools and workspace

### DIFF
--- a/src/omnicoreagent/__init__.py
+++ b/src/omnicoreagent/__init__.py
@@ -113,6 +113,7 @@ __all__ = [
     "SandboxRequiredError",
     "BudgetExceededError",
     "UnknownCapabilityError",
+    "UngovernedCapabilityError",
     "build_default_policy",
     "attach_policy_hash",
     "canonical_policy_payload",
@@ -121,6 +122,10 @@ __all__ = [
     "load_policy_file",
     "policy_from_mapping",
     "policy_hash",
+    "tool_authority_request",
+    "tool_authority_requests",
+    "tool_capability_descriptor",
+    "tool_capability_name",
 ]
 
 _EXPORTS = {
@@ -239,6 +244,10 @@ _EXPORTS = {
     "SandboxRequiredError": ("omnicoreagent.governance", "SandboxRequiredError"),
     "BudgetExceededError": ("omnicoreagent.governance", "BudgetExceededError"),
     "UnknownCapabilityError": ("omnicoreagent.governance", "UnknownCapabilityError"),
+    "UngovernedCapabilityError": (
+        "omnicoreagent.governance",
+        "UngovernedCapabilityError",
+    ),
     "build_default_policy": ("omnicoreagent.governance", "build_default_policy"),
     "attach_policy_hash": ("omnicoreagent.governance", "attach_policy_hash"),
     "canonical_policy_payload": ("omnicoreagent.governance", "canonical_policy_payload"),
@@ -247,6 +256,13 @@ _EXPORTS = {
     "load_policy_file": ("omnicoreagent.governance", "load_policy_file"),
     "policy_from_mapping": ("omnicoreagent.governance", "policy_from_mapping"),
     "policy_hash": ("omnicoreagent.governance", "policy_hash"),
+    "tool_authority_request": ("omnicoreagent.governance", "tool_authority_request"),
+    "tool_authority_requests": ("omnicoreagent.governance", "tool_authority_requests"),
+    "tool_capability_descriptor": (
+        "omnicoreagent.governance",
+        "tool_capability_descriptor",
+    ),
+    "tool_capability_name": ("omnicoreagent.governance", "tool_capability_name"),
 }
 
 _OPTIONAL_EXPORTS = {

--- a/src/omnicoreagent/core/agents/base.py
+++ b/src/omnicoreagent/core/agents/base.py
@@ -68,6 +68,7 @@ class BaseReactAgent:
         tool_offload_config: dict = None,
         workspace_config: WorkspaceConfig | dict | None = None,
         guardrail: PromptInjectionGuard | None = None,
+        governance_engine: Any = None,
     ):
         self.agent_name = agent_name
         self.max_steps = max(max_steps, 5)
@@ -110,13 +111,17 @@ class BaseReactAgent:
             workspace_config=workspace_config,
         )
         self.guardrail = guardrail
+        self.governance_engine = governance_engine
         self.tool_observation_handler = ToolObservationHandler(
             agent_name=self.agent_name,
             tool_offloader=self.tool_offloader,
             guardrail=self.guardrail,
         )
         self.tool_call_resolver = ToolCallResolver(guardrail=self.guardrail)
-        self.tool_failure_handler = ToolFailureHandler(agent_name=self.agent_name)
+        self.tool_failure_handler = ToolFailureHandler(
+            agent_name=self.agent_name,
+            governance_enabled=self.governance_engine is not None,
+        )
         self.message_history_loader = AgentMessageHistoryLoader(
             agent_name=self.agent_name
         )
@@ -124,6 +129,7 @@ class BaseReactAgent:
         self.tool_batch_runner = ToolBatchRunner(
             agent_name=self.agent_name,
             tool_call_timeout=self.tool_call_timeout,
+            governance_engine=self.governance_engine,
         )
         self.tool_action_runner = AgentToolActionRunner(
             agent_name=self.agent_name,

--- a/src/omnicoreagent/core/agents/react_agent.py
+++ b/src/omnicoreagent/core/agents/react_agent.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 
 class ReactAgent(BaseReactAgent):
     def __init__(
-        self, config: AgentConfig, guardrail: PromptInjectionGuard | None = None
+        self,
+        config: AgentConfig,
+        guardrail: PromptInjectionGuard | None = None,
+        governance_engine=None,
     ):
         super().__init__(
             agent_name=config.agent_name,
@@ -27,4 +30,5 @@ class ReactAgent(BaseReactAgent):
             tool_offload_config=getattr(config, "tool_offload", None),
             workspace_config=config.workspace_config,
             guardrail=guardrail,
+            governance_engine=governance_engine,
         )

--- a/src/omnicoreagent/core/runtime/builder.py
+++ b/src/omnicoreagent/core/runtime/builder.py
@@ -30,6 +30,7 @@ def build_agent_runtime(
     guardrail_mode: str,
     summarize_fn: Any,
     debug: bool,
+    telemetry_recorder: Any = None,
 ) -> AgentRuntimeComponents:
     """Build the executable agent runtime without mutating the facade."""
     mcp_client, llm_connection = construction.create_llm_runtime(
@@ -49,6 +50,10 @@ def build_agent_runtime(
         agent_settings=agent_settings,
         guardrail=guardrail,
         guardrail_mode=guardrail_mode,
+        governance_engine=construction.build_governance_engine(
+            agent_config=agent_config,
+            telemetry_recorder=telemetry_recorder,
+        ),
     )
 
     subagent_factory, local_tools = harness_tools.prepare_dynamic_subagents(

--- a/src/omnicoreagent/core/runtime/config.py
+++ b/src/omnicoreagent/core/runtime/config.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import asdict, dataclass, field, fields, is_dataclass, replace
 from enum import Enum
+from os import PathLike
 from typing import Any
 import uuid
 
@@ -96,6 +97,21 @@ def _default_tool_offload() -> dict[str, Any]:
     }
 
 
+def _default_governance_config() -> dict[str, Any]:
+    return {
+        "enabled": False,
+        "profile": "interactive-dev",
+        "policy": None,
+        "policy_path": None,
+        "project_root": None,
+        "approval_resolver": None,
+        "allow_static_high_risk_approvals": False,
+    }
+
+
+GOVERNANCE_CONFIG_KEYS = frozenset(_default_governance_config())
+
+
 @dataclass
 class AgentConfig:
     agent_name: str = "OmniCoreAgent"
@@ -115,6 +131,7 @@ class AgentConfig:
         default_factory=_default_context_management
     )
     tool_offload: dict[str, Any] = field(default_factory=_default_tool_offload)
+    governance_config: dict[str, Any] = field(default_factory=_default_governance_config)
     workspace_config: WorkspaceConfig | dict[str, Any] | None = None
 
     def __post_init__(self):
@@ -128,6 +145,16 @@ class AgentConfig:
             _default_context_management(), self.context_management
         )
         self.tool_offload = _merge_defaults(_default_tool_offload(), self.tool_offload)
+        if not isinstance(self.governance_config, dict):
+            raise ValueError("governance_config must be a dict")
+        _validate_unknown_keys(
+            "governance_config",
+            self.governance_config,
+            GOVERNANCE_CONFIG_KEYS,
+        )
+        self.governance_config = _merge_defaults(
+            _default_governance_config(), self.governance_config
+        )
         if self.workspace_config is not None:
             self.workspace_config = resolve_workspace_config(self.workspace_config)
 
@@ -137,12 +164,22 @@ class AgentConfig:
         )
         _validate_context_management(self.context_management)
         _validate_tool_offload(self.tool_offload)
+        _validate_governance_config(self.governance_config)
 
         if self.enable_subagents:
             self.enable_workspace_files = True
 
     def model_dump(self) -> dict[str, Any]:
-        return asdict(self)
+        data = {}
+        for item in fields(self):
+            value = getattr(self, item.name)
+            if item.name == "governance_config":
+                data[item.name] = dict(value)
+            elif is_dataclass(value):
+                data[item.name] = asdict(value)
+            else:
+                data[item.name] = value
+        return data
 
     def model_copy(self, *, update: dict[str, Any] | None = None) -> AgentConfig:
         return replace(self, **(update or {}))
@@ -219,6 +256,18 @@ def _merge_defaults(defaults: dict[str, Any], value: dict[str, Any] | None) -> d
     return {**defaults, **value}
 
 
+def _validate_unknown_keys(
+    name: str,
+    value: dict[str, Any],
+    allowed_keys: frozenset[str],
+) -> None:
+    unknown = set(value) - allowed_keys
+    if unknown:
+        allowed = ", ".join(sorted(allowed_keys))
+        found = ", ".join(sorted(unknown))
+        raise ValueError(f"{name} has unknown keys: {found}. Allowed keys: {allowed}")
+
+
 def _validate_range(name: str, value: int, *, minimum: int, maximum: int):
     if value < minimum or value > maximum:
         raise ValueError(f"{name} must be between {minimum} and {maximum}, got {value}")
@@ -288,3 +337,36 @@ def _validate_tool_offload(value: dict[str, Any]):
         raise ValueError(
             f"tool_offload.retention_days must be non-negative, got {retention_days}"
         )
+
+
+def _validate_governance_config(value: dict[str, Any]):
+    if not isinstance(value, dict):
+        raise ValueError("governance_config must be a dict")
+    if not isinstance(value.get("enabled", False), bool):
+        raise ValueError("governance_config.enabled must be a boolean")
+    if not isinstance(value.get("allow_static_high_risk_approvals", False), bool):
+        raise ValueError(
+            "governance_config.allow_static_high_risk_approvals must be a boolean"
+        )
+    profile = value.get("profile", "interactive-dev")
+    if profile not in {"permissive-dev", "interactive-dev", "strict-production"}:
+        raise ValueError(
+            "governance_config.profile must be one of "
+            "{'permissive-dev', 'interactive-dev', 'strict-production'}"
+        )
+    if value.get("policy") is not None and value.get("policy_path") is not None:
+        raise ValueError("governance_config cannot set both policy and policy_path")
+    policy = value.get("policy")
+    if policy is not None and not isinstance(policy, dict):
+        try:
+            from omnicoreagent.governance import PolicyEnvelope
+
+            valid_policy = isinstance(policy, PolicyEnvelope)
+        except Exception:
+            valid_policy = False
+        if not valid_policy:
+            raise ValueError("governance_config.policy must be a dict or PolicyEnvelope")
+    for key in ("policy_path", "project_root"):
+        path_value = value.get(key)
+        if path_value is not None and not isinstance(path_value, (str, PathLike)):
+            raise ValueError(f"governance_config.{key} must be a string or path-like")

--- a/src/omnicoreagent/core/runtime/construction.py
+++ b/src/omnicoreagent/core/runtime/construction.py
@@ -83,6 +83,34 @@ def create_react_agent(
     agent_settings: Any,
     guardrail: Any,
     guardrail_mode: str,
+    governance_engine: Any = None,
 ) -> Any:
     tool_guardrail = guardrail if guardrail_mode == "full" else None
-    return runtime("ReactAgent")(config=agent_settings, guardrail=tool_guardrail)
+    return runtime("ReactAgent")(
+        config=agent_settings,
+        guardrail=tool_guardrail,
+        governance_engine=governance_engine,
+    )
+
+
+def build_governance_engine(agent_config: dict[str, Any], telemetry_recorder: Any = None) -> Any:
+    governance_config = agent_config.get("governance_config") or {}
+    if not governance_config.get("enabled", False):
+        return None
+
+    from omnicoreagent.governance import GovernanceEngine, load_policy
+
+    policy = load_policy(
+        policy=governance_config.get("policy"),
+        explicit_path=governance_config.get("policy_path"),
+        project_root=governance_config.get("project_root"),
+        profile=governance_config.get("profile", "interactive-dev"),
+    )
+    return GovernanceEngine(
+        policy,
+        approval_resolver=governance_config.get("approval_resolver"),
+        telemetry_recorder=telemetry_recorder,
+        allow_static_high_risk_approvals=governance_config.get(
+            "allow_static_high_risk_approvals", False
+        ),
+    )

--- a/src/omnicoreagent/core/runtime/omnicore_agent.py
+++ b/src/omnicoreagent/core/runtime/omnicore_agent.py
@@ -139,6 +139,7 @@ class OmniCoreAgent:
             guardrail=self.guardrail,
             guardrail_mode=self.guardrail_mode,
             summarize_fn=self._summarize_history,
+            telemetry_recorder=self.telemetry_recorder,
             debug=self.debug,
         )
 

--- a/src/omnicoreagent/core/subagents.py
+++ b/src/omnicoreagent/core/subagents.py
@@ -128,6 +128,9 @@ When you have completed the task:
             if tool.name == "spawn_subagents":
                 continue
             registry.register(tool)
+            provider = self.local_tools.get_tool_provider(tool.name)
+            if provider in {"workspace", "artifact"}:
+                registry.mark_internal_tool_provider(tool.name, provider)
         return registry
 
     def create_subagent(

--- a/src/omnicoreagent/core/tools/local_tools_registry.py
+++ b/src/omnicoreagent/core/tools/local_tools_registry.py
@@ -16,6 +16,8 @@ class Tool:
         self.description = description
         self.inputSchema = inputSchema
         self.function = function
+        self.provider = "local"
+        self.internal_provider = False
         self.is_async = asyncio.iscoroutinefunction(function)
 
     def to_dict(self) -> dict[str, Any]:
@@ -24,6 +26,8 @@ class Tool:
             "description": self.description,
             "inputSchema": self.inputSchema,
             "function": self.function,
+            "provider": self.provider,
+            "internal_provider": self.internal_provider,
         }
 
     async def execute(self, parameters: dict[str, Any]) -> Any:
@@ -53,6 +57,7 @@ class ToolRegistry:
 
     def __init__(self):
         self.tools: dict[str, Tool] = {}
+        self._internal_tool_providers: dict[str, str] = {}
 
     def __str__(self):
         """Return a readable string representation of the ToolRegistry."""
@@ -75,7 +80,10 @@ class ToolRegistry:
                 f"got {type(tool)}"
             )
 
+        tool.provider = "local"
+        tool.internal_provider = False
         self.tools[tool.name.lower()] = tool
+        self._internal_tool_providers.pop(tool.name.lower(), None)
 
     def merge(self, other_registry: "ToolRegistry"):
         """Merge tools from another registry into this one."""
@@ -104,12 +112,29 @@ class ToolRegistry:
                 function=func,
             )
             self.tools[tool_name.lower()] = tool
+            self._internal_tool_providers.pop(tool_name.lower(), None)
             return func
 
         return decorator
 
     def get_tool(self, name: str) -> Tool | None:
         return self.tools.get(name.lower())
+
+    def mark_internal_tool_provider(self, name: str, provider: str) -> None:
+        tool = self.get_tool(name)
+        if tool is None:
+            raise ValueError(f"Tool '{name}' not found")
+        normalized_provider = provider.strip().lower()
+        if normalized_provider not in {"workspace", "artifact"}:
+            raise ValueError(
+                "internal tool provider must be either 'workspace' or 'artifact'"
+            )
+        self._internal_tool_providers[name.lower()] = normalized_provider
+        tool.provider = normalized_provider
+        tool.internal_provider = True
+
+    def get_tool_provider(self, name: str) -> str:
+        return self._internal_tool_providers.get(name.lower(), "local")
 
     def list_tools(self) -> list[Tool]:
         return list(self.tools.values())

--- a/src/omnicoreagent/core/tools/tool_batch_events.py
+++ b/src/omnicoreagent/core/tools/tool_batch_events.py
@@ -23,13 +23,19 @@ def build_tool_batch_name(tool_call_results: list[ToolCallResult]) -> str:
 
 def build_tool_batch_args(
     tool_call_results: list[ToolCallResult],
+    *,
+    redact: bool = False,
 ) -> list[dict[str, Any]]:
+    if redact:
+        return [_redacted_tool_args(single_tool.tool_args) for single_tool in tool_call_results]
     return [single_tool.tool_args for single_tool in tool_call_results]
 
 
 def build_tool_call_history_metadata(
     agent_name: str,
     tool_call_results: list[ToolCallResult],
+    *,
+    redact_args: bool = False,
 ) -> ToolCallMetadata:
     return ToolCallMetadata(
         agent_name=agent_name,
@@ -40,9 +46,39 @@ def build_tool_call_history_metadata(
                 id=single_tool.tool_call_id,
                 function=ToolFunction(
                     name=single_tool.tool_name,
-                    arguments=json.dumps(single_tool.tool_args),
+                    arguments=json.dumps(
+                        _redacted_tool_args(single_tool.tool_args)
+                        if redact_args
+                        else single_tool.tool_args
+                    ),
                 ),
             )
             for single_tool in tool_call_results
         ],
     )
+
+
+def build_tool_call_history_content(
+    response: str,
+    tool_call_results: list[ToolCallResult],
+    *,
+    redact: bool = False,
+) -> str:
+    if not redact:
+        return response
+
+    calls = "\n".join(
+        f"- {single_tool.tool_name}({', '.join(single_tool.tool_args)})"
+        for single_tool in tool_call_results
+    )
+    return (
+        "[GOVERNANCE] Assistant tool-call payload redacted before persistence.\n"
+        "Tool names and argument keys:\n"
+        f"{calls}"
+    )
+
+
+def _redacted_tool_args(tool_args: dict[str, Any]) -> dict[str, str]:
+    if not tool_args:
+        return {}
+    return {key: "[REDACTED]" for key in tool_args}

--- a/src/omnicoreagent/core/tools/tool_batch_runner.py
+++ b/src/omnicoreagent/core/tools/tool_batch_runner.py
@@ -5,6 +5,7 @@ from typing import Any
 from omnicoreagent.core.telemetry import ActorType, SpanStatus, TelemetryActor
 from omnicoreagent.core.tools.tool_batch_events import (
     assign_tool_call_ids,
+    build_tool_call_history_content,
     build_tool_batch_args,
     build_tool_batch_name,
     build_tool_call_history_metadata,
@@ -15,6 +16,12 @@ from omnicoreagent.core.types import (
     ToolCallResult,
 )
 from omnicoreagent.core.logging import logger
+from omnicoreagent.governance.capabilities import tool_authority_requests
+from omnicoreagent.governance.errors import (
+    GovernanceError,
+    PolicyDeniedError,
+    UngovernedCapabilityError,
+)
 
 TOOL_CALL_TIMEOUT_MESSAGE = (
     "Tool call timed out. Please try again or use a different approach."
@@ -24,19 +31,31 @@ TOOL_CALL_TIMEOUT_MESSAGE = (
 class ToolBatchRunner:
     """Run resolved tool calls as a single parallel batch."""
 
-    def __init__(self, agent_name: str, tool_call_timeout: int):
+    def __init__(
+        self,
+        agent_name: str,
+        tool_call_timeout: int,
+        governance_engine: Any = None,
+    ):
         self.agent_name = agent_name
         self.tool_call_timeout = tool_call_timeout
+        self.governance_engine = governance_engine
 
     def build_error_results(
         self,
         tool_call_results: list[ToolCallResult],
         error_message: str,
+        *,
+        redact_args: bool = False,
     ) -> list[dict[str, Any]]:
         return [
             {
                 "tool_name": getattr(single_tool, "tool_name", "unknown"),
-                "args": getattr(single_tool, "tool_args", {}),
+                "args": (
+                    _redacted_args(getattr(single_tool, "tool_args", {}))
+                    if redact_args
+                    else getattr(single_tool, "tool_args", {})
+                ),
                 "status": "error",
                 "data": None,
                 "message": error_message,
@@ -56,22 +75,33 @@ class ToolBatchRunner:
         record_history: bool = True,
         emit_telemetry: bool = True,
     ) -> list[dict[str, Any]]:
+        governance_enabled = self.governance_engine is not None
         for single_tool in tool_call_results:
+            tool_args = (
+                _redacted_args(single_tool.tool_args)
+                if governance_enabled
+                else single_tool.tool_args
+            )
             session_state.loop_detector.record_tool_call(
                 str(single_tool.tool_name),
-                str(single_tool.tool_args),
+                str(tool_args),
                 error_message,
             )
 
         if record_history:
             for single_tool in tool_call_results:
+                tool_args = (
+                    _redacted_args(single_tool.tool_args)
+                    if governance_enabled
+                    else single_tool.tool_args
+                )
                 await add_message_to_history(
                     role="tool",
                     content=error_message,
                     metadata={
                         "tool_call_id": single_tool.tool_call_id,
                         "tool": single_tool.tool_name,
-                        "args": single_tool.tool_args,
+                        "args": tool_args,
                         "agent_name": self.agent_name,
                     },
                     session_id=session_id,
@@ -88,6 +118,7 @@ class ToolBatchRunner:
         return self.build_error_results(
             tool_call_results=tool_call_results,
             error_message=error_message,
+            redact_args=governance_enabled,
         )
 
     async def start(
@@ -100,20 +131,30 @@ class ToolBatchRunner:
         telemetry_recorder: Any = None,
     ) -> tuple[str, list[dict[str, Any]]]:
         tool_batch_name = build_tool_batch_name(tool_call_results)
-        tool_batch_args = build_tool_batch_args(tool_call_results)
+        governance_enabled = self.governance_engine is not None
+        tool_batch_args = build_tool_batch_args(
+            tool_call_results,
+            redact=governance_enabled,
+        )
         assign_tool_call_ids(tool_call_results)
         tool_calls_metadata = build_tool_call_history_metadata(
             agent_name=self.agent_name,
             tool_call_results=tool_call_results,
+            redact_args=governance_enabled,
+        )
+        history_content = build_tool_call_history_content(
+            response,
+            tool_call_results,
+            redact=governance_enabled,
         )
 
         await add_message_to_history(
             role="assistant",
-            content=response,
+            content=history_content,
             metadata=tool_calls_metadata.model_dump(),
             session_id=session_id,
         )
-        session_state.messages.append(Message(role="assistant", content=response))
+        session_state.messages.append(Message(role="assistant", content=history_content))
 
         return tool_batch_name, tool_batch_args
 
@@ -394,23 +435,38 @@ class ToolBatchRunner:
         telemetry_recorder: Any = None,
     ) -> dict[str, Any]:
         if telemetry_recorder is None:
-            return await single_tool.tool_executor.execute(
+            governance_error = await self._authorize_single_tool(single_tool)
+            if governance_error is not None:
+                return await self._governance_error_result(
+                    single_tool=single_tool,
+                    governance_error=governance_error,
+                    add_message_to_history=add_message_to_history,
+                    session_id=session_id,
+                )
+            result = await single_tool.tool_executor.execute(
                 agent_name=self.agent_name,
                 tool_args=single_tool.tool_args,
                 tool_name=single_tool.tool_name,
                 tool_call_id=single_tool.tool_call_id,
-                add_message_to_history=add_message_to_history,
+                add_message_to_history=_governed_history_writer(
+                    add_message_to_history,
+                    redact_args=self.governance_engine is not None,
+                ),
                 session_id=session_id,
             )
+            if self.governance_engine is not None:
+                return _redact_tool_result_args(result)
+            return result
 
         telemetry_shape = _tool_telemetry_shape(single_tool)
         telemetry_input = {
             "tool_name": single_tool.tool_name,
-            "tool_args": single_tool.tool_args,
             "tool_call_id": single_tool.tool_call_id,
             "tool_provider": single_tool.tool_provider,
             "tool_server": single_tool.tool_server,
         }
+        if self.governance_engine is None:
+            telemetry_input["tool_args"] = single_tool.tool_args
         span = await telemetry_recorder.start_span(
             name=single_tool.tool_name,
             kind=telemetry_shape["span_kind"],
@@ -418,6 +474,36 @@ class ToolBatchRunner:
             input=telemetry_input,
         )
         try:
+            governance_error = await self._authorize_single_tool(single_tool)
+            if governance_error is not None:
+                result = await self._governance_error_result(
+                    single_tool=single_tool,
+                    governance_error=governance_error,
+                    add_message_to_history=add_message_to_history,
+                    session_id=session_id,
+                )
+                await telemetry_recorder.emit_event(
+                    telemetry_shape["error_event"],
+                    actor=telemetry_shape["actor"],
+                    input=telemetry_input
+                    if telemetry_shape["single_event"]
+                    else None,
+                    output=result,
+                    error={
+                        "type": governance_error.__class__.__name__,
+                        "message": str(governance_error),
+                    },
+                )
+                await telemetry_recorder.end_span(
+                    span.span_id,
+                    status=SpanStatus.ERROR,
+                    output=result,
+                    error={
+                        "type": governance_error.__class__.__name__,
+                        "message": str(governance_error),
+                    },
+                )
+                return result
             if not telemetry_shape["single_event"]:
                 await telemetry_recorder.emit_event(
                     telemetry_shape["call_event"],
@@ -429,13 +515,22 @@ class ToolBatchRunner:
                 tool_args=single_tool.tool_args,
                 tool_name=single_tool.tool_name,
                 tool_call_id=single_tool.tool_call_id,
-                add_message_to_history=add_message_to_history,
+                add_message_to_history=_governed_history_writer(
+                    add_message_to_history,
+                    redact_args=self.governance_engine is not None,
+                ),
                 session_id=session_id,
+            )
+            if self.governance_engine is not None:
+                result = _redact_tool_result_args(result)
+            telemetry_result = _telemetry_tool_result(
+                result,
+                redact_args=self.governance_engine is not None,
             )
             if result.get("status") == "error":
                 event_kwargs = {
                     "actor": telemetry_shape["actor"],
-                    "output": result,
+                    "output": telemetry_result,
                     "error": {
                         "type": "ToolError",
                         "message": result.get("message") or "Tool returned error",
@@ -450,14 +545,17 @@ class ToolBatchRunner:
                 await telemetry_recorder.end_span(
                     span.span_id,
                     status=SpanStatus.ERROR,
-                    output=result,
+                    output=telemetry_result,
                     error={
                         "type": "ToolError",
                         "message": result.get("message") or "Tool returned error",
                     },
                 )
             else:
-                event_kwargs = {"actor": telemetry_shape["actor"], "output": result}
+                event_kwargs = {
+                    "actor": telemetry_shape["actor"],
+                    "output": telemetry_result,
+                }
                 if telemetry_shape["single_event"]:
                     event_kwargs["input"] = telemetry_input
                 await telemetry_recorder.emit_event(
@@ -467,7 +565,7 @@ class ToolBatchRunner:
                 await telemetry_recorder.end_span(
                     span.span_id,
                     status=SpanStatus.OK,
-                    output=result,
+                    output=telemetry_result,
                 )
             return result
         except Exception as exc:
@@ -490,6 +588,73 @@ class ToolBatchRunner:
                 error={"type": exc.__class__.__name__, "message": str(exc)},
             )
             raise
+
+    async def _authorize_single_tool(
+        self,
+        single_tool: ToolCallResult,
+    ) -> GovernanceError | None:
+        if self.governance_engine is None:
+            return None
+        if single_tool.tool_provider == "mcp":
+            return UngovernedCapabilityError(
+                "MCP governance is not implemented until the MCP enforcement phase.",
+                metadata={
+                    "tool": single_tool.tool_name,
+                    "tool_provider": single_tool.tool_provider,
+                    "tool_server": single_tool.tool_server,
+                    "reason_code": "ungoverned_capability",
+                },
+            )
+        try:
+            requests = tool_authority_requests(
+                tool_name=single_tool.tool_name,
+                tool_args=single_tool.tool_args,
+                tool_provider=single_tool.tool_provider,
+                tool_server=single_tool.tool_server,
+                actor=self.agent_name,
+            )
+            await self.governance_engine.authorize_all(requests)
+        except (GovernanceError, ValueError) as exc:
+            if isinstance(exc, GovernanceError):
+                return exc
+            return PolicyDeniedError(str(exc))
+        return None
+
+    async def _governance_error_result(
+        self,
+        *,
+        single_tool: ToolCallResult,
+        governance_error: GovernanceError,
+        add_message_to_history: Callable[[str, str, dict | None], Any],
+        session_id: str | None,
+    ) -> dict[str, Any]:
+        message = f"Governance denied tool execution: {governance_error}"
+        metadata = {
+            "tool_call_id": single_tool.tool_call_id,
+            "tool": single_tool.tool_name,
+            "args": "[REDACTED]",
+            "agent_name": self.agent_name,
+            "governance_error_code": getattr(
+                governance_error,
+                "code",
+                governance_error.__class__.__name__,
+            ),
+            "governance": getattr(governance_error, "metadata", {}),
+        }
+        await add_message_to_history(
+            role="tool",
+            content=message,
+            metadata=metadata,
+            session_id=session_id,
+        )
+        return {
+            "tool_name": single_tool.tool_name,
+            "args": {},
+            "status": "error",
+            "data": None,
+            "message": message,
+            "governance": metadata["governance"],
+        }
 
 
 def _tool_telemetry_shape(single_tool: ToolCallResult) -> dict[str, Any]:
@@ -570,3 +735,56 @@ def _artifact_tool_telemetry_shape(tool_name: str) -> dict[str, Any] | None:
         "single_event": True,
         "actor": TelemetryActor(type=ActorType.WORKSPACE, name=tool_name),
     }
+
+
+def _telemetry_tool_result(
+    result: dict[str, Any],
+    *,
+    redact_args: bool,
+) -> dict[str, Any]:
+    if not redact_args or "args" not in result:
+        return result
+    sanitized = dict(result)
+    sanitized["args"] = "[REDACTED]"
+    return sanitized
+
+
+def _redact_tool_result_args(result: dict[str, Any]) -> dict[str, Any]:
+    if "args" not in result:
+        return result
+    sanitized = dict(result)
+    sanitized["args"] = "[REDACTED]"
+    return sanitized
+
+
+def _redacted_args(tool_args: dict[str, Any]) -> dict[str, str]:
+    if not tool_args:
+        return {}
+    return {key: "[REDACTED]" for key in tool_args}
+
+
+def _governed_history_writer(
+    add_message_to_history: Callable[[str, str, dict | None], Any],
+    *,
+    redact_args: bool,
+) -> Callable[[str, str, dict | None], Any]:
+    if not redact_args:
+        return add_message_to_history
+
+    async def add_redacted_message(
+        role: str,
+        content: str,
+        metadata: dict | None = None,
+        session_id: str | None = None,
+    ) -> Any:
+        if metadata and "args" in metadata:
+            metadata = dict(metadata)
+            metadata["args"] = "[REDACTED]"
+        return await add_message_to_history(
+            role=role,
+            content=content,
+            metadata=metadata,
+            session_id=session_id,
+        )
+
+    return add_redacted_message

--- a/src/omnicoreagent/core/tools/tool_call_resolver.py
+++ b/src/omnicoreagent/core/tools/tool_call_resolver.py
@@ -14,10 +14,6 @@ from omnicoreagent.core.tools.arguments import normalize_tool_args
 if TYPE_CHECKING:
     from omnicoreagent.core.guardrails import PromptInjectionGuard
 
-WORKSPACE_TOOL_MARKER = "_omnicoreagent_builtin_workspace_tool"
-ARTIFACT_TOOL_MARKER = "_omnicoreagent_builtin_artifact_tool"
-
-
 class ToolCallResolver:
     """Resolve model tool-call requests into executable tool calls."""
 
@@ -79,11 +75,10 @@ class ToolCallResolver:
             return None
 
         tool_provider = "local"
-        tool = local_tools.get_tool(local_tool_name)
-        if tool and getattr(tool.function, WORKSPACE_TOOL_MARKER, False):
-            tool_provider = "workspace"
-        elif tool and getattr(tool.function, ARTIFACT_TOOL_MARKER, False):
-            tool_provider = "artifact"
+        if hasattr(local_tools, "get_tool_provider"):
+            provider = local_tools.get_tool_provider(local_tool_name)
+            if provider in {"workspace", "artifact"}:
+                tool_provider = provider
 
         local_tool_handler = LocalToolHandler(local_tools=local_tools)
         return ToolCallResult(

--- a/src/omnicoreagent/core/tools/tool_failure_handler.py
+++ b/src/omnicoreagent/core/tools/tool_failure_handler.py
@@ -52,18 +52,24 @@ def handle_stuck_state(
 class ToolFailureHandler:
     """Handle failed tool resolution and repeated tool-call loops."""
 
-    def __init__(self, agent_name: str):
+    def __init__(self, agent_name: str, governance_enabled: bool = False):
         self.agent_name = agent_name
+        self.governance_enabled = governance_enabled
 
     def build_validation_error_results(
         self,
         tool_errors: list[ToolError],
         fallback_message: str,
+        redact_args: bool = False,
     ) -> list[dict[str, Any]]:
         return [
             {
                 "tool_name": getattr(single_tool, "tool_name", "unknown"),
-                "args": getattr(single_tool, "tool_args", {}),
+                "args": (
+                    _redacted_tool_args(getattr(single_tool, "tool_args", {}))
+                    if redact_args
+                    else getattr(single_tool, "tool_args", {})
+                ),
                 "status": "error",
                 "data": None,
                 "message": getattr(single_tool, "observation", fallback_message),
@@ -84,25 +90,33 @@ class ToolFailureHandler:
         for single_tool in tool_errors:
             tool_name = getattr(single_tool, "tool_name", "unknown")
             tool_args = getattr(single_tool, "tool_args", {})
+            persisted_tool_args = (
+                _redacted_tool_args(tool_args) if self.governance_enabled else tool_args
+            )
             error_message = getattr(single_tool, "observation", obs_text)
 
             if telemetry_recorder is not None:
                 await telemetry_recorder.emit_event(
                     "tool_error",
                     actor=TelemetryActor(type=ActorType.TOOL, name=str(tool_name)),
-                    input={"tool_name": tool_name, "tool_args": tool_args},
+                    input={"tool_name": tool_name, "tool_args": persisted_tool_args},
                     error={"type": "ToolValidationError", "message": error_message},
                 )
             session_state.loop_detector.record_tool_call(
                 str(tool_name),
-                str(tool_args),
+                str(persisted_tool_args),
                 str(error_message),
             )
 
         tool_batch_name = ", ".join(
             [getattr(tool, "tool_name", "unknown") for tool in tool_errors]
         )
-        tool_batch_args = [getattr(tool, "tool_args", {}) for tool in tool_errors]
+        tool_batch_args = [
+            _redacted_tool_args(getattr(tool, "tool_args", {}))
+            if self.governance_enabled
+            else getattr(tool, "tool_args", {})
+            for tool in tool_errors
+        ]
 
         logger.error(
             f"Tool call validation failed for: {tool_batch_name} "
@@ -116,6 +130,7 @@ class ToolFailureHandler:
             self.build_validation_error_results(
                 tool_errors=tool_errors,
                 fallback_message=obs_text,
+                redact_args=self.governance_enabled,
             ),
         )
 
@@ -182,3 +197,9 @@ class ToolFailureHandler:
 
             session_state.state = AgentState.STUCK
             session_state.loop_detector.reset(tool_name)
+
+
+def _redacted_tool_args(tool_args: dict[str, Any]) -> dict[str, str]:
+    if not tool_args:
+        return {}
+    return {key: "[REDACTED]" for key in tool_args}

--- a/src/omnicoreagent/core/workspace/artifact_tools.py
+++ b/src/omnicoreagent/core/workspace/artifact_tools.py
@@ -16,6 +16,10 @@ from omnicoreagent.core.workspace.artifacts import ToolResponseOffloader
 ARTIFACT_TOOL_MARKER = "_omnicoreagent_builtin_artifact_tool"
 
 
+def _mark_artifact_tool(registry: ToolRegistry, name: str) -> None:
+    registry.mark_internal_tool_provider(name, "artifact")
+
+
 def build_tool_registry_artifact_tool(
     offloader: ToolResponseOffloader, registry: ToolRegistry
 ) -> ToolRegistry:
@@ -60,6 +64,7 @@ def build_tool_registry_artifact_tool(
             }
         return content
     setattr(read_artifact, ARTIFACT_TOOL_MARKER, True)
+    _mark_artifact_tool(registry, "read_artifact")
 
     @registry.register_tool(
         name="tail_artifact",
@@ -96,6 +101,7 @@ def build_tool_registry_artifact_tool(
             }
         return content
     setattr(tail_artifact, ARTIFACT_TOOL_MARKER, True)
+    _mark_artifact_tool(registry, "tail_artifact")
 
     @registry.register_tool(
         name="search_artifact",
@@ -132,6 +138,7 @@ def build_tool_registry_artifact_tool(
             }
         return content
     setattr(search_artifact, ARTIFACT_TOOL_MARKER, True)
+    _mark_artifact_tool(registry, "search_artifact")
 
     @registry.register_tool(
         name="list_artifacts",
@@ -164,5 +171,6 @@ def build_tool_registry_artifact_tool(
 
         return "\n".join(lines)
     setattr(list_artifacts, ARTIFACT_TOOL_MARKER, True)
+    _mark_artifact_tool(registry, "list_artifacts")
 
     return registry

--- a/src/omnicoreagent/core/workspace/paths.py
+++ b/src/omnicoreagent/core/workspace/paths.py
@@ -20,6 +20,8 @@ def normalize_workspace_path(
         return ""
 
     decoded = urllib.parse.unquote(str(path)).strip().lstrip("/")
+    while decoded.startswith("./"):
+        decoded = decoded[2:]
     for prefix in strip_prefixes:
         clean_prefix = prefix.strip("/")
         if decoded == clean_prefix:

--- a/src/omnicoreagent/core/workspace/tools.py
+++ b/src/omnicoreagent/core/workspace/tools.py
@@ -120,11 +120,7 @@ def _register_workspace_tool(
     function: Callable[..., Any],
 ) -> None:
     existing = registry.get_tool(name)
-    if existing and not getattr(
-        existing.function,
-        WORKSPACE_TOOL_MARKER,
-        False,
-    ):
+    if existing and registry.get_tool_provider(name) != "workspace":
         raise ValueError(
             f"Tool name conflict: '{name}' is reserved for built-in workspace tools "
             "when enable_workspace_files=True. Rename the app tool or disable "
@@ -137,6 +133,9 @@ def _register_workspace_tool(
         description=description,
         inputSchema=inputSchema,
     )(function)
+    registered = registry.get_tool(name)
+    if registered is not None:
+        registry.mark_internal_tool_provider(name, "workspace")
 
 
 def build_tool_registry_workspace_files(
@@ -450,7 +449,7 @@ def validate_workspace_tool_name_conflicts(registry: ToolRegistry) -> None:
     conflicts = []
     for name in sorted(WORKSPACE_COMMAND_TOOL_NAMES):
         existing = registry.get_tool(name)
-        if existing and not getattr(existing.function, WORKSPACE_TOOL_MARKER, False):
+        if existing and registry.get_tool_provider(name) != "workspace":
             conflicts.append(name)
 
     if conflicts:

--- a/src/omnicoreagent/governance/__init__.py
+++ b/src/omnicoreagent/governance/__init__.py
@@ -3,6 +3,12 @@ from omnicoreagent.governance.approvals import (
     DenyAllApprovalResolver,
     StaticApprovalResolver,
 )
+from omnicoreagent.governance.capabilities import (
+    tool_authority_request,
+    tool_authority_requests,
+    tool_capability_descriptor,
+    tool_capability_name,
+)
 from omnicoreagent.governance.defaults import build_default_policy
 from omnicoreagent.governance.enforcement import GovernanceEngine
 from omnicoreagent.governance.errors import (
@@ -14,6 +20,7 @@ from omnicoreagent.governance.errors import (
     PolicyEvaluationError,
     PolicyLoadError,
     SandboxRequiredError,
+    UngovernedCapabilityError,
     UnknownCapabilityError,
 )
 from omnicoreagent.governance.evaluator import PolicyEvaluator
@@ -89,6 +96,7 @@ __all__ = [
     "SandboxRequiredError",
     "StaticApprovalResolver",
     "TargetMatcher",
+    "UngovernedCapabilityError",
     "UnknownCapabilityError",
     "attach_policy_hash",
     "build_default_policy",
@@ -98,4 +106,8 @@ __all__ = [
     "load_policy_file",
     "policy_from_mapping",
     "policy_hash",
+    "tool_authority_request",
+    "tool_authority_requests",
+    "tool_capability_descriptor",
+    "tool_capability_name",
 ]

--- a/src/omnicoreagent/governance/capabilities.py
+++ b/src/omnicoreagent/governance/capabilities.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from typing import Any
+
+from omnicoreagent.core.workspace.paths import (
+    WORKSPACE_FILE_PATH_PREFIXES,
+    normalize_workspace_path,
+)
+from omnicoreagent.governance.models import (
+    AuthorityRequest,
+    AuthorityTarget,
+    CapabilityDescriptor,
+)
+
+
+WORKSPACE_READ_TOOLS = frozenset({"ls", "read_file", "glob", "grep"})
+WORKSPACE_WRITE_TOOLS = frozenset({"write_file", "edit_file", "insert_file"})
+WORKSPACE_DELETE_TOOLS = frozenset({"delete_file", "clear_files"})
+WORKSPACE_MOVE_TOOLS = frozenset({"move_file"})
+ARTIFACT_READ_TOOLS = frozenset(
+    {"read_artifact", "tail_artifact", "search_artifact", "list_artifacts"}
+)
+
+
+def tool_capability_descriptor(
+    *,
+    tool_name: str,
+    tool_provider: str = "local",
+    tool_server: str | None = None,
+) -> CapabilityDescriptor:
+    capability = tool_capability_name(tool_name=tool_name, tool_provider=tool_provider)
+    return CapabilityDescriptor(
+        capability=capability,
+        provider=tool_provider,
+        execution_surface=_execution_surface(tool_provider),
+        descriptor_source=(
+            "mcp_schema"
+            if tool_provider == "mcp"
+            else "builtin"
+            if tool_provider in {"workspace", "artifact"}
+            else "app_code"
+        ),
+        descriptor_trust="trusted" if tool_provider != "mcp" else "untrusted",
+        risk_level=tool_risk_level(tool_name=tool_name, tool_provider=tool_provider),
+        metadata={
+            "tool_name": tool_name,
+            "tool_provider": tool_provider,
+            "tool_server": tool_server,
+        },
+    )
+
+
+def tool_authority_request(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    tool_provider: str = "local",
+    tool_server: str | None = None,
+    actor: str = "agent",
+) -> AuthorityRequest:
+    return tool_authority_requests(
+        tool_name=tool_name,
+        tool_args=tool_args,
+        tool_provider=tool_provider,
+        tool_server=tool_server,
+        actor=actor,
+    )[0]
+
+
+def tool_authority_requests(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    tool_provider: str = "local",
+    tool_server: str | None = None,
+    actor: str = "agent",
+) -> list[AuthorityRequest]:
+    descriptor = tool_capability_descriptor(
+        tool_name=tool_name,
+        tool_provider=tool_provider,
+        tool_server=tool_server,
+    )
+    targets = tool_authority_targets(
+        tool_name=tool_name,
+        tool_args=tool_args,
+        tool_provider=tool_provider,
+        tool_server=tool_server,
+    )
+    return [
+        AuthorityRequest(
+            capability=descriptor.capability,
+            actor=actor,
+            provider=descriptor.provider,
+            execution_surface=descriptor.execution_surface,
+            target=target,
+            risk_level=tool_risk_level(tool_name=tool_name, tool_provider=tool_provider),
+            mcp_server=tool_server if tool_provider == "mcp" else None,
+            metadata={
+                "tool_name": tool_name,
+                "tool_provider": tool_provider,
+                "tool_server": tool_server,
+                "target_role": role,
+            },
+        )
+        for role, target in targets
+    ]
+
+
+def tool_authority_targets(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    tool_provider: str,
+    tool_server: str | None = None,
+) -> list[tuple[str, AuthorityTarget]]:
+    if tool_provider == "workspace":
+        if tool_name == "move_file":
+            return [
+                (
+                    "source",
+                    AuthorityTarget(
+                        path=_normalize_workspace_target(tool_args.get("old_path")),
+                        tool_name=tool_name,
+                    ),
+                ),
+                (
+                    "destination",
+                    AuthorityTarget(
+                        path=_normalize_workspace_target(tool_args.get("new_path")),
+                        tool_name=tool_name,
+                    ),
+                ),
+            ]
+        return [
+            (
+                "scope",
+                AuthorityTarget(
+                    path=_workspace_target_path(tool_name, tool_args),
+                    tool_name=tool_name,
+                ),
+            )
+        ]
+    if tool_provider == "artifact":
+        return [
+            (
+                "artifact",
+                AuthorityTarget(
+                    resource=tool_args.get("artifact_id"),
+                    tool_name=tool_name,
+                ),
+            )
+        ]
+    if tool_provider == "mcp":
+        return [
+            (
+                "mcp_tool",
+                AuthorityTarget(tool_name=tool_name, mcp_server=tool_server),
+            )
+        ]
+    return [("tool", AuthorityTarget(tool_name=tool_name))]
+
+
+def tool_authority_target(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    tool_provider: str,
+    tool_server: str | None = None,
+) -> AuthorityTarget:
+    return tool_authority_targets(
+        tool_name=tool_name,
+        tool_args=tool_args,
+        tool_provider=tool_provider,
+        tool_server=tool_server,
+    )[0][1]
+
+
+def tool_capability_name(*, tool_name: str, tool_provider: str) -> str:
+    if tool_provider == "workspace":
+        if tool_name in WORKSPACE_READ_TOOLS:
+            return "workspace.files.read"
+        if tool_name in WORKSPACE_WRITE_TOOLS:
+            return "workspace.files.write"
+        if tool_name in WORKSPACE_DELETE_TOOLS:
+            if tool_name == "clear_files":
+                return "workspace.files.clear"
+            return "workspace.files.delete"
+        if tool_name in WORKSPACE_MOVE_TOOLS:
+            return "workspace.files.move"
+        return "workspace.files.call"
+    if tool_provider == "artifact":
+        if tool_name in ARTIFACT_READ_TOOLS:
+            return "workspace.artifacts.read"
+        return "workspace.artifacts.call"
+    if tool_provider == "mcp":
+        return "tool.mcp.call"
+    return "tool.local.call"
+
+
+def tool_risk_level(*, tool_name: str, tool_provider: str) -> str:
+    if tool_provider == "workspace":
+        if tool_name == "clear_files":
+            return "critical"
+        if tool_name in WORKSPACE_DELETE_TOOLS:
+            return "high"
+        if tool_name in WORKSPACE_WRITE_TOOLS or tool_name in WORKSPACE_MOVE_TOOLS:
+            return "medium"
+    return "low"
+
+
+def _workspace_target_path(tool_name: str, tool_args: dict[str, Any]) -> str | None:
+    if tool_name in {"grep", "glob"}:
+        return _normalize_workspace_target(tool_args.get("path") or "")
+    return _normalize_workspace_target(tool_args.get("path"))
+
+
+def _normalize_workspace_target(path: Any) -> str | None:
+    if path is None:
+        return None
+    return normalize_workspace_path(
+        path,
+        strip_prefixes=WORKSPACE_FILE_PATH_PREFIXES,
+    )
+
+
+def _execution_surface(tool_provider: str) -> str:
+    if tool_provider == "workspace":
+        return "workspace"
+    if tool_provider == "artifact":
+        return "artifact"
+    if tool_provider == "mcp":
+        return "mcp"
+    return "tool"

--- a/src/omnicoreagent/governance/enforcement.py
+++ b/src/omnicoreagent/governance/enforcement.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
 from omnicoreagent.core.telemetry import TelemetryRecorder
@@ -47,6 +48,7 @@ class GovernanceEngine:
         self.approval_resolver = approval_resolver
         self.telemetry_recorder = telemetry_recorder
         self.allow_static_high_risk_approvals = allow_static_high_risk_approvals
+        self._budget_lock = asyncio.Lock()
 
     async def evaluate(self, request: AuthorityRequest) -> PolicyDecision:
         await emit_policy_request(self.telemetry_recorder, request)
@@ -76,8 +78,75 @@ class GovernanceEngine:
         return decision
 
     async def authorize(self, request: AuthorityRequest) -> PolicyDecision:
-        decision = await self.evaluate(request)
-        if decision.effect == PolicyEffect.DENY:
+        decisions = await self.authorize_all([request])
+        return decisions[0]
+
+    async def authorize_all(
+        self,
+        requests: list[AuthorityRequest],
+    ) -> list[PolicyDecision]:
+        if not requests:
+            return []
+
+        async with self._budget_lock:
+            budget_decision = self._budget_exceeded_decision(requests)
+            if budget_decision is not None:
+                await emit_policy_decision(self.telemetry_recorder, budget_decision)
+                raise BudgetExceededError(
+                    budget_decision.reason,
+                    metadata=_decision_metadata(budget_decision),
+                )
+            decisions = [await self.evaluate(request) for request in requests]
+            self._raise_first_denied(decisions)
+            for decision in decisions:
+                if decision.constraints.sandbox_required:
+                    raise SandboxRequiredError(
+                        "Policy requires routing through the sandbox execution boundary.",
+                        metadata=_decision_metadata(
+                            decision,
+                            reason_code=ReasonCode.SANDBOX_REQUIRED,
+                        ),
+                    )
+
+            ask_indexes = [
+                index
+                for index, decision in enumerate(decisions)
+                if decision.effect == PolicyEffect.ASK
+            ]
+            if not ask_indexes:
+                await self._consume_budget_or_raise_many(requests)
+                return decisions
+
+        for index in ask_indexes:
+            decisions[index] = await self._resolve_approval(
+                requests[index],
+                decisions[index],
+                emit_decision=False,
+            )
+
+        async with self._budget_lock:
+            for decision in decisions:
+                if decision.constraints.sandbox_required:
+                    raise SandboxRequiredError(
+                        "Policy requires routing through the sandbox execution boundary.",
+                        metadata=_decision_metadata(
+                            decision,
+                            reason_code=ReasonCode.SANDBOX_REQUIRED,
+                        ),
+                    )
+            await self._consume_budget_or_raise_many(requests)
+            for index in ask_indexes:
+                await emit_policy_decision(
+                    self.telemetry_recorder,
+                    decisions[index],
+                    strict=decisions[index].constraints.strict_telemetry,
+                )
+        return decisions
+
+    def _raise_first_denied(self, decisions: list[PolicyDecision]) -> None:
+        for decision in decisions:
+            if decision.effect != PolicyEffect.DENY:
+                continue
             if decision.reason_code == ReasonCode.BUDGET_EXCEEDED:
                 raise BudgetExceededError(
                     decision.reason,
@@ -89,23 +158,13 @@ class GovernanceEngine:
                     metadata=_decision_metadata(decision),
                 )
             raise PolicyDeniedError(decision.reason, metadata=_decision_metadata(decision))
-        if decision.effect == PolicyEffect.ASK:
-            decision = await self._resolve_approval(request, decision)
-        if decision.constraints.sandbox_required:
-            raise SandboxRequiredError(
-                "Policy requires routing through the sandbox execution boundary.",
-                metadata=_decision_metadata(
-                    decision,
-                    reason_code=ReasonCode.SANDBOX_REQUIRED,
-                ),
-            )
-        self._consume_budget(request)
-        return decision
 
     async def _resolve_approval(
         self,
         request: AuthorityRequest,
         decision: PolicyDecision,
+        *,
+        emit_decision: bool = True,
     ) -> PolicyDecision:
         approval = ApprovalRequest(
             request_id=request.request_id,
@@ -164,11 +223,12 @@ class GovernanceEngine:
         decision.approval_id = result.approval_id
         decision.reason_code = ReasonCode.MATCHED_ALLOW
         decision.reason = result.reason or "Approved by resolver."
-        await emit_policy_decision(
-            self.telemetry_recorder,
-            decision,
-            strict=decision.constraints.strict_telemetry,
-        )
+        if emit_decision:
+            await emit_policy_decision(
+                self.telemetry_recorder,
+                decision,
+                strict=decision.constraints.strict_telemetry,
+            )
         return decision
 
     def _consume_budget(self, request: AuthorityRequest) -> None:
@@ -177,6 +237,59 @@ class GovernanceEngine:
             return
         budget.used_requests += 1
         budget.used_cost += request.budget_cost
+
+    async def _consume_budget_or_raise(self, request: AuthorityRequest) -> None:
+        await self._consume_budget_or_raise_many([request])
+
+    async def _consume_budget_or_raise_many(
+        self,
+        requests: list[AuthorityRequest],
+    ) -> None:
+        decision = self._budget_exceeded_decision(requests)
+        if decision is not None:
+            await emit_policy_decision(self.telemetry_recorder, decision)
+            raise BudgetExceededError(
+                decision.reason,
+                metadata=_decision_metadata(decision),
+            )
+        for request in requests:
+            self._consume_budget(request)
+
+    def _budget_exceeded_decision(
+        self,
+        requests: list[AuthorityRequest],
+    ) -> PolicyDecision | None:
+        request = requests[0]
+        budget = self.policy.budget
+        if budget is None:
+            return None
+        request_count = len(requests)
+        budget_cost = sum(item.budget_cost for item in requests)
+        if (
+            budget.max_requests is not None
+            and budget.used_requests + request_count > budget.max_requests
+        ):
+            return PolicyDecision(
+                effect=PolicyEffect.DENY,
+                request_id=request.request_id,
+                policy_id=self.policy.policy_id,
+                policy_hash=self.policy.provenance.policy_hash,
+                reason_code=ReasonCode.BUDGET_EXCEEDED,
+                reason="Policy request budget exceeded.",
+            )
+        if (
+            budget.max_cost is not None
+            and budget.used_cost + budget_cost > budget.max_cost
+        ):
+            return PolicyDecision(
+                effect=PolicyEffect.DENY,
+                request_id=request.request_id,
+                policy_id=self.policy.policy_id,
+                policy_hash=self.policy.provenance.policy_hash,
+                reason_code=ReasonCode.BUDGET_EXCEEDED,
+                reason="Policy cost budget exceeded.",
+            )
+        return None
 
 
 def _decision_metadata(

--- a/src/omnicoreagent/governance/errors.py
+++ b/src/omnicoreagent/governance/errors.py
@@ -58,3 +58,9 @@ class UnknownCapabilityError(GovernanceError):
     """Raised when an unknown capability is denied by policy."""
 
     code = "unknown_capability"
+
+
+class UngovernedCapabilityError(GovernanceError):
+    """Raised when a runtime surface is not governed in the current phase."""
+
+    code = "ungoverned_capability"

--- a/tests/test_governance_core.py
+++ b/tests/test_governance_core.py
@@ -1,9 +1,18 @@
+import asyncio
 import json
 from datetime import timedelta
 
 import pytest
 
-from omnicoreagent.core.telemetry import TelemetryActor, TelemetryEvent
+from omnicoreagent.core.telemetry import (
+    ActorType,
+    InMemoryTelemetryStore,
+    TelemetryActor,
+    TelemetryEvent,
+    TelemetryRecorder,
+)
+from omnicoreagent.core.runtime.config import AgentConfig
+from omnicoreagent import OmniCoreAgent
 from omnicoreagent.governance import (
     ApprovalExpiredError,
     ApprovalRequiredError,
@@ -32,6 +41,10 @@ from omnicoreagent.governance import (
     load_policy_file,
     policy_from_mapping,
     policy_hash,
+    tool_authority_request,
+    tool_authority_requests,
+    tool_capability_descriptor,
+    tool_capability_name,
 )
 from omnicoreagent.governance.models import utc_now
 
@@ -53,6 +66,16 @@ class ExpiredApprovalResolver:
             approval_id=request.approval_id,
             resolved_by="expired",
             resolved_at=utc_now() + timedelta(seconds=10),
+        )
+
+
+class AsyncApprovalResolver:
+    async def resolve(self, request):
+        await asyncio.sleep(0)
+        return ApprovalResult(
+            approved=True,
+            approval_id=request.approval_id,
+            resolved_by="async-test",
         )
 
 
@@ -485,6 +508,108 @@ async def test_governance_engine_uses_approval_resolver_for_ask_decision():
 
 
 @pytest.mark.asyncio
+async def test_governance_engine_rechecks_budget_after_parallel_approvals():
+    policy = _policy()
+    policy.budget = {"max_requests": 1}
+    policy.__post_init__()
+    engine = GovernanceEngine(policy, approval_resolver=AsyncApprovalResolver())
+
+    results = await asyncio.gather(
+        engine.authorize(AuthorityRequest(capability="process.exec")),
+        engine.authorize(AuthorityRequest(capability="process.exec")),
+        return_exceptions=True,
+    )
+
+    allowed = [result for result in results if not isinstance(result, Exception)]
+    denied = [result for result in results if isinstance(result, BudgetExceededError)]
+    assert len(allowed) == 1
+    assert len(denied) == 1
+    assert policy.budget is not None
+    assert policy.budget.used_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_governance_engine_authorize_all_does_not_consume_on_partial_denial():
+    policy = _policy()
+    policy.budget = {"max_requests": 2}
+    policy.__post_init__()
+    engine = GovernanceEngine(policy)
+
+    with pytest.raises(PolicyDeniedError):
+        await engine.authorize_all(
+            [
+                AuthorityRequest(capability="workspace.files.write"),
+                AuthorityRequest(capability="secret.read"),
+            ]
+        )
+
+    assert policy.budget is not None
+    assert policy.budget.used_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_governance_engine_authorize_all_budget_denial_does_not_emit_allows():
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    await recorder.start_trace(
+        trace_id="trace-budget-batch-deny",
+        actor=TelemetryActor(type=ActorType.SYSTEM, name="governance-test"),
+    )
+    policy = _policy()
+    policy.budget = {"max_requests": 1}
+    policy.__post_init__()
+    engine = GovernanceEngine(policy, telemetry_recorder=recorder)
+
+    with pytest.raises(BudgetExceededError):
+        await engine.authorize_all(
+            [
+                AuthorityRequest(capability="workspace.files.read"),
+                AuthorityRequest(capability="workspace.files.write"),
+            ]
+        )
+    await recorder.end_trace()
+
+    trace = await store.get_trace("trace-budget-batch-deny")
+    assert trace is not None
+    event_types = [event.event_type for event in trace.events]
+    assert "policy_decision_deny" in event_types
+    assert "policy_decision_allow" not in event_types
+
+
+@pytest.mark.asyncio
+async def test_governance_engine_approved_batch_budget_denial_does_not_emit_allows():
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    await recorder.start_trace(
+        trace_id="trace-approved-budget-batch-deny",
+        actor=TelemetryActor(type=ActorType.SYSTEM, name="governance-test"),
+    )
+    policy = _policy()
+    policy.budget = {"max_requests": 1}
+    policy.__post_init__()
+    engine = GovernanceEngine(
+        policy,
+        approval_resolver=AsyncApprovalResolver(),
+        telemetry_recorder=recorder,
+    )
+
+    with pytest.raises(BudgetExceededError):
+        await engine.authorize_all(
+            [
+                AuthorityRequest(capability="process.exec"),
+                AuthorityRequest(capability="process.exec"),
+            ]
+        )
+    await recorder.end_trace()
+
+    trace = await store.get_trace("trace-approved-budget-batch-deny")
+    assert trace is not None
+    event_types = [event.event_type for event in trace.events]
+    assert "policy_decision_deny" in event_types
+    assert "policy_decision_allow" not in event_types
+
+
+@pytest.mark.asyncio
 async def test_governance_engine_blocks_static_high_risk_approval_by_default():
     engine = GovernanceEngine(
         _policy(),
@@ -671,3 +796,174 @@ def test_rule_conditions_separate_provider_from_execution_surface():
 
     assert decision.effect == PolicyEffect.ALLOW
     assert decision.matched_rule_ids == ["allow_memory_surface"]
+
+
+def test_tool_capability_descriptors_map_workspace_artifact_and_local_tools():
+    workspace = tool_capability_descriptor(
+        tool_name="write_file",
+        tool_provider="workspace",
+    )
+    artifact = tool_capability_descriptor(
+        tool_name="read_artifact",
+        tool_provider="artifact",
+    )
+    local = tool_capability_descriptor(tool_name="lookup_customer")
+
+    assert workspace.capability == "workspace.files.write"
+    assert workspace.execution_surface == "workspace"
+    assert workspace.risk_level == "medium"
+    assert artifact.capability == "workspace.artifacts.read"
+    assert artifact.execution_surface == "artifact"
+    assert local.capability == "tool.local.call"
+    assert local.execution_surface == "tool"
+
+
+def test_mcp_tool_capability_descriptor_is_untrusted_mcp_schema():
+    descriptor = tool_capability_descriptor(
+        tool_name="remote_search",
+        tool_provider="mcp",
+        tool_server="search",
+    )
+
+    assert descriptor.capability == "tool.mcp.call"
+    assert descriptor.descriptor_source.value == "mcp_schema"
+    assert descriptor.descriptor_trust.value == "untrusted"
+
+
+def test_tool_authority_request_preserves_workspace_target_path():
+    request = tool_authority_request(
+        tool_name="move_file",
+        tool_args={"old_path": "notes/a.md", "new_path": "notes/b.md"},
+        tool_provider="workspace",
+    )
+
+    assert request.capability == "workspace.files.move"
+    assert request.provider == "workspace"
+    assert request.target.path == "notes/a.md"
+    assert request.risk_level == "medium"
+
+
+def test_tool_authority_requests_include_move_source_and_destination():
+    requests = tool_authority_requests(
+        tool_name="move_file",
+        tool_args={"old_path": "./notes/a.md", "new_path": "archive/b.md"},
+        tool_provider="workspace",
+    )
+
+    assert [request.target.path for request in requests] == [
+        "notes/a.md",
+        "archive/b.md",
+    ]
+    assert [request.metadata["target_role"] for request in requests] == [
+        "source",
+        "destination",
+    ]
+
+
+def test_workspace_authority_request_normalizes_and_rejects_traversal():
+    request = tool_authority_request(
+        tool_name="read_file",
+        tool_args={"path": "./workspace/notes/a.md"},
+        tool_provider="workspace",
+    )
+    assert request.target.path == "notes/a.md"
+
+    with pytest.raises(ValueError):
+        tool_authority_request(
+            tool_name="read_file",
+            tool_args={"path": "notes/%2e%2e/secret.txt"},
+            tool_provider="workspace",
+        )
+
+
+def test_clear_files_uses_critical_clear_capability():
+    request = tool_authority_request(
+        tool_name="clear_files",
+        tool_args={},
+        tool_provider="workspace",
+    )
+
+    assert request.capability == "workspace.files.clear"
+    assert request.risk_level == "critical"
+
+
+def test_tool_capability_name_maps_mcp_descriptor_for_phase_three():
+    assert (
+        tool_capability_name(tool_name="remote_search", tool_provider="mcp")
+        == "tool.mcp.call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omnicoreagent_initializes_governance_engine_from_agent_config():
+    agent = OmniCoreAgent(
+        name="governed",
+        system_instruction="You are governed.",
+        model_config={"provider": "openai", "model": "gpt-4o", "api_key": "test"},
+        agent_config={
+            "guardrail_mode": "off",
+            "governance_config": {
+                "enabled": True,
+                "policy": {
+                    "name": "runtime-policy",
+                    "mode": "strict",
+                    "rules": {
+                        "allow": [
+                            {
+                                "rule_id": "allow_workspace",
+                                "capability": "workspace.files.*",
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+    )
+
+    await agent.initialize()
+
+    assert agent.agent.governance_engine is not None
+    assert agent.agent.governance_engine.policy.name == "runtime-policy"
+
+
+@pytest.mark.parametrize(
+    "governance_config,error_match",
+    [
+        ("enabled", "governance_config must be a dict"),
+        ({"enabled": "true"}, "governance_config.enabled must be a boolean"),
+        (
+            {"allow_static_high_risk_approvals": "false"},
+            "allow_static_high_risk_approvals must be a boolean",
+        ),
+        (
+            {"policy": {}, "policy_path": "policy.json"},
+            "cannot set both policy and policy_path",
+        ),
+        ({"policy": "bad"}, "policy must be a dict or PolicyEnvelope"),
+        ({"policy_path": 123}, "policy_path must be a string or path-like"),
+        ({"enabeld": True}, "unknown keys: enabeld"),
+    ],
+)
+def test_governance_config_validation(governance_config, error_match):
+    with pytest.raises(ValueError, match=error_match):
+        OmniCoreAgent(
+            name="bad-governance",
+            system_instruction="You are governed.",
+            model_config={"provider": "openai", "model": "gpt-4o", "api_key": "test"},
+            agent_config={
+                "guardrail_mode": "off",
+                "governance_config": governance_config,
+            },
+        )
+
+
+def test_governance_config_preserves_runtime_approval_resolver_identity():
+    resolver = StaticApprovalResolver(approved=True)
+    config = AgentConfig(
+        governance_config={
+            "enabled": True,
+            "approval_resolver": resolver,
+        }
+    )
+
+    assert config.model_dump()["governance_config"]["approval_resolver"] is resolver

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -9,6 +9,11 @@ import pytest
 from omnicoreagent import OmniCoreAgent
 from omnicoreagent.core.subagents import SubagentFactory, build_subagent_tools
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.workspace.config import WorkspaceConfig
+from omnicoreagent.core.workspace.tools import (
+    build_tool_registry_workspace_files,
+    validate_workspace_tool_name_conflicts,
+)
 from omnicoreagent.core.token_usage import Usage
 from omnicoreagent.core.runtime.config import normalize_agent_config
 
@@ -103,6 +108,24 @@ class TestSubagentFactory:
         )
 
         assert factory._build_subagent_local_tools() is local_tools
+
+    def test_subagent_local_tools_preserves_internal_workspace_provider(
+        self, model_config, tmp_path
+    ):
+        local_tools = ToolRegistry()
+        build_tool_registry_workspace_files(
+            registry=local_tools,
+            workspace_config=WorkspaceConfig(workspace_dir=tmp_path / "workspace"),
+        )
+        factory = SubagentFactory(
+            base_model_config=model_config,
+            local_tools=local_tools,
+        )
+
+        child_tools = factory._build_subagent_local_tools()
+
+        assert child_tools.get_tool_provider("read_file") == "workspace"
+        validate_workspace_tool_name_conflicts(child_tools)
 
     @pytest.mark.asyncio
     async def test_run_subagent(self, factory):

--- a/tests/test_tool_batch_runner.py
+++ b/tests/test_tool_batch_runner.py
@@ -12,8 +12,17 @@ from omnicoreagent.core.tools.tool_batch_runner import (
     TOOL_CALL_TIMEOUT_MESSAGE,
     ToolBatchRunner,
 )
+from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
+from omnicoreagent.core.tools.tool_action import ToolAction
+from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.workspace.artifact_tools import build_tool_registry_artifact_tool
+from omnicoreagent.core.workspace.artifacts import ToolResponseOffloader
+from omnicoreagent.core.workspace.config import WorkspaceConfig
+from omnicoreagent.core.workspace.tools import build_tool_registry_workspace_files
 from omnicoreagent.core.types import AgentState, SessionState, ToolCallResult
 from omnicoreagent.core.agents.loop_detection import RobustLoopDetector
+from omnicoreagent.governance import GovernanceEngine, policy_from_mapping
+from omnicoreagent.governance.models import PolicyBudget
 
 
 @pytest.fixture
@@ -29,6 +38,104 @@ def session_state():
         loop_detector=RobustLoopDetector(debug=False),
         assistant_with_tool_calls=None,
         pending_tool_responses=[],
+    )
+
+
+class CountingExecutor:
+    def __init__(self):
+        self.calls = 0
+
+    async def execute(
+        self,
+        agent_name,
+        tool_args,
+        tool_name,
+        tool_call_id,
+        add_message_to_history,
+        session_id,
+    ):
+        self.calls += 1
+        await add_message_to_history(
+            role="tool",
+            content=f"{tool_name}:ok",
+            metadata={
+                "tool_call_id": tool_call_id,
+                "tool": tool_name,
+                "args": tool_args,
+                "agent_name": agent_name,
+            },
+            session_id=session_id,
+        )
+        return {
+            "tool_name": tool_name,
+            "args": tool_args,
+            "status": "success",
+            "data": f"{tool_name}:ok",
+            "message": None,
+        }
+
+
+def _governance_policy():
+    return policy_from_mapping(
+        {
+            "name": "tool-enforcement",
+            "mode": "strict",
+            "rules": {
+                "deny": [
+                    {
+                        "rule_id": "deny_local_tools",
+                        "capability": "tool.local.call",
+                    },
+                    {
+                        "rule_id": "deny_workspace_write",
+                        "capability": "workspace.files.write",
+                    },
+                ],
+                "allow": [
+                    {
+                        "rule_id": "allow_workspace_read",
+                        "capability": "workspace.files.read",
+                    }
+                ],
+            },
+        }
+    )
+
+
+def _budget_policy(max_requests: int = 1):
+    policy = policy_from_mapping(
+        {
+            "name": "budget-policy",
+            "mode": "strict",
+            "rules": {
+                "allow": [
+                    {
+                        "rule_id": "allow_workspace_read",
+                        "capability": "workspace.files.read",
+                    }
+                ]
+            },
+        }
+    )
+    policy.budget = PolicyBudget(max_requests=max_requests)
+    return policy
+
+
+def _allow_workspace_policy():
+    return policy_from_mapping(
+        {
+            "name": "workspace-allow",
+            "mode": "strict",
+            "rules": {
+                "allow": [
+                    {"rule_id": "allow_workspace", "capability": "workspace.files.*"},
+                    {
+                        "rule_id": "allow_artifacts",
+                        "capability": "workspace.artifacts.*",
+                    },
+                ]
+            },
+        }
     )
 
 
@@ -218,6 +325,689 @@ async def test_execute_returns_observation_and_results(runner, session_state):
         "tool-call-alpha",
         "tool-call-beta",
     ]
+
+
+@pytest.mark.asyncio
+async def test_governance_denies_local_tool_without_executing(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="lookup_customer",
+            tool_args={"customer_id": "cus_123"},
+            tool_call_id="tool-call-local",
+            tool_provider="local",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-local",
+        telemetry_recorder=None,
+        tool_batch_name="lookup_customer",
+        tool_batch_args=[{"customer_id": "cus_123"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 0
+    assert tools_results[0]["status"] == "error"
+    assert "Governance denied tool execution" in obs_text
+    assert history[0]["metadata"]["governance_error_code"] == "policy_denied"
+
+
+@pytest.mark.asyncio
+async def test_governance_denies_workspace_write_without_executing(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="write_file",
+            tool_args={"path": "notes/todo.md", "content": "ship"},
+            tool_call_id="tool-call-workspace",
+            tool_provider="workspace",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-workspace",
+        telemetry_recorder=None,
+        tool_batch_name="write_file",
+        tool_batch_args=[{"path": "notes/todo.md", "content": "ship"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 0
+    assert tools_results[0]["status"] == "error"
+    assert "Governance denied tool execution" in obs_text
+    assert history[0]["metadata"]["governance"]["reason_code"] == "matched_deny"
+
+
+@pytest.mark.asyncio
+async def test_governance_allows_workspace_read(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="read_file",
+            tool_args={"path": "notes/todo.md"},
+            tool_call_id="tool-call-workspace-read",
+            tool_provider="workspace",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-workspace-read",
+        telemetry_recorder=None,
+        tool_batch_name="read_file",
+        tool_batch_args=[{"path": "notes/todo.md"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 1
+    assert tools_results[0]["status"] == "success"
+    assert obs_text == "read_file:ok"
+
+
+@pytest.mark.asyncio
+async def test_governance_fails_closed_for_mcp_until_phase_three(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="remote_search",
+            tool_args={"query": "secret"},
+            tool_call_id="tool-call-mcp",
+            tool_provider="mcp",
+            tool_server="search",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-mcp",
+        telemetry_recorder=None,
+        tool_batch_name="remote_search",
+        tool_batch_args=[{"query": "secret"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 0
+    assert tools_results[0]["status"] == "error"
+    assert "MCP governance is not implemented" in obs_text
+    assert history[0]["metadata"]["args"] == "[REDACTED]"
+    assert history[0]["metadata"]["governance_error_code"] == "ungoverned_capability"
+
+
+@pytest.mark.asyncio
+async def test_governance_budget_is_atomic_for_parallel_tool_batch(session_state):
+    first = CountingExecutor()
+    second = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_budget_policy(max_requests=1)),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=first,
+            tool_name="read_file",
+            tool_args={"path": "notes/one.md"},
+            tool_call_id="tool-call-one",
+            tool_provider="workspace",
+        ),
+        ToolCallResult(
+            tool_executor=second,
+            tool_name="read_file",
+            tool_args={"path": "notes/two.md"},
+            tool_call_id="tool-call-two",
+            tool_provider="workspace",
+        ),
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return "\n".join(result["status"] for result in tools_results)
+
+    _obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-budget",
+        telemetry_recorder=None,
+        tool_batch_name="read_file, read_file",
+        tool_batch_args=[{"path": "notes/one.md"}, {"path": "notes/two.md"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    statuses = [result["status"] for result in tools_results]
+    assert statuses.count("success") == 1
+    assert statuses.count("error") == 1
+    assert first.calls + second.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_governance_denial_redacts_args_in_history_and_result(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="lookup_customer",
+            tool_args={"api_key": "secret", "customer_id": "cus_123"},
+            tool_call_id="tool-call-redact",
+            tool_provider="local",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    _obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-redact",
+        telemetry_recorder=None,
+        tool_batch_name="lookup_customer",
+        tool_batch_args=[{"api_key": "secret", "customer_id": "cus_123"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 0
+    assert tools_results[0]["args"] == {}
+    assert history[0]["metadata"]["args"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_governed_batch_execution_error_redacts_args(
+    session_state,
+):
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_allow_workspace_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=CountingExecutor(),
+            tool_name="read_file",
+            tool_args={"path": "customers/cus_123/private.md"},
+            tool_call_id="tool-call-timeout-redact",
+            tool_provider="workspace",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    results = await runner.handle_execution_error(
+        tool_call_results=tool_calls,
+        error_message="timeout",
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-timeout",
+        tool_batch_name="read_file",
+    )
+
+    assert results[0]["args"] == {"path": "[REDACTED]"}
+    assert history[0]["metadata"]["args"] == {"path": "[REDACTED]"}
+
+
+@pytest.mark.asyncio
+async def test_governance_denial_emits_policy_telemetry_without_tool_args(
+    session_state,
+):
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    await recorder.start_trace(
+        trace_id="trace-governance-denial",
+        session_id="governed-telemetry",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(
+            _governance_policy(),
+            telemetry_recorder=recorder,
+        ),
+    )
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="lookup_customer",
+            tool_args={"api_key": "secret", "customer_id": "cus_123"},
+            tool_call_id="tool-call-telemetry-redact",
+            tool_provider="local",
+        )
+    ]
+
+    history = []
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-telemetry",
+        telemetry_recorder=recorder,
+        tool_batch_name="lookup_customer",
+        tool_batch_args=[{"api_key": "secret", "customer_id": "cus_123"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+    await recorder.end_trace()
+
+    trace = await store.get_trace("trace-governance-denial")
+    assert trace is not None
+    event_types = [event.event_type for event in trace.events]
+    assert "policy_request_created" in event_types
+    assert "policy_decision_deny" in event_types
+    assert "tool_call" not in event_types
+    request_event = next(
+        event for event in trace.events if event.event_type == "policy_request_created"
+    )
+    assert "api_key" not in str(request_event.input)
+    assert "secret" not in str(request_event.input)
+
+
+@pytest.mark.asyncio
+async def test_governed_successful_tool_telemetry_redacts_result_args(session_state):
+    store = InMemoryTelemetryStore()
+    recorder = TelemetryRecorder(store)
+    await recorder.start_trace(
+        trace_id="trace-governance-success",
+        session_id="governed-success-telemetry",
+        actor=TelemetryActor(type=ActorType.AGENT, name="test_agent"),
+    )
+
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="read_file",
+            tool_args={"path": "customers/cus_123/private.md"},
+            tool_call_id="tool-call-success-redact",
+            tool_provider="workspace",
+        )
+    ]
+
+    history = []
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    _obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-success-telemetry",
+        telemetry_recorder=recorder,
+        tool_batch_name="read_file",
+        tool_batch_args=[{"path": "customers/cus_123/private.md"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+    await recorder.end_trace()
+
+    assert tools_results[0]["args"] == "[REDACTED]"
+    assert history[0]["metadata"]["args"] == "[REDACTED]"
+    trace = await store.get_trace("trace-governance-success")
+    assert trace is not None
+    workspace_event = next(
+        event for event in trace.events if event.event_type == "workspace_read"
+    )
+    assert workspace_event.output["args"] == "[REDACTED]"
+    read_span = next(span for span in trace.spans if span.name == "read_file")
+    assert read_span.output["args"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_governed_start_redacts_assistant_tool_call_content(session_state):
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+    history = []
+    response = """
+<tool_call>
+  <tool_name>lookup_customer</tool_name>
+  <parameters><api_key>secret</api_key></parameters>
+</tool_call>
+"""
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=CountingExecutor(),
+            tool_name="lookup_customer",
+            tool_args={"api_key": "secret"},
+            tool_call_id="tool-call-content-redact",
+            tool_provider="local",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    await runner.start(
+        tool_call_results=tool_calls,
+        response=response,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-content-redact",
+    )
+
+    assert "secret" not in history[0]["content"]
+    assert "secret" not in session_state.messages[-1].content
+    assert "lookup_customer" in history[0]["content"]
+    tool_args = history[0]["metadata"]["tool_calls"][0]["function"]["arguments"]
+    assert "secret" not in tool_args
+
+
+@pytest.mark.asyncio
+async def test_governance_denied_workspace_write_does_not_touch_real_storage(
+    session_state,
+    tmp_path,
+):
+    registry = ToolRegistry()
+    workspace_dir = tmp_path / "workspace"
+    build_tool_registry_workspace_files(
+        registry=registry,
+        workspace_config=WorkspaceConfig(workspace_dir=workspace_dir),
+    )
+    resolved = await ToolCallResolver().resolve_single_action(
+        action=ToolAction(
+            tool_name="write_file",
+            parameters={"path": "notes/denied.md", "content": "blocked"},
+            raw={
+                "tool": "write_file",
+                "parameters": {"path": "notes/denied.md", "content": "blocked"},
+            },
+        ),
+        sessions={},
+        mcp_tools=None,
+        local_tools=registry,
+    )
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_governance_policy()),
+    )
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    _obs_text, tools_results = await runner.execute(
+        tool_call_results=[resolved],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="real-workspace-deny",
+        telemetry_recorder=None,
+        tool_batch_name="write_file",
+        tool_batch_args=[{"path": "notes/denied.md", "content": "blocked"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert tools_results[0]["status"] == "error"
+    assert not (workspace_dir / "files" / "notes" / "denied.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_governance_allows_real_workspace_write_and_read(
+    session_state,
+    tmp_path,
+):
+    registry = ToolRegistry()
+    workspace_dir = tmp_path / "workspace"
+    build_tool_registry_workspace_files(
+        registry=registry,
+        workspace_config=WorkspaceConfig(workspace_dir=workspace_dir),
+    )
+    resolved = await ToolCallResolver().resolve_single_action(
+        action=ToolAction(
+            tool_name="write_file",
+            parameters={
+                "path": "notes/allowed.md",
+                "content": "allowed",
+                "mode": "create",
+            },
+            raw={
+                "tool": "write_file",
+                "parameters": {"path": "notes/allowed.md", "content": "allowed"},
+            },
+        ),
+        sessions={},
+        mcp_tools=None,
+        local_tools=registry,
+    )
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_allow_workspace_policy()),
+    )
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    _obs_text, tools_results = await runner.execute(
+        tool_call_results=[resolved],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="real-workspace-allow",
+        telemetry_recorder=None,
+        tool_batch_name="write_file",
+        tool_batch_args=[
+            {"path": "notes/allowed.md", "content": "allowed", "mode": "create"}
+        ],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert tools_results[0]["status"] == "success"
+    assert (workspace_dir / "files" / "notes" / "allowed.md").read_text() == "allowed"
+
+
+@pytest.mark.asyncio
+async def test_governance_controls_real_artifact_tool_execution(session_state, tmp_path):
+    offloader = ToolResponseOffloader(
+        config={"enabled": True},
+        base_dir=str(tmp_path / "artifacts"),
+    )
+    artifact = offloader.offload("search", "artifact content")
+    registry = ToolRegistry()
+    build_tool_registry_artifact_tool(offloader, registry)
+    resolved = await ToolCallResolver().resolve_single_action(
+        action=ToolAction(
+            tool_name="read_artifact",
+            parameters={"artifact_id": artifact.artifact_id},
+            raw={
+                "tool": "read_artifact",
+                "parameters": {"artifact_id": artifact.artifact_id},
+            },
+        ),
+        sessions={},
+        mcp_tools=None,
+        local_tools=registry,
+    )
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_allow_workspace_policy()),
+    )
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        return None
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    _obs_text, tools_results = await runner.execute(
+        tool_call_results=[resolved],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="artifact-allow",
+        telemetry_recorder=None,
+        tool_batch_name="read_artifact",
+        tool_batch_args=[{"artifact_id": artifact.artifact_id}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert tools_results[0]["status"] == "success"
+    assert tools_results[0]["data"] == "artifact content"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_call_resolver.py
+++ b/tests/test_tool_call_resolver.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
+from omnicoreagent.core.tools.local_tools_registry import Tool, ToolRegistry
 from omnicoreagent.core.tools.tool_action import ToolAction
 from omnicoreagent.core.tools.tool_call_resolver import ToolCallResolver
 from omnicoreagent.core.workspace.config import WorkspaceConfig
@@ -71,6 +71,80 @@ async def test_resolve_single_action_marks_builtin_workspace_tools(resolver, tmp
     assert isinstance(resolved, ToolCallResult)
     assert resolved.tool_name == "read_file"
     assert resolved.tool_provider == "workspace"
+
+
+@pytest.mark.asyncio
+async def test_resolve_single_action_does_not_trust_forged_workspace_marker(resolver):
+    registry = ToolRegistry()
+
+    @registry.register_tool(
+        name="fake_workspace_read",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        description="A normal app tool that forges the old internal marker.",
+    )
+    async def fake_workspace_read(path: str):
+        return {"path": path}
+
+    setattr(fake_workspace_read, "_omnicoreagent_builtin_workspace_tool", True)
+
+    resolved = await resolver.resolve_single_action(
+        action=ToolAction(
+            tool_name="fake_workspace_read",
+            parameters={"path": "notes.md"},
+            raw={"tool": "fake_workspace_read", "parameters": {"path": "notes.md"}},
+        ),
+        sessions={},
+        mcp_tools=None,
+        local_tools=registry,
+    )
+
+    assert isinstance(resolved, ToolCallResult)
+    assert resolved.tool_name == "fake_workspace_read"
+    assert resolved.tool_provider == "local"
+
+
+@pytest.mark.asyncio
+async def test_resolve_single_action_does_not_trust_prebuilt_tool_provider_metadata(
+    resolver,
+):
+    registry = ToolRegistry()
+
+    async def fake_workspace_read(path: str):
+        return {"path": path}
+
+    registry.register(
+        Tool(
+            name="fake_workspace_read",
+            description="A normal app tool that forges internal provider metadata.",
+            inputSchema={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            function=fake_workspace_read,
+        )
+    )
+    registry.get_tool("fake_workspace_read").provider = "workspace"
+    registry.get_tool("fake_workspace_read").internal_provider = True
+
+    resolved = await resolver.resolve_single_action(
+        action=ToolAction(
+            tool_name="fake_workspace_read",
+            parameters={"path": "notes.md"},
+            raw={"tool": "fake_workspace_read", "parameters": {"path": "notes.md"}},
+        ),
+        sessions={},
+        mcp_tools=None,
+        local_tools=registry,
+    )
+
+    assert isinstance(resolved, ToolCallResult)
+    assert resolved.tool_name == "fake_workspace_read"
+    assert resolved.tool_provider == "local"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_failure_handler.py
+++ b/tests/test_tool_failure_handler.py
@@ -61,6 +61,30 @@ async def test_handle_validation_error_records_loop(handler, session_state):
         }
     ]
 
+
+@pytest.mark.asyncio
+async def test_handle_validation_error_redacts_args_when_governed(session_state):
+    handler = ToolFailureHandler(agent_name="test_agent", governance_enabled=True)
+
+    (
+        _tool_batch_name,
+        tool_batch_args,
+        _obs_text,
+        results,
+    ) = await handler.handle_validation_error(
+        tool_error=ToolError(
+            observation="The tool named 'missing_tool' does not exist.",
+            tool_name="missing_tool",
+            tool_args={"api_key": "secret", "query": "customer"},
+        ),
+        session_state=session_state,
+        session_id="governed-validation-error",
+    )
+
+    assert tool_batch_args == [{"api_key": "[REDACTED]", "query": "[REDACTED]"}]
+    assert results[0]["args"] == {"api_key": "[REDACTED]", "query": "[REDACTED]"}
+
+
 @pytest.mark.asyncio
 async def test_handle_loop_state_marks_session_stuck(handler, session_state):
     session_state.messages = [Message(role="system", content="system")]


### PR DESCRIPTION
## Summary
- Wire governance config through OmniCoreAgent runtime into ReactAgent and ToolBatchRunner
- Add capability descriptors and authority requests for local, workspace, artifact, and MCP tool surfaces
- Enforce policy before local/workspace/artifact tool execution, fail closed for MCP until its dedicated enforcement phase
- Redact governed tool args across assistant history, tool history, telemetry, validation errors, and batch timeout/error paths
- Add atomic batch authorization for multi-target tools and approval/budget edge cases

## Verification
- uv run ruff check touched files
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_tool_batch_runner.py tests/test_governance_core.py tests/test_tool_failure_handler.py tests/test_subagents.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests -q -k 'not mongodb'

## Reviewer Passes
- Security reviewer: no remaining blocker
- Runtime/API reviewer: no remaining blocker
- QA reviewer: no remaining blocker