### PR TITLE
Stabilize background timeout handling

### DIFF
--- a/src/omnicoreagent/background/supervisor.py
+++ b/src/omnicoreagent/background/supervisor.py
@@ -390,7 +390,7 @@ class BackgroundSupervisor:
                 timeout_seconds=running.task.timeout_seconds,
             )
         )
-        self.active_agent_tasks[running.run.run_id] = agent_task
+        self.track_active_agent_task(running.run.run_id, agent_task)
         return await agent_task
 
     async def complete_successful_attempt(
@@ -471,6 +471,15 @@ class BackgroundSupervisor:
         self.active_agent_tasks.pop(running.run.run_id, None)
         running.heartbeat_task.cancel()
         await self.drain_cancelled_task(running.heartbeat_task)
+
+    def track_active_agent_task(self, run_id: str, task: asyncio.Task) -> None:
+        self.active_agent_tasks[run_id] = task
+
+        def _forget(completed: asyncio.Task) -> None:
+            if self.active_agent_tasks.get(run_id) is completed:
+                self.active_agent_tasks.pop(run_id, None)
+
+        task.add_done_callback(_forget)
 
     async def run_agent_with_run_context(
         self,

--- a/src/omnicoreagent/serve/middleware/timeout.py
+++ b/src/omnicoreagent/serve/middleware/timeout.py
@@ -20,6 +20,8 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
         self.timeout_seconds = timeout_seconds
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if _route_manages_timeout(request.url.path):
+            return await call_next(request)
         try:
             return await asyncio.wait_for(
                 call_next(request), timeout=self.timeout_seconds
@@ -48,3 +50,17 @@ def add_timeout_middleware(app: FastAPI, config: OmniServeConfig) -> None:
 
     app.add_middleware(TimeoutMiddleware, timeout_seconds=config.request_timeout)
     logger.info(f"OmniServe: Request timeout set to {config.request_timeout}s")
+
+
+def _route_manages_timeout(path: str) -> bool:
+    """Return true for routes that produce their own structured timeout response."""
+    parts = [part for part in path.strip("/").split("/") if part]
+    for index, part in enumerate(parts):
+        if part != "background":
+            continue
+        return (
+            len(parts) == index + 4
+            and parts[index + 1] == "tasks"
+            and parts[index + 3] == "run"
+        )
+    return False

--- a/tests/test_background_durable_manager_integration.py
+++ b/tests/test_background_durable_manager_integration.py
@@ -16,6 +16,7 @@ from omnicoreagent.core.workspace.manager import Workspace
 
 
 DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+REDIS_MANAGER_CONNECT_TIMEOUT = 2.0
 DEFAULT_MONGODB_URI = "mongodb://localhost:27017"
 DEFAULT_MONGODB_DATABASE = "omnicoreagent_test"
 
@@ -107,7 +108,7 @@ async def test_redis_manager_executes_queued_run_after_restart(tmp_path):
         "backend": "redis",
         "url": os.getenv("OMNICOREAGENT_TEST_REDIS_URL", DEFAULT_REDIS_URL),
         "prefix": prefix,
-        "connect_timeout": 0.2,
+        "connect_timeout": REDIS_MANAGER_CONNECT_TIMEOUT,
     }
     await require_redis_available(config)
     try:

--- a/tests/test_background_task_store_contract.py
+++ b/tests/test_background_task_store_contract.py
@@ -32,6 +32,7 @@ from omnicoreagent.background.models import (
 
 REDIS_CONTRACT_URL_ENV = "OMNICOREAGENT_TEST_REDIS_URL"
 DEFAULT_REDIS_CONTRACT_URL = "redis://localhost:6379/0"
+REDIS_CONTRACT_CONNECT_TIMEOUT = 2.0
 MONGODB_CONTRACT_URI_ENV = "OMNICOREAGENT_TEST_MONGODB_URI"
 MONGODB_CONTRACT_DATABASE_ENV = "OMNICOREAGENT_TEST_MONGODB_DATABASE"
 DEFAULT_MONGODB_CONTRACT_URI = "mongodb://localhost:27017"
@@ -92,7 +93,7 @@ async def create_store(kind: str, tmp_path):
         store = RedisTaskStore(
             url=redis_contract_url(),
             prefix=f"test:omnicoreagent:background:{uuid4().hex}",
-            connect_timeout=0.2,
+            connect_timeout=REDIS_CONTRACT_CONNECT_TIMEOUT,
             lock_timeout=0.5,
         )
     elif kind == "mongodb":
@@ -670,7 +671,7 @@ async def test_redis_task_store_contract_persists_across_reconnect():
     first = RedisTaskStore(
         url=url,
         prefix=prefix,
-        connect_timeout=0.2,
+        connect_timeout=REDIS_CONTRACT_CONNECT_TIMEOUT,
         lock_timeout=0.5,
     )
     try:
@@ -727,7 +728,7 @@ async def test_redis_task_store_contract_persists_across_reconnect():
         restored = RedisTaskStore(
             url=url,
             prefix=prefix,
-            connect_timeout=0.2,
+            connect_timeout=REDIS_CONTRACT_CONNECT_TIMEOUT,
             lock_timeout=0.5,
         )
         await restored.initialize()

--- a/tests/test_omniserve_background.py
+++ b/tests/test_omniserve_background.py
@@ -9,6 +9,7 @@ import pytest
 from omnicoreagent import OmniServe, OmniServeConfig
 from omnicoreagent.background import BackgroundAgentManager
 from omnicoreagent.core.workspace.manager import Workspace
+from omnicoreagent.serve.middleware.timeout import _route_manages_timeout
 
 
 @pytest.fixture(autouse=True)
@@ -462,6 +463,13 @@ def test_background_api_wait_true_times_out_before_slow_inline_run_finishes(tmp_
         assert timeout_detail["request_timeout_seconds"] == 1
 
     assert len(agent.calls) == 1
+
+
+def test_background_manual_run_route_owns_structured_timeout_with_api_prefix():
+    assert _route_manages_timeout("/background/tasks/task-1/run") is True
+    assert _route_manages_timeout("/api/v1/background/tasks/task-1/run") is True
+    assert _route_manages_timeout("/background/tasks/task-1") is False
+    assert _route_manages_timeout("/background/runs/run-1") is False
 
 
 def test_background_api_rejects_invalid_schedule_payload(tmp_path):


### PR DESCRIPTION
## Summary
- let the background manual-run endpoint own its structured wait timeout response instead of racing the global request timeout middleware
- clean active background agent task registry immediately when agent tasks complete or are cancelled
- make Redis live integration test connection timeouts practical under full-suite load

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_omniserve_background.py::test_background_api_wait_true_without_worker_times_out_on_delayed_retry tests/test_omniserve_background.py::test_background_api_wait_true_times_out_before_slow_inline_run_finishes tests/test_omniserve_background.py::test_background_manual_run_route_owns_structured_timeout_with_api_prefix -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_omniserve_background.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_background_agent.py::test_cancel_running_same_worker_stops_active_agent_task tests/test_background_agent.py::test_cancel_requested_before_agent_task_starts_marks_cancelled -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_background_durable_manager_integration.py::test_redis_manager_executes_queued_run_after_restart tests/test_background_task_store_contract.py -q -k redis
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_background_agent.py tests/test_omniserve_background.py tests/test_background_durable_manager_integration.py tests/test_background_task_store_contract.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_omniserve_production_validation.py::test_omniserve_runtime_memory_backends_expose_session_history\[mongodb\] -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests -q
- uv run ruff check src/omnicoreagent/background/supervisor.py src/omnicoreagent/serve/middleware/timeout.py tests/test_omniserve_background.py tests/test_background_task_store_contract.py tests/test_background_durable_manager_integration.py
- git diff --check

Full suite result: 962 passed.