### PR TITLE
Govern subagent and background policy propagation

### DIFF
--- a/engineering/architecture/governed-execution.md
+++ b/engineering/architecture/governed-execution.md
@@ -169,7 +169,12 @@ Examples:
 - `observation.inject`
 - `subagent.spawn`
 - `background.task.create`
-- `background.task.cancel`
+- `background.task.update`
+- `background.task.delete`
+- `background.task.pause`
+- `background.task.resume`
+- `background.run.start`
+- `background.run.cancel`
 - `serve.response.stream`
 
 Capability requests include actor, target, scope, inputs, declared risk, data
@@ -488,7 +493,8 @@ Background tasks must carry policy across time.
 
 Every durable task stores:
 
-- policy snapshot id
+- policy snapshot id, schema version, and hash
+- budget counters from the latest governed decision on that task/run
 - task capability scope
 - sandbox profile
 - workspace scope
@@ -497,8 +503,11 @@ Every durable task stores:
 - budget and expiry
 - approval state
 
-If a task resumes after restart, it resumes under the stored policy snapshot
-or fails closed if that policy can no longer be resolved.
+If a task resumes after restart, the stored task and run policy snapshots must
+match the active policy version and hash. If the snapshot is missing,
+unavailable, or different, execution fails closed before the agent runs.
+Stored budget counters restore the active policy budget floor before execution
+continues, so restart cannot reset already-consumed background authority.
 
 ## MCP Tools
 

--- a/engineering/specifications/governed-execution.md
+++ b/engineering/specifications/governed-execution.md
@@ -529,7 +529,7 @@ Required enforcement points:
 | Artifacts | `workspace.artifacts.read/write` |
 | Memory | `memory.read/write` |
 | Subagent spawn | `subagent.spawn` plus derived child policy |
-| Background task | `background.task.create/schedule/cancel` |
+| Background task/run | `background.task.create/update/delete/pause/resume`, `background.run.start/cancel` |
 | Skills | `skill.load` and `skill.execute` |
 | Sandbox command | `process.exec` plus filesystem/network/secrets |
 | Network | `network.*` |
@@ -757,9 +757,13 @@ Required tests:
 
 Rules:
 
-- Task creation and scheduling require policy decisions.
-- Durable task stores a policy snapshot id.
-- Restarted tasks load the same snapshot or fail closed.
+- Task creation, update, deletion, pause, resume, scheduling, run start, and run
+  cancellation require policy decisions.
+- Durable task and run records store a policy snapshot id, schema version, and hash.
+- Restarted tasks load the same snapshot or fail closed before the agent runs.
+- Missing snapshots fail closed for governed background execution.
+- Stored snapshots carry budget counters and restore the active policy budget
+  floor before background execution decisions.
 - Task retry does not reset policy budgets unless configured.
 - Long-running tasks may need approval renewal.
 
@@ -769,7 +773,7 @@ Required tests:
 - restart loads snapshot
 - missing snapshot fails closed
 - retry preserves policy
-- cancel requires policy
+- cancel run requires policy
 
 ---
 
@@ -1096,9 +1100,20 @@ code call this boundary instead of each implementing policy semantics.
 
 ### Phase 5: Subagent and Background Policy
 
-- Derive child policy for subagents.
-- Store policy snapshot for background tasks.
-- Enforce restart fail-closed behavior.
+- Gate dynamic subagent spawn behind `subagent.spawn`.
+- Prevent recursive spawn by deriving subagent runtime config with
+  `enable_subagents=False`.
+- Derive an inherited child policy for subagents that denies recursive spawn
+  and cannot multiply parent budget authority by default.
+- Include subagent task, tool, MCP, workspace, memory, budget, and deadline
+  metadata in spawn authority requests so later policy composition can narrow
+  those scopes deterministically.
+- Store policy snapshots on governed background task and run records.
+- Enforce restart fail-closed behavior for missing, unavailable, or changed
+  policy snapshots.
+- Restore stored background budget counters as the active policy budget floor on
+  restart.
+- Gate background run execution and cancellation behind policy.
 
 ### Phase 6: Sandbox Runtime Interface
 

--- a/src/omnicoreagent/background/manager.py
+++ b/src/omnicoreagent/background/manager.py
@@ -37,6 +37,15 @@ from omnicoreagent.background.store.router import TaskStoreRouter
 from omnicoreagent.background.supervisor import BackgroundSupervisor
 from omnicoreagent.background.workspace_io import BackgroundWorkspaceIO
 from omnicoreagent.core.telemetry import InMemoryTelemetryStore, TelemetryStream
+from omnicoreagent.governance.capabilities import (
+    background_run_authority_request,
+    background_task_authority_request,
+)
+from omnicoreagent.governance.snapshots import (
+    POLICY_SNAPSHOT_METADATA_KEY,
+    attach_policy_snapshot,
+    require_current_policy_snapshot,
+)
 
 
 _EVENT_REPLAY_TIMEOUT_SECONDS = 2.0
@@ -53,21 +62,27 @@ class BackgroundAgentManager:
         workspace: Any = None,
         telemetry_store: Any = None,
         telemetry_stream: Any = None,
+        governance_engine: Any = None,
         worker_id: str | None = None,
         lease_seconds: int = 30,
     ) -> None:
         self.task_store = TaskStoreRouter.create(task_store)
         self.memory_router = memory_router
         self.telemetry_store = telemetry_store or (
-            telemetry_stream.store if telemetry_stream is not None else InMemoryTelemetryStore()
+            telemetry_stream.store
+            if telemetry_stream is not None
+            else InMemoryTelemetryStore()
         )
-        self.telemetry_stream = telemetry_stream or TelemetryStream(self.telemetry_store)
+        self.telemetry_stream = telemetry_stream or TelemetryStream(
+            self.telemetry_store
+        )
         if self.telemetry_stream.store is not self.telemetry_store:
             raise ValueError(
                 "telemetry_stream.store must be the same object as telemetry_store"
             )
         self.worker_id = worker_id or f"worker_{uuid4().hex}"
         self.lease_seconds = lease_seconds
+        self.governance_engine = governance_engine
 
         self._agents: dict[str, Any] = {}
         self._running = False
@@ -86,6 +101,7 @@ class BackgroundAgentManager:
         self._scheduler = BackgroundScheduleDispatcher(
             task_store=self.task_store,
             event_log=self._event_log,
+            governance_engine=self.governance_engine,
             emit_run=self._emit_run,
         )
         self._supervisor = BackgroundSupervisor(
@@ -94,6 +110,7 @@ class BackgroundAgentManager:
             worker_id=self.worker_id,
             lease_seconds=self.lease_seconds,
             memory_router=self.memory_router,
+            governance_engine=self.governance_engine,
             event_log=self._event_log,
             emit_run=self._emit_run,
         )
@@ -124,7 +141,7 @@ class BackgroundAgentManager:
         if existing and not replace:
             raise AgentAlreadyRegisteredError(
                 f"Agent already registered: {agent_spec.agent_id}"
-        )
+            )
         self._agents.pop(agent_spec.agent_id, None)
         await self.task_store.save_agent(agent_spec)
         return agent_spec
@@ -181,23 +198,78 @@ class BackgroundAgentManager:
         )
         if not await self.task_store.get_agent(task.agent_id):
             raise AgentNotFoundError(f"Agent not found: {task.agent_id}")
-        if await self.task_store.get_task(task.task_id) and not replace:
+        existing = await self.task_store.get_task(task.task_id)
+        if existing and not replace:
             raise TaskAlreadyRegisteredError(f"Task already registered: {task.task_id}")
+        if self.governance_engine is not None:
+            action = "update" if existing is not None else "create"
+            if existing is not None:
+                require_current_policy_snapshot(
+                    existing.metadata,
+                    self.governance_engine,
+                    surface=f"background task {existing.task_id}",
+                    required=True,
+                )
+            await self.governance_engine.authorize(
+                background_task_authority_request(task=task, action=action)
+            )
+            task = task.model_copy(
+                update={
+                    "metadata": attach_policy_snapshot(
+                        task.metadata,
+                        self.governance_engine,
+                    ),
+                    "updated_at": utc_now(),
+                }
+            )
         await self.task_store.save_task(task)
         return task
 
-    async def update_task(self, task_id: str, patch: dict[str, Any]) -> BackgroundTaskSpec:
+    async def update_task(
+        self, task_id: str, patch: dict[str, Any]
+    ) -> BackgroundTaskSpec:
         existing = await self.task_store.get_task(task_id)
         if not existing:
             raise TaskNotFoundError(f"Task not found: {task_id}")
+        if self.governance_engine is not None:
+            require_current_policy_snapshot(
+                existing.metadata,
+                self.governance_engine,
+                surface=f"background task {existing.task_id}",
+                required=True,
+            )
         data = existing.model_dump(mode="python")
         data.update(patch)
         data["updated_at"] = utc_now()
         updated = BackgroundTaskSpec(**data)
+        if self.governance_engine is not None:
+            await self.governance_engine.authorize(
+                background_task_authority_request(task=updated, action="update")
+            )
+            updated = updated.model_copy(
+                update={
+                    "metadata": attach_policy_snapshot(
+                        updated.metadata,
+                        self.governance_engine,
+                    ),
+                    "updated_at": utc_now(),
+                }
+            )
         await self.task_store.save_task(updated)
         return updated
 
     async def delete_task(self, task_id: str, delete_runs: bool = False) -> None:
+        existing = await self.task_store.get_task(task_id)
+        if self.governance_engine is not None and existing is not None:
+            require_current_policy_snapshot(
+                existing.metadata,
+                self.governance_engine,
+                surface=f"background task {existing.task_id}",
+                required=True,
+            )
+            await self.governance_engine.authorize(
+                background_task_authority_request(task=existing, action="delete")
+            )
         await self.task_store.delete_task(task_id)
         if delete_runs:
             await self.task_store.delete_runs_for_task(task_id)
@@ -240,9 +312,31 @@ class BackgroundAgentManager:
         self._initialized = False
 
     async def pause_task(self, task_id: str) -> None:
+        task = await self.task_store.get_task(task_id)
+        if self.governance_engine is not None and task is not None:
+            require_current_policy_snapshot(
+                task.metadata,
+                self.governance_engine,
+                surface=f"background task {task.task_id}",
+                required=True,
+            )
+            await self.governance_engine.authorize(
+                background_task_authority_request(task=task, action="pause")
+            )
         await self.task_store.set_schedule_paused(task_id, True)
 
     async def resume_task(self, task_id: str) -> None:
+        task = await self.task_store.get_task(task_id)
+        if self.governance_engine is not None and task is not None:
+            require_current_policy_snapshot(
+                task.metadata,
+                self.governance_engine,
+                surface=f"background task {task.task_id}",
+                required=True,
+            )
+            await self.governance_engine.authorize(
+                background_task_authority_request(task=task, action="resume")
+            )
         await self.task_store.set_schedule_paused(task_id, False)
 
     async def run_now(
@@ -255,7 +349,36 @@ class BackgroundAgentManager:
         task = await self.task_store.get_task(task_id)
         if not task or not task.enabled:
             raise TaskNotFoundError(f"Task not found: {task_id}")
+        if self.governance_engine is not None:
+            require_current_policy_snapshot(
+                task.metadata,
+                self.governance_engine,
+                surface=f"background task {task.task_id}",
+                required=True,
+            )
         run = build_run(task, TriggerType.MANUAL, query or task.query)
+        if self.governance_engine is not None:
+            await self.governance_engine.authorize(
+                background_run_authority_request(action="start", run=run, task=task)
+            )
+            task = task.model_copy(
+                update={
+                    "metadata": attach_policy_snapshot(
+                        task.metadata,
+                        self.governance_engine,
+                    ),
+                    "updated_at": utc_now(),
+                }
+            )
+            await self.task_store.save_task(task)
+            run = run.model_copy(
+                update={
+                    "metadata": {
+                        **attach_policy_snapshot(run.metadata, self.governance_engine),
+                        "governance_run_start_authorized": True,
+                    }
+                }
+            )
         created = await self.task_store.create_run_with_overlap_guard(
             run, task.overlap_policy
         )
@@ -330,6 +453,25 @@ class BackgroundAgentManager:
 
     async def cancel_run(self, run_id: str) -> None:
         self._sync_services_config()
+        run = await self.task_store.get_run(run_id)
+        if run is not None:
+            if self.governance_engine is None:
+                if POLICY_SNAPSHOT_METADATA_KEY in run.metadata:
+                    require_current_policy_snapshot(
+                        run.metadata,
+                        None,
+                        surface=f"background run {run.run_id}",
+                    )
+            else:
+                require_current_policy_snapshot(
+                    run.metadata,
+                    self.governance_engine,
+                    surface=f"background run {run.run_id}",
+                    required=True,
+                )
+                await self.governance_engine.authorize(
+                    background_run_authority_request(action="cancel", run=run)
+                )
         await self._supervisor.cancel_run(run_id)
 
     async def recover_expired_runs(self) -> None:
@@ -538,6 +680,8 @@ class BackgroundAgentManager:
         self._supervisor.worker_id = self.worker_id
         self._supervisor.memory_router = self.memory_router
         self._supervisor.lease_seconds = self.lease_seconds
+        self._supervisor.governance_engine = self.governance_engine
+        self._scheduler.governance_engine = self.governance_engine
 
     def _sync_event_log_config(self) -> None:
         self._event_log.replay_timeout_seconds = self._event_replay_timeout_seconds

--- a/src/omnicoreagent/background/run_helpers.py
+++ b/src/omnicoreagent/background/run_helpers.py
@@ -37,6 +37,7 @@ def build_run(
         occurrence_id=occurrence_id,
         session_id=build_session_id(task, run_id),
         workspace_path=build_workspace_path(task, run_id),
+        metadata=dict(task.metadata),
     )
 
 

--- a/src/omnicoreagent/background/scheduler.py
+++ b/src/omnicoreagent/background/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from omnicoreagent.background.event_log import BackgroundEventLog
 from omnicoreagent.background.models import (
@@ -15,6 +16,13 @@ from omnicoreagent.background.models import (
 )
 from omnicoreagent.background.run_helpers import build_run
 from omnicoreagent.background.store.base import AbstractTaskStore
+from omnicoreagent.governance.capabilities import background_run_authority_request
+from omnicoreagent.governance.errors import GovernanceError
+from omnicoreagent.governance.snapshots import (
+    POLICY_SNAPSHOT_METADATA_KEY,
+    attach_policy_snapshot,
+    require_current_policy_snapshot,
+)
 
 
 class BackgroundScheduleDispatcher:
@@ -25,10 +33,12 @@ class BackgroundScheduleDispatcher:
         *,
         task_store: AbstractTaskStore,
         event_log: BackgroundEventLog,
+        governance_engine=None,
         emit_run: Callable[..., Awaitable[None]] | None = None,
     ) -> None:
         self.task_store = task_store
         self.event_log = event_log
+        self.governance_engine = governance_engine
         self._emit_run = emit_run
 
     async def emit_run(self, event_name: str, run: BackgroundRun) -> None:
@@ -69,6 +79,11 @@ class BackgroundScheduleDispatcher:
                     due_at=due_at,
                     occurrence_id=occurrence_for_due,
                 )
+                try:
+                    task, run = await self._authorize_scheduled_run(task=task, run=run)
+                except GovernanceError:
+                    await self.task_store.set_schedule_paused(task.task_id, True)
+                    raise
                 existing_run_ids = {
                     item.run_id for item in await self.task_store.list_runs(task.task_id)
                 }
@@ -95,3 +110,47 @@ class BackgroundScheduleDispatcher:
                     created,
                 )
         return dispatched_any
+
+    async def _authorize_scheduled_run(
+        self, *, task, run: BackgroundRun
+    ) -> tuple[Any, BackgroundRun]:
+        if self.governance_engine is None:
+            if POLICY_SNAPSHOT_METADATA_KEY in task.metadata:
+                require_current_policy_snapshot(
+                    task.metadata,
+                    None,
+                    surface=f"background task {task.task_id}",
+                )
+            return task, run
+        require_current_policy_snapshot(
+            task.metadata,
+            self.governance_engine,
+            surface=f"background task {task.task_id}",
+            required=True,
+        )
+        await self.governance_engine.authorize(
+            background_run_authority_request(
+                action="start",
+                run=run,
+                task=task,
+                actor="background_scheduler",
+            )
+        )
+        task = task.model_copy(
+            update={
+                "metadata": attach_policy_snapshot(
+                    task.metadata,
+                    self.governance_engine,
+                ),
+                "updated_at": utc_now(),
+            }
+        )
+        await self.task_store.save_task(task)
+        return task, run.model_copy(
+            update={
+                "metadata": {
+                    **attach_policy_snapshot(run.metadata, self.governance_engine),
+                    "governance_run_start_authorized": True,
+                }
+            }
+        )

--- a/src/omnicoreagent/background/supervisor.py
+++ b/src/omnicoreagent/background/supervisor.py
@@ -34,6 +34,12 @@ from omnicoreagent.background.run_helpers import (
 )
 from omnicoreagent.background.store.base import AbstractTaskStore
 from omnicoreagent.background.transitions import BackgroundRunTransitions
+from omnicoreagent.governance.capabilities import background_run_authority_request
+from omnicoreagent.governance.errors import GovernanceError
+from omnicoreagent.governance.snapshots import (
+    attach_policy_snapshot,
+    require_current_policy_snapshot,
+)
 
 
 @dataclass(slots=True)
@@ -59,6 +65,7 @@ class BackgroundSupervisor:
         worker_id: str,
         lease_seconds: int,
         memory_router: Any = None,
+        governance_engine: Any = None,
         event_log: BackgroundEventLog,
         emit_run: Callable[..., Awaitable[None]] | None = None,
     ) -> None:
@@ -67,6 +74,7 @@ class BackgroundSupervisor:
         self.worker_id = worker_id
         self.lease_seconds = lease_seconds
         self.memory_router = memory_router
+        self.governance_engine = governance_engine
         self.event_log = event_log
         self._emit_run = emit_run
         self.transitions = BackgroundRunTransitions(
@@ -133,10 +141,10 @@ class BackgroundSupervisor:
                 except asyncio.TimeoutError:
                     return await self.task_store.get_run(run_id) or latest
 
-            if deadline is None:
+            if deadline is None and latest.status == RunStatus.QUEUED:
                 return latest
 
-            if asyncio.get_running_loop().time() >= deadline:
+            if deadline is not None and asyncio.get_running_loop().time() >= deadline:
                 return latest
 
             await asyncio.sleep(
@@ -221,11 +229,12 @@ class BackgroundSupervisor:
         if latest.status == RunStatus.QUEUED:
             await self.mark_terminal(latest, RunStatus.CANCELLED, "cancelled")
         elif (
-            latest.status == RunStatus.CLAIMED
-            and latest.lease_owner == self.worker_id
+            latest.status == RunStatus.CLAIMED and latest.lease_owner == self.worker_id
         ):
             await self.mark_terminal(latest, RunStatus.CANCELLED, "cancelled")
-        elif latest.status == RunStatus.RUNNING and latest.lease_owner == self.worker_id:
+        elif (
+            latest.status == RunStatus.RUNNING and latest.lease_owner == self.worker_id
+        ):
             active_task = self.active_agent_tasks.get(run_id)
             if active_task is not None and not active_task.done():
                 active_task.cancel()
@@ -328,6 +337,63 @@ class BackgroundSupervisor:
         if await self.task_store.is_cancel_requested(claimed.run_id):
             await self.mark_terminal(claimed, RunStatus.CANCELLED, "cancelled")
             return
+        try:
+            require_current_policy_snapshot(
+                claimed.metadata,
+                self.governance_engine,
+                surface=f"background run {claimed.run_id}",
+                required=self.governance_engine is not None,
+            )
+            require_current_policy_snapshot(
+                task.metadata,
+                self.governance_engine,
+                surface=f"background task {task.task_id}",
+                required=self.governance_engine is not None,
+            )
+            if (
+                self.governance_engine is not None
+                and not claimed.metadata.get("governance_run_start_authorized")
+            ):
+                await self.governance_engine.authorize(
+                    background_run_authority_request(
+                        action="start",
+                        run=claimed,
+                        task=task,
+                        actor="background_worker",
+                    )
+                )
+                task = task.model_copy(
+                    update={
+                        "metadata": attach_policy_snapshot(
+                            task.metadata,
+                            self.governance_engine,
+                        ),
+                        "updated_at": utc_now(),
+                    }
+                )
+                await self.task_store.save_task(task)
+                claimed = await self.task_store.update_run_metadata(
+                    claimed.run_id,
+                    {
+                        **attach_policy_snapshot(
+                            claimed.metadata,
+                            self.governance_engine,
+                        ),
+                        "governance_run_start_authorized": True,
+                    },
+                    self.worker_id,
+                    claimed.lease_token,
+                )
+        except Exception as exc:
+            if isinstance(exc, GovernanceError):
+                await self.task_store.update_run_metadata(
+                    claimed.run_id,
+                    {"governance_failure": dict(exc.metadata)},
+                    self.worker_id,
+                    claimed.lease_token,
+                )
+            await self.mark_terminal(claimed, RunStatus.FAILED, str(exc))
+            return
         return task, agent
 
     async def start_claimed_attempt(
@@ -354,7 +420,9 @@ class BackgroundSupervisor:
         attempt = BackgroundAttempt(
             run_id=run.run_id,
             attempt_number=attempt_number,
-            reason=AttemptReason.INITIAL if attempt_number == 1 else AttemptReason.RETRY,
+            reason=AttemptReason.INITIAL
+            if attempt_number == 1
+            else AttemptReason.RETRY,
             worker_id=self.worker_id,
             lease_token=run.lease_token,
         )

--- a/src/omnicoreagent/core/runtime/builder.py
+++ b/src/omnicoreagent/core/runtime/builder.py
@@ -67,6 +67,7 @@ def build_agent_runtime(
         agent_config=agent_config,
         prompt_builder=prompt_builder,
         memory_router=memory_router,
+        governance_engine=governance_engine,
         debug=debug,
     )
 

--- a/src/omnicoreagent/core/runtime/harness_tools.py
+++ b/src/omnicoreagent/core/runtime/harness_tools.py
@@ -15,6 +15,7 @@ def prepare_dynamic_subagents(
     agent_config: dict[str, Any],
     prompt_builder: Any,
     memory_router: Any,
+    governance_engine: Any = None,
     debug: bool,
 ) -> tuple[Any, Any]:
     if not enabled:
@@ -34,6 +35,7 @@ def prepare_dynamic_subagents(
         agent_config=agent_config,
         prompt_builder=prompt_builder,
         memory_router=memory_router,
+        governance_engine=governance_engine,
         debug=debug,
     )
     runtime("build_subagent_tools")(factory, local_tools)

--- a/src/omnicoreagent/core/subagents.py
+++ b/src/omnicoreagent/core/subagents.py
@@ -14,6 +14,8 @@ import json
 from typing import Any, Dict, List, Optional
 from omnicoreagent.core.tools.local_tools_registry import ToolRegistry
 from omnicoreagent.core.logging import logger
+from omnicoreagent.governance.capabilities import subagent_spawn_authority_requests
+from omnicoreagent.governance.snapshots import derive_subagent_policy
 
 
 class SubagentFactory:
@@ -34,6 +36,7 @@ class SubagentFactory:
         agent_config: Optional[Dict[str, Any]] = None,
         prompt_builder: Optional[Any] = None,
         memory_router: Optional[Any] = None,
+        governance_engine: Optional[Any] = None,
         debug: Optional[bool] = False,
     ):
         """
@@ -46,6 +49,7 @@ class SubagentFactory:
             agent_config: Full agent config (context_management, tool_offload, etc.)
             prompt_builder: Optional prompt builder with build_subagent_prompt support
             memory_router: MemoryRouter instance
+            governance_engine: Optional governed execution policy engine
             debug: Debug mode
         """
         self.base_model_config = base_model_config
@@ -55,9 +59,10 @@ class SubagentFactory:
         self.debug = debug
         self.agent_config = agent_config or {}
         self.prompt_builder = prompt_builder
+        self.governance_engine = governance_engine
         self._active_subagents: Dict[str, Any] = {}
 
-    def _build_subagent_config(self) -> Dict[str, Any]:
+    def _build_subagent_config(self, *, subagent_name: str = "subagent") -> Dict[str, Any]:
         """
         Build agent_config for subagents inheriting parent's config.
 
@@ -71,6 +76,18 @@ class SubagentFactory:
         config["max_steps"] = min(config.get("max_steps", 15), 15)
         config["enable_subagents"] = False
         config["enable_workspace_files"] = True
+        if self.governance_engine is not None:
+            governance_config = dict(config.get("governance_config") or {})
+            governance_config.update(
+                {
+                    "enabled": True,
+                    "policy": derive_subagent_policy(
+                        self.governance_engine.policy,
+                        subagent_name=subagent_name,
+                    ),
+                }
+            )
+            config["governance_config"] = governance_config
 
         return config
 
@@ -158,7 +175,7 @@ When you have completed the task:
             output_path=output_path,
         )
 
-        subagent_config = self._build_subagent_config()
+        subagent_config = self._build_subagent_config(subagent_name=name)
 
         from omnicoreagent.core.runtime.omnicore_agent import OmniCoreAgent
 
@@ -228,6 +245,7 @@ When you have completed the task:
                         "subagent_name": name,
                         "output_path": output_path,
                         "error": response[:500] if len(response) > 500 else response,
+                        "governance": self._governance_reference(),
                     },
                     "message": f"Subagent '{name}' encountered an error: {response[:100]}",
                 }
@@ -240,6 +258,7 @@ When you have completed the task:
                     "subagent_name": name,
                     "output_path": output_path,
                     "summary": response[:500] if len(response) > 500 else response,
+                    "governance": self._governance_reference(),
                 },
                 "message": f"Subagent '{name}' completed. Output saved to {output_path}",
             }
@@ -250,7 +269,11 @@ When you have completed the task:
 
             return {
                 "status": "error",
-                "data": {"subagent_name": name, "error": error_msg},
+                "data": {
+                    "subagent_name": name,
+                    "error": error_msg,
+                    "governance": self._governance_reference(),
+                },
                 "message": f"Subagent '{name}' failed: {error_msg}",
             }
 
@@ -273,6 +296,7 @@ When you have completed the task:
                 "message": "No subagents to spawn",
             }
 
+        await self._authorize_subagent_spawns(subagent_specs)
         logger.info(f"Spawning {len(subagent_specs)} subagents in parallel")
 
         tasks = [
@@ -323,6 +347,47 @@ When you have completed the task:
                 "results": processed_results,
             },
             "message": f"Completed {successful}/{len(subagent_specs)} subagents successfully",
+        }
+
+    async def _authorize_subagent_spawns(
+        self, subagent_specs: list[dict[str, Any]]
+    ) -> None:
+        if self.governance_engine is None:
+            return
+        requests = subagent_spawn_authority_requests(
+            subagent_specs=subagent_specs,
+            tool_names=self._local_tool_names(),
+            mcp_servers=self._mcp_server_names(),
+            memory_scope=str(self.agent_config.get("memory_config") or ""),
+            budget=self._governance_budget_snapshot(),
+        )
+        await self.governance_engine.authorize_all(requests)
+
+    def _local_tool_names(self) -> list[str]:
+        if self.local_tools is None or not hasattr(self.local_tools, "list_tools"):
+            return []
+        return [tool.name for tool in self.local_tools.list_tools()]
+
+    def _mcp_server_names(self) -> list[str]:
+        return [str(server.get("name") or "") for server in self.mcp_tools or []]
+
+    def _governance_budget_snapshot(self) -> dict[str, Any]:
+        if self.governance_engine is None or self.governance_engine.policy.budget is None:
+            return {}
+        budget = self.governance_engine.policy.budget
+        return {
+            "max_requests": budget.max_requests,
+            "max_cost": budget.max_cost,
+            "used_requests": budget.used_requests,
+            "used_cost": budget.used_cost,
+        }
+
+    def _governance_reference(self) -> dict[str, Any] | None:
+        if self.governance_engine is None:
+            return None
+        return {
+            "parent_policy_id": self.governance_engine.policy.policy_id,
+            "parent_policy_hash": self.governance_engine.policy.provenance.policy_hash,
         }
 
     async def cleanup(self):

--- a/src/omnicoreagent/governance/__init__.py
+++ b/src/omnicoreagent/governance/__init__.py
@@ -4,7 +4,10 @@ from omnicoreagent.governance.approvals import (
     StaticApprovalResolver,
 )
 from omnicoreagent.governance.capabilities import (
+    background_run_authority_request,
+    background_task_authority_request,
     mcp_server_authority_request,
+    subagent_spawn_authority_requests,
     tool_authority_request,
     tool_authority_requests,
     tool_capability_descriptor,
@@ -59,6 +62,14 @@ from omnicoreagent.governance.policy import (
     load_policy_file,
     policy_from_mapping,
 )
+from omnicoreagent.governance.snapshots import (
+    POLICY_SNAPSHOT_METADATA_KEY,
+    attach_policy_snapshot,
+    derive_subagent_policy,
+    policy_snapshot_from_engine,
+    policy_snapshot_from_policy,
+    require_current_policy_snapshot,
+)
 from omnicoreagent.governance.telemetry import GOVERNANCE_EVENT_TYPES
 
 __all__ = [
@@ -100,14 +111,23 @@ __all__ = [
     "UngovernedCapabilityError",
     "UnknownCapabilityError",
     "attach_policy_hash",
+    "attach_policy_snapshot",
+    "background_run_authority_request",
+    "background_task_authority_request",
     "build_default_policy",
     "canonical_policy_payload",
     "discover_policy_file",
+    "derive_subagent_policy",
     "load_policy",
     "load_policy_file",
     "mcp_server_authority_request",
     "policy_from_mapping",
     "policy_hash",
+    "policy_snapshot_from_engine",
+    "policy_snapshot_from_policy",
+    "POLICY_SNAPSHOT_METADATA_KEY",
+    "require_current_policy_snapshot",
+    "subagent_spawn_authority_requests",
     "tool_authority_request",
     "tool_authority_requests",
     "tool_capability_descriptor",

--- a/src/omnicoreagent/governance/capabilities.py
+++ b/src/omnicoreagent/governance/capabilities.py
@@ -22,6 +22,8 @@ ARTIFACT_READ_TOOLS = frozenset(
     {"read_artifact", "tail_artifact", "search_artifact", "list_artifacts"}
 )
 MCP_SERVER_TRANSPORTS = frozenset({"stdio", "sse", "streamable_http"})
+BACKGROUND_TASK_ACTIONS = frozenset({"create", "update", "delete", "pause", "resume"})
+BACKGROUND_RUN_ACTIONS = frozenset({"start", "cancel"})
 
 
 def tool_capability_descriptor(
@@ -95,7 +97,9 @@ def tool_authority_requests(
             provider=descriptor.provider,
             execution_surface=descriptor.execution_surface,
             target=target,
-            risk_level=tool_risk_level(tool_name=tool_name, tool_provider=tool_provider),
+            risk_level=tool_risk_level(
+                tool_name=tool_name, tool_provider=tool_provider
+            ),
             mcp_server=tool_server if tool_provider == "mcp" else None,
             metadata={
                 "tool_name": tool_name,
@@ -212,11 +216,7 @@ def mcp_server_authority_request(
         )
     server_name = str(server.get("name") or "")
     host = _server_host(server)
-    capability = (
-        "mcp.server.start"
-        if transport == "stdio"
-        else "mcp.server.connect"
-    )
+    capability = "mcp.server.start" if transport == "stdio" else "mcp.server.connect"
     return AuthorityRequest(
         capability=capability,
         actor=actor,
@@ -238,6 +238,104 @@ def mcp_server_authority_request(
             "has_explicit_env": bool(server.get("env")),
             "url": _redacted_url(server.get("url")),
             "command": server.get("command") if transport == "stdio" else None,
+        },
+    )
+
+
+def subagent_spawn_authority_requests(
+    *,
+    subagent_specs: list[dict[str, Any]],
+    tool_names: list[str] | None = None,
+    mcp_servers: list[str] | None = None,
+    memory_scope: str | None = None,
+    budget: dict[str, Any] | None = None,
+    deadline: str | None = None,
+    actor: str = "agent",
+) -> list[AuthorityRequest]:
+    return [
+        AuthorityRequest(
+            capability="subagent.spawn",
+            actor=actor,
+            provider="subagent",
+            execution_surface="subagent",
+            target=AuthorityTarget(
+                resource=str(spec.get("name") or f"subagent_{index}"),
+                path=spec.get("output_path"),
+            ),
+            risk_level="medium",
+            metadata={
+                "subagent_name": spec.get("name") or f"subagent_{index}",
+                "role": spec.get("role"),
+                "task": spec.get("task"),
+                "output_path": spec.get("output_path"),
+                "task_length": len(str(spec.get("task") or "")),
+                "tool_names": list(tool_names or []),
+                "mcp_servers": list(mcp_servers or []),
+                "workspace_scope": spec.get("output_path"),
+                "memory_scope": memory_scope,
+                "budget": dict(budget or {}),
+                "deadline": deadline,
+            },
+        )
+        for index, spec in enumerate(subagent_specs)
+    ]
+
+
+def background_task_authority_request(
+    *,
+    task: Any,
+    action: str = "create",
+    actor: str = "background_manager",
+) -> AuthorityRequest:
+    if action not in BACKGROUND_TASK_ACTIONS:
+        supported = ", ".join(sorted(BACKGROUND_TASK_ACTIONS))
+        raise ValueError(
+            f"Unsupported background task action: {action}. Supported: {supported}"
+        )
+    return AuthorityRequest(
+        capability=f"background.task.{action}",
+        actor=actor,
+        provider="background",
+        execution_surface="background",
+        target=AuthorityTarget(resource=task.task_id),
+        risk_level="medium" if action in {"create", "update"} else "low",
+        metadata={
+            "action": action,
+            "task_id": task.task_id,
+            "agent_id": task.agent_id,
+            "schedule_type": getattr(task.schedule.type, "value", task.schedule.type),
+            "enabled": task.enabled,
+        },
+    )
+
+
+def background_run_authority_request(
+    *,
+    action: str,
+    run: Any = None,
+    task: Any = None,
+    actor: str = "background_manager",
+) -> AuthorityRequest:
+    if action not in BACKGROUND_RUN_ACTIONS:
+        supported = ", ".join(sorted(BACKGROUND_RUN_ACTIONS))
+        raise ValueError(
+            f"Unsupported background run action: {action}. Supported: {supported}"
+        )
+    task_id = getattr(run, "task_id", None) or getattr(task, "task_id", None)
+    agent_id = getattr(run, "agent_id", None) or getattr(task, "agent_id", None)
+    return AuthorityRequest(
+        capability=f"background.run.{action}",
+        actor=actor,
+        provider="background",
+        execution_surface="background",
+        target=AuthorityTarget(resource=task_id),
+        risk_level="medium" if action == "start" else "low",
+        metadata={
+            "action": action,
+            "run_id": getattr(run, "run_id", None),
+            "task_id": task_id,
+            "agent_id": agent_id,
+            "trigger_type": getattr(getattr(run, "trigger_type", None), "value", None),
         },
     )
 

--- a/src/omnicoreagent/governance/defaults.py
+++ b/src/omnicoreagent/governance/defaults.py
@@ -85,6 +85,16 @@ def _permissive_dev_policy() -> PolicyEnvelope:
                     effect=PolicyEffect.ALLOW,
                     capability="telemetry.*",
                 ),
+                PolicyRule(
+                    rule_id="allow_subagent_spawn",
+                    effect=PolicyEffect.ALLOW,
+                    capability="subagent.*",
+                ),
+                PolicyRule(
+                    rule_id="allow_background_execution",
+                    effect=PolicyEffect.ALLOW,
+                    capability="background.*",
+                ),
             ],
         ),
     )
@@ -133,6 +143,16 @@ def _interactive_dev_policy() -> PolicyEnvelope:
                     rule_id="ask_mcp_server_start",
                     effect=PolicyEffect.ASK,
                     capability="mcp.server.*",
+                ),
+                PolicyRule(
+                    rule_id="ask_subagent_spawn",
+                    effect=PolicyEffect.ASK,
+                    capability="subagent.*",
+                ),
+                PolicyRule(
+                    rule_id="ask_background_execution",
+                    effect=PolicyEffect.ASK,
+                    capability="background.*",
                 ),
                 PolicyRule(
                     rule_id="ask_high_risk",

--- a/src/omnicoreagent/governance/snapshots.py
+++ b/src/omnicoreagent/governance/snapshots.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from omnicoreagent.governance.hashing import attach_policy_hash
+from omnicoreagent.governance.errors import PolicyDeniedError
+from omnicoreagent.governance.models import (
+    PolicyBudget,
+    PolicyEffect,
+    PolicyEnvelope,
+    PolicyProvenance,
+    PolicyRule,
+    PolicySource,
+    governance_id,
+)
+
+
+POLICY_SNAPSHOT_METADATA_KEY = "governance_policy_snapshot"
+
+
+def policy_snapshot_from_engine(governance_engine: Any) -> dict[str, Any] | None:
+    if governance_engine is None:
+        return None
+    return policy_snapshot_from_policy(governance_engine.policy)
+
+
+def policy_snapshot_from_policy(policy: PolicyEnvelope) -> dict[str, Any]:
+    budget = None
+    if policy.budget is not None:
+        budget = {
+            "max_requests": policy.budget.max_requests,
+            "max_cost": policy.budget.max_cost,
+            "used_requests": policy.budget.used_requests,
+            "used_cost": policy.budget.used_cost,
+            "count_failed_attempts": policy.budget.count_failed_attempts,
+        }
+    return {
+        "policy_id": policy.policy_id,
+        "policy_hash": policy.provenance.policy_hash,
+        "version": policy.version,
+        "name": policy.name,
+        "mode": policy.mode.value,
+        "profile": policy.profile.value if policy.profile is not None else None,
+        "budget": budget,
+    }
+
+
+def attach_policy_snapshot(
+    metadata: dict[str, Any] | None,
+    governance_engine: Any,
+) -> dict[str, Any]:
+    updated = dict(metadata or {})
+    snapshot = policy_snapshot_from_engine(governance_engine)
+    if snapshot is not None:
+        updated[POLICY_SNAPSHOT_METADATA_KEY] = snapshot
+    return updated
+
+
+def require_current_policy_snapshot(
+    metadata: dict[str, Any] | None,
+    governance_engine: Any,
+    *,
+    surface: str,
+    required: bool = False,
+) -> None:
+    snapshot = (metadata or {}).get(POLICY_SNAPSHOT_METADATA_KEY)
+    if not snapshot:
+        if required:
+            raise PolicyDeniedError(
+                f"{surface} is missing a required policy snapshot.",
+                metadata={"reason_code": "expired_policy"},
+            )
+        return
+    if governance_engine is None:
+        raise PolicyDeniedError(
+            f"{surface} has a stored policy snapshot but no governance engine is configured.",
+            metadata={
+                "reason_code": "expired_policy",
+                "stored_policy_hash": snapshot.get("policy_hash"),
+                "stored_policy_id": snapshot.get("policy_id"),
+            },
+        )
+    current = policy_snapshot_from_engine(governance_engine) or {}
+    if snapshot.get("version") != current.get("version"):
+        raise PolicyDeniedError(
+            f"{surface} was created under a different policy schema version.",
+            metadata={
+                "reason_code": "expired_policy",
+                "stored_policy_version": snapshot.get("version"),
+                "current_policy_version": current.get("version"),
+                "stored_policy_hash": snapshot.get("policy_hash"),
+                "current_policy_hash": current.get("policy_hash"),
+            },
+        )
+    if snapshot.get("policy_hash") != current.get("policy_hash"):
+        raise PolicyDeniedError(
+            f"{surface} was created under a different policy snapshot.",
+            metadata={
+                "reason_code": "expired_policy",
+                "stored_policy_hash": snapshot.get("policy_hash"),
+                "current_policy_hash": current.get("policy_hash"),
+                "stored_policy_id": snapshot.get("policy_id"),
+                "current_policy_id": current.get("policy_id"),
+            },
+        )
+    _restore_budget_floor(snapshot, governance_engine)
+
+
+def derive_subagent_policy(
+    parent_policy: PolicyEnvelope,
+    *,
+    subagent_name: str,
+) -> PolicyEnvelope:
+    child = deepcopy(parent_policy)
+    child.policy_id = governance_id("policy")
+    child.policy_id_supplied = True
+    child.name = f"{parent_policy.name}:subagent:{subagent_name}"
+    child.provenance = PolicyProvenance(
+        source=PolicySource.INHERITED,
+        parent_policy_id=parent_policy.policy_id,
+    )
+    child.rules.deny = [
+        PolicyRule(
+            rule_id="deny_recursive_subagent_spawn",
+            effect=PolicyEffect.DENY,
+            capability="subagent.spawn",
+            reason="Subagents cannot spawn nested subagents unless a later scoped policy explicitly allows it.",
+        ),
+        *child.rules.deny,
+    ]
+    child.metadata = {
+        **child.metadata,
+        "derived_for": "subagent",
+        "subagent_name": subagent_name,
+        "parent_policy_hash": parent_policy.provenance.policy_hash,
+    }
+    if parent_policy.budget is not None:
+        child.budget = PolicyBudget(
+            max_requests=0 if parent_policy.budget.max_requests is not None else None,
+            max_cost=0.0 if parent_policy.budget.max_cost is not None else None,
+            used_requests=0,
+            used_cost=0.0,
+            count_failed_attempts=parent_policy.budget.count_failed_attempts,
+        )
+        child.metadata["budget_narrowing"] = (
+            "Subagent child policies receive zero budget until explicit budget "
+            "allocation is implemented."
+        )
+    return attach_policy_hash(child)
+
+
+def _restore_budget_floor(snapshot: dict[str, Any], governance_engine: Any) -> None:
+    stored_budget = snapshot.get("budget") or {}
+    current_budget = getattr(governance_engine.policy, "budget", None)
+    if current_budget is None or not stored_budget:
+        return
+    current_budget.used_requests = max(
+        current_budget.used_requests,
+        int(stored_budget.get("used_requests") or 0),
+    )
+    current_budget.used_cost = max(
+        current_budget.used_cost,
+        float(stored_budget.get("used_cost") or 0.0),
+    )

--- a/src/omnicoreagent/serve/app_factory.py
+++ b/src/omnicoreagent/serve/app_factory.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import FastAPI
 
 from omnicoreagent.core.logging import logger
+from omnicoreagent.core.runtime import construction
 
 from .config import OmniServeConfig
 from .lifespan import agent_lifespan
@@ -82,6 +83,7 @@ def _build_background_manager(
     return BackgroundAgentManager(
         task_store=config.background_task_store_config(),
         telemetry_store=getattr(agent, "telemetry_store", None),
+        governance_engine=_resolve_agent_governance_engine(agent),
     )
 
 
@@ -89,3 +91,19 @@ def _ensure_agent_telemetry(agent: AgentType) -> None:
     ensure_telemetry = getattr(agent, "_ensure_telemetry", None)
     if callable(ensure_telemetry):
         ensure_telemetry()
+
+
+def _resolve_agent_governance_engine(agent: AgentType) -> Any | None:
+    runtime_agent = getattr(agent, "agent", None)
+    runtime_engine = getattr(runtime_agent, "governance_engine", None)
+    if runtime_engine is not None:
+        return runtime_engine
+
+    agent_config = getattr(agent, "agent_config", {}) or {}
+    governance_config = agent_config.get("governance_config") or {}
+    if not governance_config.get("enabled", False):
+        return None
+    return construction.build_governance_engine(
+        agent_config=agent_config,
+        telemetry_recorder=getattr(agent, "telemetry_recorder", None),
+    )

--- a/tests/test_background_agent.py
+++ b/tests/test_background_agent.py
@@ -46,6 +46,42 @@ from omnicoreagent.background.event_log import BackgroundEventLog
 from omnicoreagent.background.recovery import BackgroundRunRecovery
 from omnicoreagent.background.transitions import BackgroundRunTransitions
 from omnicoreagent.core.telemetry import TelemetryStreamScope
+from omnicoreagent.governance import (
+    BudgetExceededError,
+    GovernanceEngine,
+    POLICY_SNAPSHOT_METADATA_KEY,
+    PolicyDeniedError,
+    UnknownCapabilityError,
+    policy_from_mapping,
+)
+from omnicoreagent.governance.models import PolicyBudget
+
+
+def _background_governance_policy(*, name="background-policy", allow_start=True):
+    allow_rules = [
+        {
+            "rule_id": "allow_background_tasks",
+            "capability": "background.task.*",
+        },
+        {
+            "rule_id": "allow_background_run_cancel",
+            "capability": "background.run.cancel",
+        },
+    ]
+    if allow_start:
+        allow_rules.append(
+            {
+                "rule_id": "allow_background_run_start",
+                "capability": "background.run.start",
+            }
+        )
+    return policy_from_mapping(
+        {
+            "name": name,
+            "mode": "strict",
+            "rules": {"allow": allow_rules},
+        }
+    )
 
 
 class FakeAgent:
@@ -98,7 +134,10 @@ class ConfiguredFakeAgent(FakeAgent):
         self.mcp_tools = [{"name": "filesystem", "transport": "stdio"}]
         self.agent_config = {
             "enable_workspace_files": True,
-            "workspace_config": {"workspace_backend": "local", "workspace_dir": "custom"},
+            "workspace_config": {
+                "workspace_backend": "local",
+                "workspace_dir": "custom",
+            },
         }
 
 
@@ -636,7 +675,9 @@ async def test_due_schedule_and_atomic_dispatch_advances_state():
 async def test_cron_schedule_gets_initial_due_time():
     store = InMemoryTaskStore()
     await store.save_agent(agent_spec())
-    await store.save_task(task_spec(schedule={"type": "cron", "expression": "* * * * *"}))
+    await store.save_task(
+        task_spec(schedule={"type": "cron", "expression": "* * * * *"})
+    )
 
     state = await store.get_schedule_state("task")
 
@@ -932,6 +973,291 @@ async def test_manager_run_now_executes_agent_and_records_events():
     assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
     assert events[-1]["event"] == "background_run_completed"
     assert "background_run_claimed" in {event["event"] for event in events}
+
+
+@pytest.mark.asyncio
+async def test_manager_stores_policy_snapshot_on_governed_background_tasks():
+    engine = GovernanceEngine(_background_governance_policy())
+    manager = BackgroundAgentManager(task_store="in_memory", governance_engine=engine)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+
+    task = await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task", wait=True)
+
+    task_snapshot = task.metadata[POLICY_SNAPSHOT_METADATA_KEY]
+    run_snapshot = run.metadata[POLICY_SNAPSHOT_METADATA_KEY]
+    assert task_snapshot["policy_hash"] == engine.policy.provenance.policy_hash
+    assert run_snapshot == task_snapshot
+    assert run.status == RunStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_manager_governs_background_task_lifecycle_mutations():
+    engine = GovernanceEngine(_background_governance_policy())
+    manager = BackgroundAgentManager(task_store="in_memory", governance_engine=engine)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "interval", "seconds": 60},
+    )
+
+    updated = await manager.update_task("task", {"query": "updated work"})
+    await manager.pause_task("task")
+    await manager.resume_task("task")
+    await manager.delete_task("task")
+
+    assert updated.query == "updated work"
+    assert updated.metadata[POLICY_SNAPSHOT_METADATA_KEY]["policy_hash"] == (
+        engine.policy.provenance.policy_hash
+    )
+    assert await manager.get_task("task") is None
+
+
+@pytest.mark.asyncio
+async def test_manager_denies_background_task_registration_without_policy_allow():
+    engine = GovernanceEngine(
+        policy_from_mapping(
+            {"name": "deny-background", "mode": "strict", "rules": {"allow": []}}
+        )
+    )
+    manager = BackgroundAgentManager(task_store="in_memory", governance_engine=engine)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+
+    with pytest.raises(UnknownCapabilityError):
+        await manager.register_task(
+            task_id="task",
+            agent_id="agent",
+            query="do work",
+            schedule={"type": "manual"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_manager_denies_manual_run_start_before_queuing():
+    engine = GovernanceEngine(_background_governance_policy(allow_start=False))
+    manager = BackgroundAgentManager(task_store="in_memory", governance_engine=engine)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    with pytest.raises(UnknownCapabilityError):
+        await manager.run_now("task")
+
+    assert await manager.list_runs(task_id="task") == []
+
+
+@pytest.mark.asyncio
+async def test_manager_denies_scheduled_run_start_before_dispatching():
+    store = InMemoryTaskStore()
+    engine = GovernanceEngine(_background_governance_policy(allow_start=False))
+    manager = BackgroundAgentManager(task_store=store, governance_engine=engine)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    due_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="scheduled work",
+        schedule={"type": "once", "run_at": due_at},
+        overlap_policy=OverlapPolicy.ALLOW_PARALLEL,
+    )
+    state_before = await store.get_schedule_state("task")
+
+    with pytest.raises(UnknownCapabilityError):
+        await manager._dispatch_due_schedules()
+
+    assert await manager.list_runs(task_id="task") == []
+    state_after = await store.get_schedule_state("task")
+    assert state_after.next_due_at == state_before.next_due_at
+    assert state_after.paused is True
+
+
+@pytest.mark.asyncio
+async def test_manager_fails_closed_when_governed_schedule_loses_engine():
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(
+        task_store=store,
+        governance_engine=GovernanceEngine(_background_governance_policy()),
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    due_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="scheduled work",
+        schedule={"type": "once", "run_at": due_at},
+    )
+    manager.governance_engine = None
+
+    with pytest.raises(PolicyDeniedError, match="no governance engine"):
+        await manager._dispatch_due_schedules()
+
+    assert await manager.list_runs(task_id="task") == []
+    assert (await store.get_schedule_state("task")).paused is True
+
+
+@pytest.mark.asyncio
+async def test_manager_replace_governed_task_validates_existing_snapshot():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    manager.governance_engine = GovernanceEngine(_background_governance_policy())
+
+    with pytest.raises(PolicyDeniedError, match="missing a required policy snapshot"):
+        await manager.register_task(
+            task_id="task",
+            agent_id="agent",
+            query="replacement",
+            schedule={"type": "manual"},
+            replace=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_manager_fails_closed_when_background_policy_snapshot_changes():
+    first = GovernanceEngine(_background_governance_policy(name="first-policy"))
+    manager = BackgroundAgentManager(task_store="in_memory", governance_engine=first)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    manager.governance_engine = GovernanceEngine(
+        _background_governance_policy(name="changed-policy")
+    )
+
+    with pytest.raises(PolicyDeniedError, match="different policy snapshot"):
+        await manager.run_now("task")
+
+
+@pytest.mark.asyncio
+async def test_manager_fails_closed_when_governed_background_task_has_no_snapshot():
+    manager = BackgroundAgentManager(task_store="in_memory")
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    manager.governance_engine = GovernanceEngine(_background_governance_policy())
+
+    with pytest.raises(PolicyDeniedError, match="missing a required policy snapshot"):
+        await manager.run_now("task")
+
+
+@pytest.mark.asyncio
+async def test_manager_restores_background_policy_budget_floor_from_snapshot():
+    policy = _background_governance_policy()
+    policy.budget = PolicyBudget(max_requests=1)
+    first = GovernanceEngine(policy)
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(task_store=store, governance_engine=first)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+
+    restarted_policy = _background_governance_policy()
+    restarted_policy.budget = PolicyBudget(max_requests=1)
+    restarted = BackgroundAgentManager(
+        task_store=store,
+        governance_engine=GovernanceEngine(restarted_policy),
+    )
+
+    with pytest.raises(BudgetExceededError):
+        await restarted.run_now("task")
+
+
+@pytest.mark.asyncio
+async def test_manager_persists_run_start_budget_floor_back_to_task_snapshot():
+    policy = _background_governance_policy()
+    policy.budget = PolicyBudget(max_requests=2)
+    store = InMemoryTaskStore()
+    manager = BackgroundAgentManager(
+        task_store=store,
+        governance_engine=GovernanceEngine(policy),
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    await manager.run_now("task", wait=True)
+
+    restarted_policy = _background_governance_policy()
+    restarted_policy.budget = PolicyBudget(max_requests=2)
+    restarted = BackgroundAgentManager(
+        task_store=store,
+        governance_engine=GovernanceEngine(restarted_policy),
+    )
+
+    with pytest.raises(BudgetExceededError):
+        await restarted.run_now("task")
+
+
+@pytest.mark.asyncio
+async def test_supervisor_fails_closed_for_durable_run_without_governance_engine():
+    first = GovernanceEngine(_background_governance_policy())
+    manager = BackgroundAgentManager(task_store="in_memory", governance_engine=first)
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task")
+
+    manager.governance_engine = None
+    terminal = await manager.run_until_terminal(run.run_id, timeout_seconds=2)
+
+    assert terminal.status == RunStatus.FAILED
+    assert "stored policy snapshot" in terminal.error
+    assert terminal.metadata["governance_failure"]["reason_code"] == "expired_policy"
+
+
+@pytest.mark.asyncio
+async def test_manager_fails_closed_when_governed_cancel_loses_engine():
+    manager = BackgroundAgentManager(
+        task_store="in_memory",
+        governance_engine=GovernanceEngine(_background_governance_policy()),
+    )
+    await manager.register_agent("agent", FakeAgent(response="complete"))
+    await manager.register_task(
+        task_id="task",
+        agent_id="agent",
+        query="do work",
+        schedule={"type": "manual"},
+    )
+    run = await manager.run_now("task")
+    manager.governance_engine = None
+
+    with pytest.raises(PolicyDeniedError, match="no governance engine"):
+        await manager.cancel_run(run.run_id)
 
 
 @pytest.mark.asyncio
@@ -1502,7 +1828,9 @@ async def test_update_task_validates_nested_schedule_patch():
         schedule={"type": "manual"},
     )
 
-    updated = await manager.update_task("task", {"schedule": {"type": "interval", "seconds": 60}})
+    updated = await manager.update_task(
+        "task", {"schedule": {"type": "interval", "seconds": 60}}
+    )
     state = await manager.task_store.get_schedule_state("task")
 
     assert updated.schedule.type == ScheduleType.INTERVAL
@@ -1552,7 +1880,10 @@ async def test_manager_dispatches_due_schedule_from_worker_loop():
         task_id="task",
         agent_id="agent",
         query="scheduled work",
-        schedule={"type": "once", "run_at": datetime.now(timezone.utc) - timedelta(seconds=1)},
+        schedule={
+            "type": "once",
+            "run_at": datetime.now(timezone.utc) - timedelta(seconds=1),
+        },
         overlap_policy=OverlapPolicy.ALLOW_PARALLEL,
     )
 
@@ -2077,6 +2408,7 @@ async def test_running_cancel_finishes_cancelled_not_completed():
     run = await manager.run_now("task")
     await wait_for(lambda: agent.calls, timeout=0.5)
     await manager.cancel_run(run.run_id)
+
     async def terminal_run():
         latest = await manager.get_run(run.run_id)
         if latest and latest.status in {
@@ -2182,7 +2514,9 @@ async def test_recover_expired_running_run_requeues_when_retry_available():
     )
     async with store._lock:
         store._runs[run.run_id] = running.model_copy(
-            update={"lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+            update={
+                "lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)
+            }
         )
 
     await manager.recover_expired_runs()
@@ -2207,7 +2541,9 @@ async def test_recovery_service_requeues_expired_running_run_directly():
         session_id="s1",
         workspace_path="w1",
     )
-    created = await store.create_run_with_overlap_guard(run, OverlapPolicy.ALLOW_PARALLEL)
+    created = await store.create_run_with_overlap_guard(
+        run, OverlapPolicy.ALLOW_PARALLEL
+    )
     claimed = await store.claim_run(created.run_id, "lost_worker", lease_seconds=30)
     running = await store.transition_run(
         claimed.run_id,
@@ -2227,7 +2563,9 @@ async def test_recovery_service_requeues_expired_running_run_directly():
     )
     async with store._lock:
         store._runs[run.run_id] = running.model_copy(
-            update={"lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+            update={
+                "lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)
+            }
         )
 
     emitted = []
@@ -2298,7 +2636,9 @@ async def test_recover_expired_running_run_honors_cancelled_transition_race(
     )
     async with store._lock:
         store._runs[run.run_id] = running.model_copy(
-            update={"lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+            update={
+                "lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)
+            }
         )
 
     await manager.recover_expired_runs()
@@ -2391,7 +2731,9 @@ async def test_recover_expired_retrying_run_requeues_without_self_transition():
     )
     async with store._lock:
         store._runs[run.run_id] = retrying.model_copy(
-            update={"lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+            update={
+                "lease_expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)
+            }
         )
 
     await manager.recover_expired_runs()

--- a/tests/test_omniserve_full.py
+++ b/tests/test_omniserve_full.py
@@ -18,6 +18,8 @@ from omnicoreagent.core.telemetry import (
     TelemetryStreamScope,
 )
 from omnicoreagent.serve.cli import cli
+from omnicoreagent.serve.app_factory import _build_background_manager
+from omnicoreagent.governance import policy_from_mapping
 
 
 @pytest.fixture(autouse=True)
@@ -113,6 +115,38 @@ class TestConfiguration:
         with patch.dict(os.environ, {"OMNICOREAGENT_SERVE_AUTH_ENABLED": "true"}):
             with pytest.raises(ValidationError, match="AUTH_TOKEN is required"):
                 OmniServeConfig()
+
+    def test_background_manager_inherits_agent_governance_config(self):
+        policy = policy_from_mapping(
+            {
+                "name": "serve-background-policy",
+                "mode": "strict",
+                "rules": {
+                    "allow": [
+                        {
+                            "rule_id": "allow_background",
+                            "capability": "background.*",
+                        }
+                    ]
+                },
+            }
+        )
+        agent = SimpleNamespace(
+            agent=None,
+            agent_config={"governance_config": {"enabled": True, "policy": policy}},
+            telemetry_store=None,
+            telemetry_recorder=None,
+            _ensure_telemetry=lambda: None,
+        )
+
+        manager = _build_background_manager(
+            agent=agent,
+            config=OmniServeConfig(background_enabled=True),
+            background_manager=None,
+        )
+
+        assert manager.governance_engine is not None
+        assert manager.governance_engine.policy.name == "serve-background-policy"
 
     @pytest.mark.parametrize(
         ("kwargs", "message"),

--- a/tests/test_subagent_governance.py
+++ b/tests/test_subagent_governance.py
@@ -1,0 +1,196 @@
+import pytest
+
+from omnicoreagent.core.subagents import SubagentFactory
+from omnicoreagent.governance import (
+    GovernanceEngine,
+    PolicySource,
+    UnknownCapabilityError,
+    policy_from_mapping,
+)
+from omnicoreagent.governance.models import PolicyBudget
+
+
+def _subagent_policy():
+    return policy_from_mapping(
+        {
+            "name": "subagent-policy",
+            "mode": "strict",
+            "rules": {
+                "allow": [
+                    {"rule_id": "allow_subagent_spawn", "capability": "subagent.spawn"}
+                ]
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagent_factory_authorizes_parallel_spawn_before_execution(monkeypatch):
+    factory = SubagentFactory(
+        base_model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        governance_engine=GovernanceEngine(_subagent_policy()),
+    )
+    executed = []
+
+    async def fake_run_subagent(name, role, task, output_path):
+        executed.append(name)
+        return {
+            "status": "success",
+            "data": {"subagent_name": name, "output_path": output_path},
+            "message": "done",
+        }
+
+    monkeypatch.setattr(factory, "run_subagent", fake_run_subagent)
+
+    result = await factory.run_parallel_subagents(
+        [
+            {
+                "name": "api",
+                "role": "API reviewer",
+                "task": "review API",
+                "output_path": "/workspace/reports/api.md",
+            },
+            {
+                "name": "tests",
+                "role": "Test reviewer",
+                "task": "review tests",
+                "output_path": "/workspace/reports/tests.md",
+            },
+        ]
+    )
+
+    assert executed == ["api", "tests"]
+    assert result["status"] == "success"
+    assert result["data"]["successful"] == 2
+    assert factory.governance_engine.policy.budget is None
+
+
+@pytest.mark.asyncio
+async def test_subagent_factory_denies_spawn_before_any_worker_runs(monkeypatch):
+    factory = SubagentFactory(
+        base_model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        governance_engine=GovernanceEngine(
+            policy_from_mapping(
+                {"name": "deny-subagent", "mode": "strict", "rules": {"allow": []}}
+            )
+        ),
+    )
+    executed = []
+
+    async def fake_run_subagent(name, role, task, output_path):
+        executed.append(name)
+        return {"status": "success", "data": {}, "message": "done"}
+
+    monkeypatch.setattr(factory, "run_subagent", fake_run_subagent)
+
+    with pytest.raises(UnknownCapabilityError):
+        await factory.run_parallel_subagents(
+            [
+                {
+                    "name": "api",
+                    "role": "API reviewer",
+                    "task": "review API",
+                    "output_path": "/workspace/reports/api.md",
+                }
+            ]
+        )
+
+    assert executed == []
+
+
+def test_subagent_factory_derives_child_policy_that_denies_recursive_spawn():
+    engine = GovernanceEngine(_subagent_policy())
+    factory = SubagentFactory(
+        base_model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        agent_config={
+            "governance_config": {
+                "enabled": True,
+                "profile": "strict-production",
+            }
+        },
+        governance_engine=engine,
+    )
+
+    config = factory._build_subagent_config(subagent_name="api")
+    child_policy = config["governance_config"]["policy"]
+
+    assert config["enable_subagents"] is False
+    assert child_policy.provenance.source == PolicySource.INHERITED
+    assert child_policy.provenance.parent_policy_id == engine.policy.policy_id
+    assert child_policy.metadata["parent_policy_hash"] == (
+        engine.policy.provenance.policy_hash
+    )
+    assert child_policy.rules.deny[0].capability == "subagent.spawn"
+
+
+def test_subagent_child_policy_does_not_copy_parent_budget_authority():
+    policy = _subagent_policy()
+    policy.budget = PolicyBudget(max_requests=10, max_cost=2.5)
+    engine = GovernanceEngine(policy)
+    factory = SubagentFactory(
+        base_model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        governance_engine=engine,
+    )
+
+    config = factory._build_subagent_config(subagent_name="api")
+    child_budget = config["governance_config"]["policy"].budget
+
+    assert child_budget.max_requests == 0
+    assert child_budget.max_cost == 0.0
+
+
+def test_subagent_governance_reference_exposes_parent_policy_identity():
+    engine = GovernanceEngine(_subagent_policy())
+    factory = SubagentFactory(
+        base_model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        governance_engine=engine,
+    )
+
+    reference = factory._governance_reference()
+
+    assert reference == {
+        "parent_policy_id": engine.policy.policy_id,
+        "parent_policy_hash": engine.policy.provenance.policy_hash,
+    }
+
+
+@pytest.mark.asyncio
+async def test_subagent_authority_request_includes_scope_contract():
+    class RecordingEngine:
+        def __init__(self):
+            self.policy = _subagent_policy()
+            self.requests = []
+
+        async def authorize_all(self, requests):
+            self.requests.extend(requests)
+            return []
+
+    engine = RecordingEngine()
+    registry = None
+    factory = SubagentFactory(
+        base_model_config={"provider": "openai", "model": "gpt-4o-mini"},
+        mcp_tools=[{"name": "filesystem"}],
+        local_tools=registry,
+        agent_config={"memory_config": {"mode": "sliding_window", "value": 100}},
+        governance_engine=engine,
+    )
+
+    await factory._authorize_subagent_spawns(
+        [
+            {
+                "name": "api",
+                "role": "API reviewer",
+                "task": "review API",
+                "output_path": "/workspace/reports/api.md",
+            }
+        ]
+    )
+
+    request = engine.requests[0]
+    assert request.capability == "subagent.spawn"
+    assert request.target.resource == "api"
+    assert request.target.path == "/workspace/reports/api.md"
+    assert request.metadata["task"] == "review API"
+    assert request.metadata["mcp_servers"] == ["filesystem"]
+    assert request.metadata["workspace_scope"] == "/workspace/reports/api.md"
+    assert request.metadata["memory_scope"]


### PR DESCRIPTION
## Summary
- add governance capability requests and policy snapshots for subagent/background execution
- enforce background task/run lifecycle policy, restart fail-closed checks, budget floor restoration, and OmniServe governance propagation
- derive subagent child policy, enrich spawn authority metadata, and document Phase 5 behavior

## Verification
- uv run ruff check src/omnicoreagent/background/manager.py src/omnicoreagent/background/scheduler.py src/omnicoreagent/background/supervisor.py src/omnicoreagent/core/subagents.py src/omnicoreagent/governance/snapshots.py src/omnicoreagent/governance/capabilities.py src/omnicoreagent/serve/app_factory.py tests/test_background_agent.py tests/test_subagent_governance.py tests/test_omniserve_full.py
- uv run pytest tests/test_background_agent.py tests/test_subagents.py tests/test_subagent_governance.py -q
- uv run pytest tests/test_background_agent.py tests/test_subagent_governance.py tests/test_omniserve_full.py tests/test_agent_runtime.py tests/test_governance_core.py -q
- uv run pytest -q