### PR TITLE
Add sandbox runtime factory config

### DIFF
--- a/docs/how-to-guides/configuration.mdx
+++ b/docs/how-to-guides/configuration.mdx
@@ -198,7 +198,12 @@ agent_config = {
     "enable_agent_skills": True,     # Enable local skill discovery
     "enable_advanced_tool_use": True, # Enable BM25 tool retrieval
     "context_management": {"enabled": True},
-    "tool_offload": {"enabled": True}
+    "tool_offload": {"enabled": True},
+    "governance_config": {
+        "enabled": True,
+        "profile": "interactive-dev",
+        "sandbox_config": {"provider": "none"}
+    }
 }
 
 agent = OmniCoreAgent(
@@ -213,6 +218,26 @@ the active workspace. For full harness-style workloads, pair dynamic subagents
 with context management and tool offloading. Context management checks the prompt
 before each model call; tool offloading keeps large tool payloads in workspace
 artifacts instead of feeding the full payload back into the loop.
+
+`governance_config.sandbox_config` selects the sandbox runtime boundary used by
+governed execution. Supported built-in providers are:
+
+| Provider | Use |
+| --- | --- |
+| `none` | Policy-only mode. Does not satisfy `sandbox_required`. |
+| `local_test` | Development/test adapter that runs registered handlers only. No shell or production isolation. |
+
+Use `local_test` only for tests and local harness wiring:
+
+```python
+agent_config = {
+    "governance_config": {
+        "enabled": True,
+        "sandbox_config": {"provider": "local_test"},
+        "allow_test_sandbox_runtime": True,
+    }
+}
+```
 
 ---
 

--- a/engineering/specifications/governed-execution.md
+++ b/engineering/specifications/governed-execution.md
@@ -1170,7 +1170,10 @@ code call this boundary instead of each implementing policy semantics.
 
 ### Phase 8: Provider Adapters
 
-- Evaluate and add adapters only after the interface is stable.
+- Add runtime selection/factory support for built-in `none` and `local_test`
+  adapters before external providers.
+- External provider adapters must plug into the same factory/config path.
+- Evaluate and add external adapters only after the interface is stable.
 - Candidate adapters: OpenSandbox, OpenShell, E2B, Vercel, Modal, Daytona,
   Runloop, Cloudflare.
 

--- a/src/omnicoreagent/__init__.py
+++ b/src/omnicoreagent/__init__.py
@@ -146,6 +146,7 @@ __all__ = [
     "SandboxAuthorityContext",
     "SandboxCommand",
     "SandboxCommandContext",
+    "SandboxRuntimeConfig",
     "SandboxProvider",
     "NetworkPolicy",
     "SandboxEnvironment",
@@ -157,6 +158,7 @@ __all__ = [
     "SandboxRuntimeError",
     "SandboxUnsupportedError",
     "SandboxSessionNotFoundError",
+    "build_sandbox_runtime",
 ]
 
 _EXPORTS = {
@@ -337,6 +339,7 @@ _EXPORTS = {
     "SandboxAuthorityContext": ("omnicoreagent.sandbox", "SandboxAuthorityContext"),
     "SandboxCommand": ("omnicoreagent.sandbox", "SandboxCommand"),
     "SandboxCommandContext": ("omnicoreagent.sandbox", "SandboxCommandContext"),
+    "SandboxRuntimeConfig": ("omnicoreagent.sandbox", "SandboxRuntimeConfig"),
     "SandboxProvider": ("omnicoreagent.sandbox", "SandboxProvider"),
     "NetworkPolicy": ("omnicoreagent.sandbox", "NetworkPolicy"),
     "SandboxEnvironment": ("omnicoreagent.sandbox", "SandboxEnvironment"),
@@ -351,6 +354,7 @@ _EXPORTS = {
         "omnicoreagent.sandbox",
         "SandboxSessionNotFoundError",
     ),
+    "build_sandbox_runtime": ("omnicoreagent.sandbox", "build_sandbox_runtime"),
 }
 
 _OPTIONAL_EXPORTS = {

--- a/src/omnicoreagent/core/runtime/config.py
+++ b/src/omnicoreagent/core/runtime/config.py
@@ -106,6 +106,7 @@ def _default_governance_config() -> dict[str, Any]:
         "project_root": None,
         "approval_resolver": None,
         "sandbox_runtime": None,
+        "sandbox_config": None,
         "allow_test_sandbox_runtime": False,
         "allow_static_high_risk_approvals": False,
     }
@@ -352,6 +353,37 @@ def _validate_governance_config(value: dict[str, Any]):
         )
     if not isinstance(value.get("allow_test_sandbox_runtime", False), bool):
         raise ValueError("governance_config.allow_test_sandbox_runtime must be a boolean")
+    sandbox_config = value.get("sandbox_config")
+    if sandbox_config is not None:
+        if value.get("sandbox_runtime") is not None:
+            raise ValueError(
+                "governance_config cannot set both sandbox_runtime and sandbox_config"
+            )
+        if isinstance(sandbox_config, str):
+            provider = sandbox_config
+        elif isinstance(sandbox_config, dict):
+            _validate_unknown_keys(
+                "governance_config.sandbox_config",
+                sandbox_config,
+                frozenset({"provider"}),
+            )
+            provider = sandbox_config.get("provider", "none")
+        else:
+            try:
+                from omnicoreagent.sandbox import SandboxRuntimeConfig
+
+                valid_config = isinstance(sandbox_config, SandboxRuntimeConfig)
+                provider = sandbox_config.provider.value if valid_config else None
+            except Exception:
+                valid_config = False
+                provider = None
+            if not valid_config:
+                raise ValueError("governance_config.sandbox_config must be a dict or string")
+        if provider not in {"none", "local_test"}:
+            raise ValueError(
+                "governance_config.sandbox_config.provider must be one of "
+                "{'none', 'local_test'}"
+            )
     profile = value.get("profile", "interactive-dev")
     if profile not in {"permissive-dev", "interactive-dev", "strict-production"}:
         raise ValueError(

--- a/src/omnicoreagent/core/runtime/construction.py
+++ b/src/omnicoreagent/core/runtime/construction.py
@@ -108,11 +108,19 @@ def build_governance_engine(agent_config: dict[str, Any], telemetry_recorder: An
         project_root=governance_config.get("project_root"),
         profile=governance_config.get("profile", "interactive-dev"),
     )
+    sandbox_runtime = governance_config.get("sandbox_runtime")
+    if sandbox_runtime is None and governance_config.get("sandbox_config") is not None:
+        from omnicoreagent.sandbox import build_sandbox_runtime
+
+        sandbox_runtime = build_sandbox_runtime(
+            governance_config.get("sandbox_config"),
+            telemetry_recorder=telemetry_recorder,
+        )
     return GovernanceEngine(
         policy,
         approval_resolver=governance_config.get("approval_resolver"),
         telemetry_recorder=telemetry_recorder,
-        sandbox_runtime=governance_config.get("sandbox_runtime"),
+        sandbox_runtime=sandbox_runtime,
         allow_test_sandbox_runtime=governance_config.get(
             "allow_test_sandbox_runtime", False
         ),

--- a/src/omnicoreagent/sandbox/__init__.py
+++ b/src/omnicoreagent/sandbox/__init__.py
@@ -4,6 +4,7 @@ from omnicoreagent.sandbox.errors import (
     SandboxSessionNotFoundError,
     SandboxUnsupportedError,
 )
+from omnicoreagent.sandbox.factory import SandboxRuntimeConfig, build_sandbox_runtime
 from omnicoreagent.sandbox.local import (
     LocalTestSandboxRuntime,
     SandboxCommand,
@@ -43,6 +44,7 @@ __all__ = [
     "SandboxProvider",
     "SandboxResources",
     "SandboxRuntime",
+    "SandboxRuntimeConfig",
     "SandboxRuntimeError",
     "SandboxSession",
     "SandboxSessionNotFoundError",
@@ -50,4 +52,5 @@ __all__ = [
     "SandboxUnsupportedError",
     "WorkspaceMount",
     "WorkspaceMountMode",
+    "build_sandbox_runtime",
 ]

--- a/src/omnicoreagent/sandbox/factory.py
+++ b/src/omnicoreagent/sandbox/factory.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from omnicoreagent.sandbox.base import SandboxRuntime
+from omnicoreagent.sandbox.local import LocalTestSandboxRuntime
+from omnicoreagent.sandbox.models import SandboxProvider
+from omnicoreagent.sandbox.none import NoneSandboxRuntime
+
+
+@dataclass(slots=True)
+class SandboxRuntimeConfig:
+    provider: SandboxProvider | str = SandboxProvider.NONE
+
+    def __post_init__(self) -> None:
+        try:
+            self.provider = SandboxProvider(self.provider)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported sandbox provider: {self.provider}") from exc
+
+
+def build_sandbox_runtime(
+    config: SandboxRuntimeConfig | dict[str, Any] | str | SandboxRuntime | None,
+    *,
+    telemetry_recorder=None,
+) -> SandboxRuntime | None:
+    if config is None:
+        return None
+    if isinstance(config, SandboxRuntime):
+        return config
+    if isinstance(config, str):
+        runtime_config = SandboxRuntimeConfig(provider=config)
+    elif isinstance(config, SandboxRuntimeConfig):
+        runtime_config = config
+    elif isinstance(config, dict):
+        runtime_config = SandboxRuntimeConfig(**config)
+    else:
+        raise ValueError("sandbox_config must be a dict, string, or SandboxRuntime")
+
+    if runtime_config.provider == SandboxProvider.NONE:
+        return NoneSandboxRuntime()
+    if runtime_config.provider == SandboxProvider.LOCAL_TEST:
+        return LocalTestSandboxRuntime(telemetry_recorder=telemetry_recorder)
+    raise ValueError(f"Unsupported sandbox provider: {runtime_config.provider.value}")

--- a/tests/test_governance_core.py
+++ b/tests/test_governance_core.py
@@ -1320,6 +1320,21 @@ async def test_omnicoreagent_initializes_governance_engine_from_agent_config():
         ),
         ({"policy": "bad"}, "policy must be a dict or PolicyEnvelope"),
         ({"policy_path": 123}, "policy_path must be a string or path-like"),
+        (
+            {"sandbox_config": {"provider": "docker"}},
+            "sandbox_config.provider must be one of",
+        ),
+        (
+            {"sandbox_config": {"provider": "local_test", "extra": True}},
+            "governance_config.sandbox_config has unknown keys: extra",
+        ),
+        (
+            {
+                "sandbox_runtime": LocalTestSandboxRuntime(),
+                "sandbox_config": {"provider": "local_test"},
+            },
+            "cannot set both sandbox_runtime and sandbox_config",
+        ),
         ({"enabeld": True}, "unknown keys: enabeld"),
     ],
 )
@@ -1349,3 +1364,43 @@ def test_governance_config_preserves_runtime_approval_resolver_identity():
 
     assert config.model_dump()["governance_config"]["approval_resolver"] is resolver
     assert config.model_dump()["governance_config"]["sandbox_runtime"] is sandbox_runtime
+
+
+@pytest.mark.asyncio
+async def test_omnicoreagent_builds_sandbox_runtime_from_governance_config():
+    agent = OmniCoreAgent(
+        name="governed-sandbox",
+        system_instruction="You are governed.",
+        model_config={"provider": "openai", "model": "gpt-4o", "api_key": "test"},
+        agent_config={
+            "guardrail_mode": "off",
+            "governance_config": {
+                "enabled": True,
+                "profile": "strict-production",
+                "sandbox_config": {"provider": "local_test"},
+                "allow_test_sandbox_runtime": True,
+                "policy": {
+                    "name": "sandbox-runtime-policy",
+                    "mode": "strict",
+                    "rules": {
+                        "allow": [
+                            {
+                                "rule_id": "allow_sandboxed_process",
+                                "capability": "process.exec",
+                                "constraints": {"sandbox_required": True},
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+    )
+
+    await agent.initialize()
+    engine = agent.agent.governance_engine
+
+    assert isinstance(engine.sandbox_runtime, LocalTestSandboxRuntime)
+    decision = await engine.authorize_sandboxed(
+        AuthorityRequest(capability="process.exec")
+    )
+    assert decision.constraints.sandbox_required is True

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -21,9 +21,11 @@ from omnicoreagent.sandbox import (
     SandboxManifest,
     SandboxProvider,
     SandboxResources,
+    SandboxRuntimeConfig,
     SandboxSessionNotFoundError,
     SandboxUnsupportedError,
     WorkspaceMount,
+    build_sandbox_runtime,
 )
 from omnicoreagent.sandbox.telemetry import emit_sandbox_event
 
@@ -98,6 +100,18 @@ def test_sandbox_observation_truncates_untrusted_output():
         "timed_out": False,
         "metadata": {"stdout_truncated": True, "stderr_truncated": True},
     }
+
+
+def test_build_sandbox_runtime_from_config():
+    none_runtime = build_sandbox_runtime({"provider": "none"})
+    local_runtime = build_sandbox_runtime(SandboxRuntimeConfig(provider="local_test"))
+
+    assert isinstance(none_runtime, NoneSandboxRuntime)
+    assert isinstance(local_runtime, LocalTestSandboxRuntime)
+    assert build_sandbox_runtime(local_runtime) is local_runtime
+
+    with pytest.raises(ValueError, match="Unsupported sandbox provider"):
+        build_sandbox_runtime({"provider": "docker"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- Add sandbox runtime config and factory for the built-in none and local_test adapters.
- Wire governance_config.sandbox_config into GovernanceEngine construction with telemetry recorder propagation.
- Validate unsupported providers, extra sandbox_config keys, and ambiguous sandbox_runtime plus sandbox_config usage.
- Document sandbox_config in public configuration docs and align the governed execution spec.

Reviewer pass
- DX review found the missing public docs and untracked factory file risk; both are fixed.
- Contract review found no issues.
- QA review found sandbox_config extra keys were accepted too early; validation and coverage are fixed.

Verification
- uv run ruff check on changed Python files: passed.
- uv run pytest tests/test_sandbox_runtime.py tests/test_governance_core.py tests/test_import_startup.py tests/test_runtime_telemetry_wiring.py -q: 119 passed.
- uv run pytest -q: 1008 passed.