### PR TITLE
docs(mcp): add Parallel Search remote example

### DIFF
--- a/docs/core-concepts/mcp.mdx
+++ b/docs/core-concepts/mcp.mdx
@@ -54,6 +54,17 @@ Process communication with local CLI tools:
 }
 ```
 
+Parallel Search MCP is an optional public endpoint for live web search and URL
+fetching. It does not require an account, API key, or OAuth:
+
+```python
+{
+    "name": "parallel_search",
+    "transport_type": "streamable_http",
+    "url": "https://search.parallel.ai/mcp"
+}
+```
+
 ### 3. sse — Server-Sent Events
 
 ```python


### PR DESCRIPTION
## Description

OmniCoreAgent already supports remote MCP servers over Streamable HTTP. This adds one optional configuration example for the public Parallel Search MCP endpoint, giving users a no-account, no-API-key way to add live web search and URL fetching without changing any runtime behavior or defaults.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

The exact staged patch passed these checks in a disposable GCP VM:

- `git diff --cached --check`
- `python3 -m compileall -q src/omnicoreagent`

Full pytest was not available in the base image because the repository's development dependencies and Redis/MongoDB services were not installed.

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] CHANGELOG.md updated

Tests and the changelog were not changed because this patch only adds a single documentation example and does not alter executable behavior.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.