### PR TITLE
Enforce governance for MCP lifecycle

### DIFF
--- a/engineering/architecture/governed-execution.md
+++ b/engineering/architecture/governed-execution.md
@@ -213,9 +213,10 @@ Policy rules are deterministic and ordered by precedence:
 deny -> ask -> allow
 ```
 
-Deny wins. Ask pauses the action until an approval resolver returns a decision.
-Allow may still attach constraints such as sandbox profile, timeout, output
-limit, redaction, or workspace destination.
+Deny wins. Ask requires app-owned external authority. Without a resolver, the
+runtime fails closed with a stable approval-required error. Allow may still
+attach constraints such as sandbox profile, timeout, output limit, redaction, or
+workspace destination.
 
 ## Trust Zones
 
@@ -444,15 +445,17 @@ Approval results include:
 - expiry
 - audit reason
 
-Approval resolvers must bind the approval to a trusted principal from CLI,
-OmniServe, or application-owned identity context. Production high-risk
-approvals cannot come from unauthenticated strings or model output.
+Approval resolvers are app-owned extensions. The core harness only exposes the
+small resolver contract and fails closed when no resolver exists. Production
+high-risk approvals cannot come from unauthenticated strings or model output.
+The core runtime must not add a built-in babysitting loop, approval UI, callback
+server, or OmniServe approval workflow by default.
 
 Approvals may come from:
 
-- application callback
-- CLI prompt
-- OmniServe API
+- application-owned resolver
+- CLI prompt implemented by the app
+- application-owned API/dashboard
 - static policy default
 - future human review UI
 
@@ -521,10 +524,15 @@ AgentBound's MCP-focused access-control model is important here: enforcement
 must be possible even when the MCP server itself is not modified.
 
 Local MCP servers must not run with ambient host authority by default. They need
-scrubbed environment, explicit mounts, and sandbox or egress controls when
-their declared capabilities require them. Remote MCP servers need pinned
-identity and schema/tool drift checks, usually through a gateway or proxy
-boundary.
+a scrubbed operational environment, explicit mounts, and sandbox or egress
+controls when their declared capabilities require them. If a server reports a
+different identity during initialization than the configured identity used to
+start it, the reported identity must be authorized before its tools are
+registered. Remote MCP servers need pinned identity and schema/tool drift
+checks, usually through a gateway or proxy boundary.
+
+Unsupported MCP transports fail closed. The runtime must never interpret an
+unknown transport as stdio or any other side-effecting transport.
 
 ## Telemetry Integration
 

--- a/engineering/specifications/governed-execution.md
+++ b/engineering/specifications/governed-execution.md
@@ -449,7 +449,9 @@ telemetry:
 Rules:
 
 - `deny` stops execution.
-- `ask` creates an approval request and pauses execution.
+- `ask` creates an approval request. If the application did not provide an
+  approval resolver for that run, execution fails closed with
+  `ApprovalRequiredError`.
 - `allow` may still require sandbox enforcement.
 - A decision must include enough reason text to debug policy behavior.
 - `reason_code` is required so tests, telemetry, dashboards, and future evals do
@@ -491,9 +493,10 @@ Rules:
 - Approvals cannot broaden beyond the policy envelope.
 - Expired approvals deny by default.
 - Approval state is recorded in telemetry.
-- Background tasks that need approval must enter a paused state.
-- The approver principal must come from trusted CLI, OmniServe, or
-  application-owned identity context.
+- Background task approval behavior is application-owned. The core harness does
+  not provide a babysitting loop or approval UI by default.
+- The approver principal must come from trusted application-owned identity
+  context.
 - The approver principal must be authorized for the policy scope, tenant,
   session, data class, and requested capability.
 - Approval records must include tenant/session/request binding where available.
@@ -548,8 +551,9 @@ Tool provider resolution:
   generic `tool.local.call`.
 - Application local tools emit `tool.local.call` plus any declared capabilities
   from their descriptor.
-- MCP tools emit `tool.mcp.call` plus any declared or policy-overridden
-  capabilities.
+- MCP tools currently emit `tool.mcp.call`. A later descriptor phase will add
+  declared or policy-overridden secondary capabilities such as network,
+  filesystem, memory, and secret use.
 - Composite actions produce one deterministic governance decision path, either
   by evaluating all required capabilities together or by producing a single
   approval request that lists every required capability.
@@ -696,14 +700,20 @@ Rules:
 - MCP servers default to untrusted external capability providers.
 - MCP server startup or connection requires `mcp.server.start` or
   `mcp.server.connect`.
+- Unsupported MCP transport types fail closed before authorization and before
+  opening any local process or remote connection.
 - Tool calls require `tool.mcp.call`.
 - Server-level allow does not imply all tool-level capabilities.
 - Tool descriptors can be generated but policy overrides are authoritative.
 - MCP tool outputs are untrusted observations.
 - MCP servers cannot gain workspace, memory, network, or secret authority unless
   declared and allowed.
-- Local MCP servers must run with scrubbed environment, explicit mounts,
-  sandbox/egress policy when required, and no ambient credentials by default.
+- Local MCP servers must run with a scrubbed operational environment, explicit
+  mounts, sandbox/egress policy when required, and no ambient credentials by
+  default.
+- If the configured MCP server name differs from the server identity returned by
+  MCP initialization, the runtime must authorize the reported identity before
+  registering tools from that server.
 - Remote MCP servers require an explicit remote identity boundary such as a
   gateway/proxy, pinned server identity or URL, and schema/tool hash.
 - MCP schema or tool drift is denied until reapproved or explicitly allowed by
@@ -717,6 +727,7 @@ Required tests:
 - deny MCP tool network capability not granted
 - policy wraps MCP calls without modifying server code
 - deny local MCP startup with ambient secrets
+- deny reported MCP server identity drift unless policy allows it
 - deny remote MCP schema/tool drift until approved
 
 ---
@@ -1065,16 +1076,23 @@ code call this boundary instead of each implementing policy semantics.
 ### Phase 3: MCP Enforcement
 
 - Add MCP server/tool capability descriptors.
-- Enforce policy around MCP tool calls.
+- Enforce policy before MCP server start/connect and MCP tool calls.
 - Add per-server/per-tool rules.
-- Add tests with fake MCP tools.
+- Add tests with fake MCP servers and tools.
+- Do not treat remote schema/tool hash pinning or MCP secondary capability
+  enforcement as complete in this phase; those require the later descriptor and
+  sandbox/policy phases.
 
 ### Phase 4: Approval Interface
 
-- Add approval resolver protocol.
-- Add static resolver and callback resolver.
-- Add paused/denied behavior.
-- Add OmniServe approval API design later if needed.
+- Keep approval resolution app-owned.
+- Keep the core resolver protocol small and deterministic.
+- `ask` without an app-provided resolver fails closed with `ApprovalRequiredError`.
+- Static resolvers remain test/development helpers and must not silently approve
+  high-risk production actions.
+- Do not add a built-in babysitting loop, approval UI, callback server, or
+  OmniServe approval API in the core harness unless a later application-facing
+  design explicitly needs it.
 
 ### Phase 5: Subagent and Background Policy
 

--- a/src/omnicoreagent/core/runtime/builder.py
+++ b/src/omnicoreagent/core/runtime/builder.py
@@ -33,10 +33,15 @@ def build_agent_runtime(
     telemetry_recorder: Any = None,
 ) -> AgentRuntimeComponents:
     """Build the executable agent runtime without mutating the facade."""
+    governance_engine = construction.build_governance_engine(
+        agent_config=agent_config,
+        telemetry_recorder=telemetry_recorder,
+    )
     mcp_client, llm_connection = construction.create_llm_runtime(
         mcp_tools=mcp_tools,
         model_config=model_config,
         debug=debug,
+        governance_engine=governance_engine,
     )
 
     agent_settings = construction.build_agent_settings(agent_config)
@@ -50,10 +55,7 @@ def build_agent_runtime(
         agent_settings=agent_settings,
         guardrail=guardrail,
         guardrail_mode=guardrail_mode,
-        governance_engine=construction.build_governance_engine(
-            agent_config=agent_config,
-            telemetry_recorder=telemetry_recorder,
-        ),
+        governance_engine=governance_engine,
     )
 
     subagent_factory, local_tools = harness_tools.prepare_dynamic_subagents(

--- a/src/omnicoreagent/core/runtime/construction.py
+++ b/src/omnicoreagent/core/runtime/construction.py
@@ -35,6 +35,7 @@ def create_llm_runtime(
     mcp_tools: list[dict[str, Any]],
     model_config: dict[str, Any],
     debug: bool,
+    governance_engine: Any = None,
 ) -> tuple[Any, Any]:
     if not mcp_tools:
         llm_connection = runtime("LLMConnection")(
@@ -49,6 +50,7 @@ def create_llm_runtime(
         servers=mcp_tools,
         model_config=model_config,
         api_key=model_config.get("api_key"),
+        governance_engine=governance_engine,
         debug=debug,
     )
     return mcp_client, mcp_client.llm_connection

--- a/src/omnicoreagent/core/tools/tool_batch_runner.py
+++ b/src/omnicoreagent/core/tools/tool_batch_runner.py
@@ -20,7 +20,6 @@ from omnicoreagent.governance.capabilities import tool_authority_requests
 from omnicoreagent.governance.errors import (
     GovernanceError,
     PolicyDeniedError,
-    UngovernedCapabilityError,
 )
 
 TOOL_CALL_TIMEOUT_MESSAGE = (
@@ -595,14 +594,13 @@ class ToolBatchRunner:
     ) -> GovernanceError | None:
         if self.governance_engine is None:
             return None
-        if single_tool.tool_provider == "mcp":
-            return UngovernedCapabilityError(
-                "MCP governance is not implemented until the MCP enforcement phase.",
+        if single_tool.tool_provider == "mcp" and not single_tool.tool_server:
+            return PolicyDeniedError(
+                "MCP tool execution requires a concrete server identity.",
                 metadata={
                     "tool": single_tool.tool_name,
                     "tool_provider": single_tool.tool_provider,
-                    "tool_server": single_tool.tool_server,
-                    "reason_code": "ungoverned_capability",
+                    "reason_code": "unknown_target",
                 },
             )
         try:

--- a/src/omnicoreagent/core/tools/tool_call_resolver.py
+++ b/src/omnicoreagent/core/tools/tool_call_resolver.py
@@ -44,8 +44,15 @@ class ToolCallResolver:
         action: ToolAction,
         sessions: dict,
         mcp_tools: dict | None,
-    ) -> ToolCallResult | None:
-        match = find_mcp_tool(tool_name=action.tool_name, mcp_tools=mcp_tools)
+    ) -> ToolCallResult | ToolError | None:
+        try:
+            match = find_mcp_tool(tool_name=action.tool_name, mcp_tools=mcp_tools)
+        except ValueError as exc:
+            return ToolError(
+                observation=str(exc),
+                tool_name=action.tool_name,
+                tool_args=action.parameters,
+            )
         if not match:
             return None
 
@@ -111,6 +118,8 @@ class ToolCallResolver:
                 sessions=sessions,
                 mcp_tools=mcp_tools,
             )
+            if isinstance(resolved, ToolError):
+                return resolved
 
         if not resolved:
             resolved = self.resolve_local_tool_action(

--- a/src/omnicoreagent/core/tools/tool_catalog.py
+++ b/src/omnicoreagent/core/tools/tool_catalog.py
@@ -25,13 +25,23 @@ def find_mcp_tool(
     if not normalized_name:
         return None
 
+    matches: list[MCPToolMatch] = []
     for server_name, tools in mcp_tools.items():
         for tool in tools:
             candidate = getattr(tool, "name", "")
             if str(candidate).lower() == normalized_name:
-                return MCPToolMatch(server_name=server_name, tool=tool)
+                matches.append(MCPToolMatch(server_name=server_name, tool=tool))
 
-    return None
+    if not matches:
+        return None
+    if len(matches) > 1:
+        servers = ", ".join(sorted(match.server_name for match in matches))
+        raise ValueError(
+            f"MCP tool name '{tool_name}' is available on multiple servers "
+            f"({servers}). Rename one MCP server tool; server-qualified MCP tool "
+            "calls are not supported yet."
+        )
+    return matches[0]
 
 
 def find_local_tool_name(tool_name: str, local_tools: Any) -> str | None:

--- a/src/omnicoreagent/governance/__init__.py
+++ b/src/omnicoreagent/governance/__init__.py
@@ -4,6 +4,7 @@ from omnicoreagent.governance.approvals import (
     StaticApprovalResolver,
 )
 from omnicoreagent.governance.capabilities import (
+    mcp_server_authority_request,
     tool_authority_request,
     tool_authority_requests,
     tool_capability_descriptor,
@@ -104,6 +105,7 @@ __all__ = [
     "discover_policy_file",
     "load_policy",
     "load_policy_file",
+    "mcp_server_authority_request",
     "policy_from_mapping",
     "policy_hash",
     "tool_authority_request",

--- a/src/omnicoreagent/governance/capabilities.py
+++ b/src/omnicoreagent/governance/capabilities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 from omnicoreagent.core.workspace.paths import (
     WORKSPACE_FILE_PATH_PREFIXES,
@@ -20,6 +21,7 @@ WORKSPACE_MOVE_TOOLS = frozenset({"move_file"})
 ARTIFACT_READ_TOOLS = frozenset(
     {"read_artifact", "tail_artifact", "search_artifact", "list_artifacts"}
 )
+MCP_SERVER_TRANSPORTS = frozenset({"stdio", "sse", "streamable_http"})
 
 
 def tool_capability_descriptor(
@@ -197,6 +199,49 @@ def tool_capability_name(*, tool_name: str, tool_provider: str) -> str:
     return "tool.local.call"
 
 
+def mcp_server_authority_request(
+    *,
+    server: dict[str, Any],
+    actor: str = "agent",
+) -> AuthorityRequest:
+    transport = str(server.get("transport_type", "stdio")).lower()
+    if transport not in MCP_SERVER_TRANSPORTS:
+        supported = ", ".join(sorted(MCP_SERVER_TRANSPORTS))
+        raise ValueError(
+            f"Unsupported MCP transport_type: {transport}. Supported: {supported}"
+        )
+    server_name = str(server.get("name") or "")
+    host = _server_host(server)
+    capability = (
+        "mcp.server.start"
+        if transport == "stdio"
+        else "mcp.server.connect"
+    )
+    return AuthorityRequest(
+        capability=capability,
+        actor=actor,
+        provider="mcp",
+        execution_surface="mcp",
+        target=AuthorityTarget(
+            resource=server_name,
+            host=host,
+            mcp_server=server_name,
+        ),
+        risk_level="medium" if transport == "stdio" else "low",
+        method=transport,
+        host=host,
+        mcp_server=server_name,
+        metadata={
+            "server_name": server_name,
+            "requested_name": server.get("requested_name"),
+            "transport_type": transport,
+            "has_explicit_env": bool(server.get("env")),
+            "url": _redacted_url(server.get("url")),
+            "command": server.get("command") if transport == "stdio" else None,
+        },
+    )
+
+
 def tool_risk_level(*, tool_name: str, tool_provider: str) -> str:
     if tool_provider == "workspace":
         if tool_name == "clear_files":
@@ -231,3 +276,22 @@ def _execution_surface(tool_provider: str) -> str:
     if tool_provider == "mcp":
         return "mcp"
     return "tool"
+
+
+def _server_host(server: dict[str, Any]) -> str | None:
+    url = server.get("url")
+    if not url:
+        return None
+    parsed = urlparse(str(url))
+    return parsed.hostname
+
+
+def _redacted_url(url: Any) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(str(url))
+    if not parsed.scheme or not parsed.netloc:
+        return str(url)
+    host = parsed.hostname or ""
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{parsed.scheme}://{host}{port}{parsed.path}"

--- a/src/omnicoreagent/governance/defaults.py
+++ b/src/omnicoreagent/governance/defaults.py
@@ -130,6 +130,11 @@ def _interactive_dev_policy() -> PolicyEnvelope:
                     capability="tool.mcp.call",
                 ),
                 PolicyRule(
+                    rule_id="ask_mcp_server_start",
+                    effect=PolicyEffect.ASK,
+                    capability="mcp.server.*",
+                ),
+                PolicyRule(
                     rule_id="ask_high_risk",
                     effect=PolicyEffect.ASK,
                     capability="*",

--- a/src/omnicoreagent/governance/enforcement.py
+++ b/src/omnicoreagent/governance/enforcement.py
@@ -171,12 +171,21 @@ class GovernanceEngine:
             decision_id=decision.decision_id,
             capability=request.capability,
             actor=request.actor,
+            target=request.target,
+            provider=request.provider,
+            execution_surface=request.execution_surface,
+            risk_level=request.risk_level,
+            data_classes=list(request.data_classes),
+            method=request.method,
+            host=request.host,
+            mcp_server=request.mcp_server,
             reason=decision.reason,
             expires_at=(
                 utc_now() + timedelta(seconds=decision.constraints.approval_expires_seconds)
                 if decision.constraints.approval_expires_seconds is not None
                 else None
             ),
+            metadata=dict(request.metadata),
         )
         if self.approval_resolver is None:
             decision.approval_id = approval.approval_id

--- a/src/omnicoreagent/governance/models.py
+++ b/src/omnicoreagent/governance/models.py
@@ -249,10 +249,22 @@ class ApprovalRequest:
     capability: str
     actor: str
     approval_id: str = field(default_factory=lambda: governance_id("approval"))
+    target: AuthorityTarget | dict[str, Any] | None = None
+    provider: str | None = None
+    execution_surface: str | None = None
+    risk_level: str = "low"
+    data_classes: list[str] = field(default_factory=list)
+    method: str | None = None
+    host: str | None = None
+    mcp_server: str | None = None
     reason: str = ""
     created_at: datetime = field(default_factory=utc_now)
     expires_at: datetime | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.target, dict):
+            self.target = AuthorityTarget(**self.target)
 
 
 @dataclass

--- a/src/omnicoreagent/mcp_clients_connection/client.py
+++ b/src/omnicoreagent/mcp_clients_connection/client.py
@@ -7,6 +7,8 @@ from mcp import ClientSession
 
 from omnicoreagent.core.llm import LLMConnection
 from omnicoreagent.core.logging import logger
+from omnicoreagent.governance.capabilities import mcp_server_authority_request
+from omnicoreagent.governance.errors import GovernanceError
 from omnicoreagent.mcp_clients_connection.oauth import (
     build_oauth_provider,
     is_oauth_enabled,
@@ -24,11 +26,13 @@ class MCPClient:
         servers: list[dict[str, Any]] | None = None,
         model_config: dict[str, Any] | None = None,
         api_key: str | None = None,
+        governance_engine: Any = None,
         debug: bool = False,
     ):
         self.servers = self._normalize_servers(servers or [])
         self.state = MCPClientState()
         self.debug = debug
+        self.governance_engine = governance_engine
         self.llm_connection = (
             LLMConnection(model_config=model_config, api_key=api_key)
             if model_config
@@ -90,12 +94,17 @@ class MCPClient:
             for result in results:
                 if isinstance(result, Exception):
                     logger.error(f"Server connection failed: {result}")
+                    if isinstance(result, GovernanceError):
+                        raise result
                 logger.info(f"Server connection result: {result}")
+        except (GovernanceError, ValueError):
+            raise
         except Exception as e:
             logger.info(f"start servers task error: {e}")
 
     async def _connect_to_single_server(self, server, server_added_name):
         try:
+            await self._authorize_server_connection(server)
             stack = AsyncExitStack()
             url = server.get("url", "")
 
@@ -124,6 +133,11 @@ class MCPClient:
             )
             init_result = await session.initialize()
             server_name = init_result.serverInfo.name
+            if server_name != server_added_name:
+                await self._authorize_server_connection(
+                    server,
+                    resolved_server_name=server_name,
+                )
             if self.state.has_server(server_name):
                 error_message = (
                     f"{server_name} is already connected. Disconnect it and try again."
@@ -150,10 +164,42 @@ class MCPClient:
             await self._load_server_tools(server_name)
 
             return f"{server_name} connected successfully"
+        except (GovernanceError, ValueError):
+            stack = locals().get("stack")
+            if stack is not None:
+                try:
+                    await stack.aclose()
+                except Exception as cleanup_error:
+                    logger.error(f"Error cleaning failed MCP connection: {cleanup_error}")
+            raise
         except Exception as e:
+            stack = locals().get("stack")
+            if stack is not None:
+                try:
+                    await stack.aclose()
+                except Exception as cleanup_error:
+                    logger.error(f"Error cleaning failed MCP connection: {cleanup_error}")
             error_message = f"Failed to connect to server: {str(e)}"
             logger.error(error_message)
             return error_message
+
+    async def _authorize_server_connection(
+        self,
+        server: dict[str, Any],
+        *,
+        resolved_server_name: str | None = None,
+    ) -> None:
+        if self.governance_engine is None:
+            return
+        server_identity = dict(server)
+        if resolved_server_name is not None:
+            server_identity["name"] = resolved_server_name
+            server_identity["requested_name"] = server.get("name")
+        request = mcp_server_authority_request(
+            server=server_identity,
+            actor="mcp_client",
+        )
+        await self.governance_engine.authorize(request)
 
     async def _load_server_tools(self, server_name: str) -> list[Any]:
         """Load MCP tools for one connected server."""
@@ -193,6 +239,8 @@ class MCPClient:
         for server, result in zip(servers, results, strict=True):
             if isinstance(result, Exception):
                 logger.error(f"Failed to add server '{server['name']}': {result}")
+                if isinstance(result, GovernanceError):
+                    raise result
                 responses.append((server["name"], str(result)))
             else:
                 responses.append(result)

--- a/src/omnicoreagent/mcp_clients_connection/transports.py
+++ b/src/omnicoreagent/mcp_clients_connection/transports.py
@@ -12,6 +12,26 @@ from mcp.client.streamable_http import streamable_http_client
 
 from omnicoreagent.core.logging import logger
 
+STDIO_ENV_ALLOWLIST = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "NODE_PATH",
+    }
+)
+SUPPORTED_TRANSPORTS = frozenset({"stdio", "sse", "streamable_http"})
+
 
 async def open_server_transport(
     *,
@@ -20,8 +40,7 @@ async def open_server_transport(
     oauth_auth: Any = None,
     debug: bool = False,
 ) -> tuple[Any, Any, str]:
-    transport_type = server.get("transport_type", "stdio")
-    normalized_transport = transport_type.lower()
+    normalized_transport = normalize_transport_type(server)
 
     if normalized_transport == "sse":
         return await _open_sse_transport(
@@ -39,7 +58,20 @@ async def open_server_transport(
             debug=debug,
         )
 
-    return await _open_stdio_transport(stack=stack, server=server)
+    if normalized_transport == "stdio":
+        return await _open_stdio_transport(stack=stack, server=server)
+
+    raise ValueError(f"Unsupported MCP transport_type: {normalized_transport}")
+
+
+def normalize_transport_type(server: dict[str, Any]) -> str:
+    transport = str(server.get("transport_type", "stdio")).lower()
+    if transport not in SUPPORTED_TRANSPORTS:
+        supported = ", ".join(sorted(SUPPORTED_TRANSPORTS))
+        raise ValueError(
+            f"Unsupported MCP transport_type: {transport}. Supported: {supported}"
+        )
+    return transport
 
 
 async def _open_sse_transport(
@@ -103,13 +135,24 @@ async def _open_stdio_transport(
     stack: AsyncExitStack,
     server: dict[str, Any],
 ) -> tuple[Any, Any, str]:
-    env = {**os.environ, **server["env"]} if server.get("env") else None
     server_params = StdioServerParameters(
         command=server["command"],
         args=server["args"],
-        env=env,
+        env=build_stdio_env(server),
     )
     read_stream, write_stream = await stack.enter_async_context(
         stdio_client(server_params)
     )
     return read_stream, write_stream, "stdio"
+
+
+def build_stdio_env(server: dict[str, Any]) -> dict[str, str] | None:
+    """Return a scrubbed stdio env plus explicit app-owned overrides."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in STDIO_ENV_ALLOWLIST or key.startswith("LC_")
+    }
+    explicit_env = server.get("env") or {}
+    env.update({str(key): str(value) for key, value in explicit_env.items()})
+    return env

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from omnicoreagent.governance import (
+    GovernanceEngine,
+    UnknownCapabilityError,
+    policy_from_mapping,
+)
 from omnicoreagent.mcp_clients_connection.client import MCPClient
+from omnicoreagent.mcp_clients_connection.transports import (
+    build_stdio_env,
+    normalize_transport_type,
+)
 
 # Mock data for testing
 MOCK_MODEL_CONFIG = {
@@ -43,6 +52,29 @@ MOCK_TOOLS = [
     MockTool("tool1", "Test tool 1"),
     MockTool("tool2", "Test tool 2"),
 ]
+
+
+def _strict_mcp_connection_policy():
+    return policy_from_mapping(
+        {
+            "name": "mcp-connect-policy",
+            "mode": "strict",
+            "rules": {
+                "allow": [
+                    {
+                        "rule_id": "allow_docs_stdio_server",
+                        "capability": "mcp.server.start",
+                        "target": {"mcp_server": "server1"},
+                    },
+                    {
+                        "rule_id": "allow_docs_remote_server",
+                        "capability": "mcp.server.connect",
+                        "target": {"host": "test.com", "mcp_server": "server2"},
+                    },
+                ]
+            },
+        }
+    )
 
 
 class TestMCPClient:
@@ -209,6 +241,188 @@ class TestMCPClient:
             "server2 connected successfully",
         ]
         assert mock_client._connect_to_single_server.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_governance_denies_mcp_server_connect_before_transport(
+        self,
+        mock_client,
+    ):
+        mock_client.governance_engine = GovernanceEngine(
+            policy_from_mapping(
+                {
+                    "name": "deny-mcp-connect",
+                    "mode": "strict",
+                    "rules": {},
+                }
+            )
+        )
+
+        with patch(
+            "omnicoreagent.mcp_clients_connection.client.open_server_transport"
+        ) as open_transport:
+            with pytest.raises(UnknownCapabilityError):
+                await mock_client._connect_to_single_server(
+                    MOCK_MCP_SERVERS[0],
+                    "server1",
+                )
+
+        open_transport.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_governance_allows_mcp_server_connect_before_transport(
+        self,
+        mock_client,
+    ):
+        mock_client.governance_engine = GovernanceEngine(_strict_mcp_connection_policy())
+        server_info = MagicMock()
+        server_info.name = "server1"
+        matching_session = AsyncMock()
+        matching_session.initialize = AsyncMock(
+            return_value=MagicMock(
+                serverInfo=server_info,
+            )
+        )
+        matching_session.list_tools = AsyncMock(return_value=MagicMock(tools=MOCK_TOOLS))
+        mock_transport = (AsyncMock(), AsyncMock())
+        mock_stack = AsyncMock()
+        mock_stack.enter_async_context.return_value = matching_session
+
+        with patch(
+            "omnicoreagent.mcp_clients_connection.client.AsyncExitStack",
+            return_value=mock_stack,
+        ), patch(
+            "omnicoreagent.mcp_clients_connection.client.open_server_transport",
+            AsyncMock(return_value=(*mock_transport, "stdio")),
+        ) as open_transport:
+            result = await mock_client._connect_to_single_server(
+                MOCK_MCP_SERVERS[0],
+                "server1",
+            )
+
+        assert result == "server1 connected successfully"
+        open_transport.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_governance_reauthorizes_reported_mcp_server_identity(
+        self,
+        mock_client,
+    ):
+        mock_client.governance_engine = GovernanceEngine(_strict_mcp_connection_policy())
+        server_info = MagicMock()
+        server_info.name = "unexpected-server"
+        reported_session = AsyncMock()
+        reported_session.initialize = AsyncMock(
+            return_value=MagicMock(
+                serverInfo=server_info,
+            )
+        )
+        reported_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+        mock_transport = (AsyncMock(), AsyncMock())
+        mock_stack = AsyncMock()
+        mock_stack.enter_async_context.return_value = reported_session
+
+        with patch(
+            "omnicoreagent.mcp_clients_connection.client.AsyncExitStack",
+            return_value=mock_stack,
+        ), patch(
+            "omnicoreagent.mcp_clients_connection.client.open_server_transport",
+            AsyncMock(return_value=(*mock_transport, "stdio")),
+        ) as open_transport:
+            with pytest.raises(UnknownCapabilityError):
+                await mock_client._connect_to_single_server(
+                    MOCK_MCP_SERVERS[0],
+                    "server1",
+                )
+
+        open_transport.assert_awaited_once()
+        mock_stack.aclose.assert_awaited_once()
+        assert "unexpected-server" not in mock_client.sessions
+
+    @pytest.mark.asyncio
+    async def test_unsupported_mcp_transport_fails_before_transport(self, mock_client):
+        mock_client.governance_engine = GovernanceEngine(_strict_mcp_connection_policy())
+        server = {
+            "name": "server1",
+            "transport_type": "http",
+            "command": "mock_command",
+            "args": [],
+        }
+
+        with patch(
+            "omnicoreagent.mcp_clients_connection.client.open_server_transport"
+        ) as open_transport:
+            with pytest.raises(ValueError, match="Unsupported MCP transport_type: http"):
+                await mock_client._connect_to_single_server(server, "server1")
+
+        open_transport.assert_not_called()
+
+    def test_transport_normalization_rejects_unsupported_type(self):
+        with pytest.raises(ValueError, match="Unsupported MCP transport_type: http"):
+            normalize_transport_type({"transport_type": "http"})
+
+    @pytest.mark.asyncio
+    async def test_governance_checks_dynamic_add_servers(self, mock_client):
+        mock_client.governance_engine = GovernanceEngine(
+            policy_from_mapping(
+                {
+                    "name": "deny-dynamic-mcp-connect",
+                    "mode": "strict",
+                    "rules": {},
+                }
+            )
+        )
+
+        with patch(
+            "omnicoreagent.mcp_clients_connection.client.open_server_transport"
+        ) as open_transport:
+            with pytest.raises(UnknownCapabilityError):
+                await mock_client.add_servers([MOCK_MCP_SERVERS[1]])
+
+        open_transport.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connect_to_servers_surfaces_governance_error(self, mock_client):
+        mock_client.governance_engine = GovernanceEngine(
+            policy_from_mapping(
+                {
+                    "name": "deny-mcp-connect",
+                    "mode": "strict",
+                    "rules": {},
+                }
+            )
+        )
+
+        with patch(
+            "omnicoreagent.mcp_clients_connection.client.open_server_transport"
+        ) as open_transport:
+            with pytest.raises(UnknownCapabilityError):
+                await mock_client.connect_to_servers()
+
+        open_transport.assert_not_called()
+
+    def test_stdio_env_uses_only_explicit_server_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("LANG", "C.UTF-8")
+        monkeypatch.setenv("HTTPS_PROXY", "http://secret@example.test")
+
+        env = build_stdio_env({"env": {"SAFE_TOKEN": "explicit", "COUNT": 3}})
+
+        assert env["PATH"] == "/usr/bin"
+        assert env["LANG"] == "C.UTF-8"
+        assert env["SAFE_TOKEN"] == "explicit"
+        assert env["COUNT"] == "3"
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        assert "HTTPS_PROXY" not in env
+
+    def test_stdio_env_uses_scrubbed_baseline_without_explicit_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        env = build_stdio_env({})
+
+        assert env["PATH"] == "/usr/bin"
+        assert "AWS_SECRET_ACCESS_KEY" not in env
 
     @pytest.mark.asyncio
     async def test_remove_server(self, mock_client):

--- a/tests/test_governance_core.py
+++ b/tests/test_governance_core.py
@@ -79,6 +79,19 @@ class AsyncApprovalResolver:
         )
 
 
+class RecordingApprovalResolver:
+    def __init__(self):
+        self.requests = []
+
+    async def resolve(self, request):
+        self.requests.append(request)
+        return ApprovalResult(
+            approved=True,
+            approval_id=request.approval_id,
+            resolved_by="recording-test",
+        )
+
+
 def _policy(*, mode=PolicyMode.STRICT):
     return policy_from_mapping(
         {
@@ -505,6 +518,39 @@ async def test_governance_engine_uses_approval_resolver_for_ask_decision():
     assert decision.effect == PolicyEffect.ALLOW
     assert decision.approval_id is not None
     assert decision.reason == "approved in test"
+
+
+@pytest.mark.asyncio
+async def test_governance_approval_request_preserves_authority_context():
+    resolver = RecordingApprovalResolver()
+    engine = GovernanceEngine(
+        build_default_policy("interactive-dev"),
+        approval_resolver=resolver,
+    )
+
+    decision = await engine.authorize(
+        AuthorityRequest(
+            capability="tool.mcp.call",
+            actor="agent",
+            provider="mcp",
+            execution_surface="mcp",
+            target={"tool_name": "search_docs", "mcp_server": "docs-server"},
+            risk_level="low",
+            method="call_tool",
+            mcp_server="docs-server",
+            metadata={"tool_name": "search_docs"},
+        )
+    )
+
+    assert decision.effect == PolicyEffect.ALLOW
+    approval_request = resolver.requests[0]
+    assert approval_request.capability == "tool.mcp.call"
+    assert approval_request.provider == "mcp"
+    assert approval_request.execution_surface == "mcp"
+    assert approval_request.mcp_server == "docs-server"
+    assert approval_request.target.tool_name == "search_docs"
+    assert approval_request.target.mcp_server == "docs-server"
+    assert approval_request.metadata["tool_name"] == "search_docs"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_batch_runner.py
+++ b/tests/test_tool_batch_runner.py
@@ -1,5 +1,6 @@
 import pytest
 import asyncio
+from types import SimpleNamespace
 
 from omnicoreagent.core.telemetry import (
     ActorType,
@@ -21,7 +22,11 @@ from omnicoreagent.core.workspace.config import WorkspaceConfig
 from omnicoreagent.core.workspace.tools import build_tool_registry_workspace_files
 from omnicoreagent.core.types import AgentState, SessionState, ToolCallResult
 from omnicoreagent.core.agents.loop_detection import RobustLoopDetector
-from omnicoreagent.governance import GovernanceEngine, policy_from_mapping
+from omnicoreagent.governance import (
+    GovernanceEngine,
+    build_default_policy,
+    policy_from_mapping,
+)
 from omnicoreagent.governance.models import PolicyBudget
 
 
@@ -134,6 +139,37 @@ def _allow_workspace_policy():
                         "capability": "workspace.artifacts.*",
                     },
                 ]
+            },
+        }
+    )
+
+
+def _mcp_policy():
+    return policy_from_mapping(
+        {
+            "name": "mcp-policy",
+            "mode": "strict",
+            "rules": {
+                "deny": [
+                    {
+                        "rule_id": "deny_destructive_docs",
+                        "capability": "tool.mcp.call",
+                        "target": {
+                            "mcp_server": "docs-server",
+                            "tool_name": "delete_docs",
+                        },
+                    }
+                ],
+                "allow": [
+                    {
+                        "rule_id": "allow_docs_search",
+                        "capability": "tool.mcp.call",
+                        "target": {
+                            "mcp_server": "docs-server",
+                            "tool_name": "search_docs",
+                        },
+                    }
+                ],
             },
         }
     )
@@ -471,7 +507,7 @@ async def test_governance_allows_workspace_read(session_state):
 
 
 @pytest.mark.asyncio
-async def test_governance_fails_closed_for_mcp_until_phase_three(session_state):
+async def test_governance_requires_policy_for_mcp_tool(session_state):
     executor = CountingExecutor()
     runner = ToolBatchRunner(
         agent_name="test_agent",
@@ -515,9 +551,217 @@ async def test_governance_fails_closed_for_mcp_until_phase_three(session_state):
 
     assert executor.calls == 0
     assert tools_results[0]["status"] == "error"
-    assert "MCP governance is not implemented" in obs_text
+    assert "Unknown capability denied" in obs_text
     assert history[0]["metadata"]["args"] == "[REDACTED]"
-    assert history[0]["metadata"]["governance_error_code"] == "ungoverned_capability"
+    assert history[0]["metadata"]["governance_error_code"] == "unknown_capability"
+
+
+@pytest.mark.asyncio
+async def test_governance_interactive_default_requires_mcp_approval(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(build_default_policy("interactive-dev")),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="remote_search",
+            tool_args={"query": "docs"},
+            tool_call_id="tool-call-mcp-approval",
+            tool_provider="mcp",
+            tool_server="search",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-mcp-approval",
+        telemetry_recorder=None,
+        tool_batch_name="remote_search",
+        tool_batch_args=[{"query": "docs"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 0
+    assert tools_results[0]["status"] == "error"
+    assert "Matched ask policy rule" in obs_text
+    assert history[0]["metadata"]["governance_error_code"] == "approval_required"
+
+
+@pytest.mark.asyncio
+async def test_governance_allows_specific_mcp_tool(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_mcp_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="search_docs",
+            tool_args={"query": "governance"},
+            tool_call_id="tool-call-mcp-allow",
+            tool_provider="mcp",
+            tool_server="docs-server",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-mcp-allow",
+        telemetry_recorder=None,
+        tool_batch_name="search_docs",
+        tool_batch_args=[{"query": "governance"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 1
+    assert tools_results[0]["status"] == "success"
+    assert tools_results[0]["args"] == "[REDACTED]"
+    assert history[0]["metadata"]["args"] == "[REDACTED]"
+    assert obs_text == "search_docs:ok"
+
+
+@pytest.mark.asyncio
+async def test_governance_wraps_resolved_mcp_call_without_server_changes(
+    session_state,
+):
+    class FakeMcpSession:
+        def __init__(self):
+            self.calls = []
+
+        async def call_tool(self, tool_name, tool_args):
+            self.calls.append((tool_name, tool_args))
+            return {"status": "success", "data": "docs result"}
+
+    session = FakeMcpSession()
+    resolved = await ToolCallResolver().resolve_single_action(
+        action=ToolAction(
+            tool_name="search_docs",
+            parameters={"query": "policy"},
+            raw={"tool": "search_docs", "parameters": {"query": "policy"}},
+        ),
+        sessions={"docs-server": {"session": session}},
+        mcp_tools={"docs-server": [SimpleNamespace(name="search_docs")]},
+        local_tools=None,
+    )
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_mcp_policy()),
+    )
+    history = []
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["data"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=[resolved],
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-resolved-mcp",
+        telemetry_recorder=None,
+        tool_batch_name="search_docs",
+        tool_batch_args=[{"query": "policy"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert session.calls == [("search_docs", {"query": "policy"})]
+    assert tools_results[0]["status"] == "success"
+    assert tools_results[0]["args"] == "[REDACTED]"
+    assert history[0]["metadata"]["args"] == "[REDACTED]"
+    assert obs_text == "docs result"
+
+
+@pytest.mark.asyncio
+async def test_governance_denies_specific_mcp_tool_on_allowed_server(session_state):
+    executor = CountingExecutor()
+    runner = ToolBatchRunner(
+        agent_name="test_agent",
+        tool_call_timeout=10,
+        governance_engine=GovernanceEngine(_mcp_policy()),
+    )
+    history = []
+    tool_calls = [
+        ToolCallResult(
+            tool_executor=executor,
+            tool_name="delete_docs",
+            tool_args={"path": "prod"},
+            tool_call_id="tool-call-mcp-deny",
+            tool_provider="mcp",
+            tool_server="docs-server",
+        )
+    ]
+
+    async def add_message_to_history(role, content, metadata=None, session_id=None):
+        history.append({"role": role, "content": content, "metadata": metadata or {}})
+
+    async def parse_tool_observation(raw_output):
+        return raw_output
+
+    def build_tool_results_observation(
+        tool_call_results, tools_results, session_state, session_id
+    ):
+        return tools_results[0]["message"]
+
+    obs_text, tools_results = await runner.execute(
+        tool_call_results=tool_calls,
+        session_state=session_state,
+        add_message_to_history=add_message_to_history,
+        session_id="governed-mcp-deny",
+        telemetry_recorder=None,
+        tool_batch_name="delete_docs",
+        tool_batch_args=[{"path": "prod"}],
+        parse_tool_observation=parse_tool_observation,
+        build_tool_results_observation=build_tool_results_observation,
+    )
+
+    assert executor.calls == 0
+    assert tools_results[0]["status"] == "error"
+    assert "Governance denied tool execution" in obs_text
+    assert history[0]["metadata"]["governance_error_code"] == "policy_denied"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_call_resolver.py
+++ b/tests/test_tool_call_resolver.py
@@ -177,6 +177,29 @@ async def test_resolve_single_action_uses_mcp_tools_before_local(resolver):
 
 
 @pytest.mark.asyncio
+async def test_resolve_single_action_rejects_ambiguous_mcp_tool_names(resolver):
+    resolved = await resolver.resolve_single_action(
+        action=ToolAction(
+            tool_name="search",
+            parameters={"query": "runtime"},
+            raw={"tool": "search", "parameters": {"query": "runtime"}},
+        ),
+        sessions={
+            "docs": {"session": object()},
+            "tickets": {"session": object()},
+        },
+        mcp_tools={
+            "docs": [SimpleNamespace(name="search")],
+            "tickets": [SimpleNamespace(name="search")],
+        },
+        local_tools=None,
+    )
+
+    assert isinstance(resolved, ToolError)
+    assert "available on multiple servers" in resolved.observation
+
+
+@pytest.mark.asyncio
 async def test_resolve_single_action_rejects_tool_call_to_sub_agent(resolver):
     sub_agent = SimpleNamespace(name="research_agent")
 


### PR DESCRIPTION
## Summary
- enforce governance before MCP server start/connect and MCP tool execution
- surface governance failures from MCP connect/add-server paths as structured errors
- reject ambiguous MCP tool names, unsupported transports, and reported server identity drift
- scrub stdio MCP process env to an operational allowlist plus explicit app-owned env
- update governed execution architecture/spec wording for app-owned approvals and current MCP phase boundaries

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_client.py tests/test_tool_call_resolver.py tests/test_tool_batch_runner.py tests/test_governance_core.py -q
- uv run ruff check src/omnicoreagent/governance src/omnicoreagent/mcp_clients_connection src/omnicoreagent/core/runtime src/omnicoreagent/core/tools tests/test_client.py tests/test_tool_call_resolver.py tests/test_governance_core.py tests/test_tool_batch_runner.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_background_task_store_contract.py::test_task_store_contract_active_runs_and_cancel_previous\[redis\] -q
- git diff --check

## Notes
- Full non-Mongo suite reached 936 passed, 23 deselected but two OmniServe background timeout tests failed under full-suite load with the generic request timeout payload; both passed in isolation immediately after.